### PR TITLE
Onboard specifix to the AgentCulture sibling pattern (the works)

### DIFF
--- a/.agex/data/pr/events.jsonl
+++ b/.agex/data/pr/events.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-05-22T18:58:46.511796+00:00","type":"pr_opened","pr":3,"title":"Onboard specifix to the AgentCulture sibling pattern (the works)"}
+{"ts":"2026-05-22T18:59:49.652073+00:00","type":"readiness_arrived","pr":3,"waited_secs":60}
+{"ts":"2026-05-22T18:59:53.126230+00:00","type":"pr_read","pr":3,"comment_count":2,"threads_unresolved":0,"ci_state":"failure"}

--- a/.agex/data/pr/events.jsonl
+++ b/.agex/data/pr/events.jsonl
@@ -1,3 +1,0 @@
-{"ts":"2026-05-22T18:58:46.511796+00:00","type":"pr_opened","pr":3,"title":"Onboard specifix to the AgentCulture sibling pattern (the works)"}
-{"ts":"2026-05-22T18:59:49.652073+00:00","type":"readiness_arrived","pr":3,"waited_secs":60}
-{"ts":"2026-05-22T18:59:53.126230+00:00","type":"pr_read","pr":3,"comment_count":2,"threads_unresolved":0,"ci_state":"failure"}

--- a/.claude/skills.local.yaml.example
+++ b/.claude/skills.local.yaml.example
@@ -1,0 +1,19 @@
+# Per-machine config for specifix's vendored skills.
+#
+# Skills read .claude/skills.local.yaml (git-ignored) and fall back to this
+# committed .example. Copy this file to .claude/skills.local.yaml and fill in
+# real values for the local machine. No /home/<user>/... paths in the tracked
+# .example — keep those in the git-ignored copy only.
+
+# Path to the local Culture server manifest, used by skills that resolve
+# Culture agent suffixes or mesh channels. Leave empty if specifix is not yet
+# a registered mesh agent.
+culture_server_yaml: ""
+
+# Map of sibling-project names to their local checkout paths. Used by
+# cross-repo skills (e.g. communicate, cicd delta) to locate siblings
+# without hard-coded absolute paths. Relative paths are resolved from the
+# repo root.
+sibling_projects: {}
+  # steward: ../steward
+  # agtag: ../agtag

--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: cicd
+description: >
+  Steward's CI/CD lane, layered on `agex pr`. Delegates lint / open /
+  read / reply / delta to agex; adds two steward extensions — `status`
+  (SonarCloud quality gate + hotspots + unresolved-thread tally) and
+  `await` (read --wait + status with non-zero exit on Sonar ERROR or
+  unresolved threads). Use when: creating PRs in steward, handling
+  review feedback, polling CI status, or the user says "create PR",
+  "review comments", "address feedback", "resolve threads". Renamed
+  from `pr-review` in steward 0.7.0; rebased on agex in 0.12.0.
+---
+
+# CI/CD — Steward edition
+
+`agex pr` (in `agentculture/agex-cli`) is the upstream for the
+five core PR-lifecycle verbs — `lint`, `open`, `read`, `reply`,
+`delta`. Steward used to vendor parallel scripts for each; in 0.12.0
+those vendored copies were dropped in favor of delegating to `agex`.
+What's left in this skill is **the steward-specific gating layer**:
+
+- `status` — SonarCloud quality gate, OPEN issues, hotspots, deploy
+  preview URL, unresolved-inline-thread tally.
+- `await` — composes `agex pr read --wait` with `status` and gates on
+  Sonar `ERROR` / unresolved threads. The single command to run after
+  pushing a fix when you want "wake me when this PR is triage-able."
+
+Those two are the steward unique surface today. They're filed as a
+feature ask upstream
+([agex-cli#41](https://github.com/agentculture/agex-cli/issues/41));
+once they land they migrate out of this skill.
+
+The workflow is encapsulated in `scripts/workflow.sh` — follow that
+(or call `agex pr` directly).
+
+## Prerequisites
+
+Hard requirements: `agex` (>=0.1), `gh` (GitHub CLI), `jq`, `bash`,
+`python3` (stdlib only), `curl` (used by `pr-status.sh`).
+
+Install agex once:
+
+```bash
+uv tool install agex-cli   # or: pip install --user agex-cli
+```
+
+Soft requirement: `PyYAML` is needed **only for suffix mode** of the
+sibling `agent-config` skill, where it parses Culture's server
+manifest. Every `cicd` script works without it; suffix mode prints a
+clear install hint when invoked without it.
+
+Per-machine paths (sibling-project layout) live in
+`.claude/skills.local.yaml`; see the committed `.example` for the
+schema. `agex pr delta` reads the same file.
+
+## How to run
+
+`scripts/workflow.sh` is the entry point. Subcommands:
+
+| Command | What it does |
+|---------|--------------|
+| `workflow.sh lint` | `agex pr lint --exit-on-violation` — portability + alignment-trigger check. |
+| `workflow.sh open [gh-flags]` | `agex pr open --delayed-read`. Creates the PR, then polls 180s for an initial briefing. `--title TITLE` required; body via `--body-file PATH` or stdin. |
+| `workflow.sh read [PR] [--wait N]` | `agex pr read`. One-shot briefing (CI checks, SonarCloud gate + new issues, all comments, next-step footer). Pass `--wait N` to poll up to N seconds for required reviewers. |
+| `workflow.sh reply <PR>` | `agex pr reply <PR>` — batch JSONL replies (stdin) + thread resolve. agex auto-signs from `culture.yaml`. |
+| `workflow.sh delta` | `agex pr delta` — sibling alignment dump. |
+| `workflow.sh status <PR>` | **Steward extension.** `pr-status.sh` — Sonar gate, OPEN issues, hotspots, unresolved-thread breakdown, deploy preview URL. Authoritative gate for `await`. |
+| `workflow.sh await <PR>` | **Steward extension.** `agex pr read --wait` then `status`. Exits non-zero on Sonar ERROR or unresolved threads. Tunables: `STEWARD_PR_AWAIT_WAIT` (default 1800s passed to `--wait`), `STEWARD_PR_AWAIT_SECONDS` (legacy fixed pre-sleep, deprecated). |
+| `workflow.sh help` | Print the list. |
+
+You can also call `agex pr <verb>` directly — `workflow.sh` is a
+typing-saver around the same verbs. The steward `status` and `await`
+extensions only have shell entry points.
+
+The vendored single-comment helper `pr-reply.sh` (plus its
+`_resolve-nick.sh` dependency) is still shipped — pinned by
+`tests/test_pr_reply_signature.py` and `tests/test_resolve_nick.py`,
+and useful when a one-off reply doesn't merit batch JSONL. It is not
+called by `workflow.sh` anymore. The vendored `portability-lint.sh`
+is also still shipped — `steward doctor`'s portability check runs it
+directly against target repos. Both are scheduled for follow-up
+migration to agex.
+
+## Long waits (background polling)
+
+`agex pr read --wait N` polls in-session for up to N seconds. The
+Anthropic prompt cache has a 5-minute TTL; sleeping past it burns
+context every cache miss. Two ways to drive the wait:
+
+- **Synchronous** — `workflow.sh await <PR>` after `gh pr create` /
+  `workflow.sh open`. Fine when readiness is expected within ~5
+  minutes.
+- **Asynchronous** — for longer waits, run `agex pr read --wait NNN`
+  inside a background subagent (Agent tool, `run_in_background: true`)
+  so the main session only pays the cache cost when readiness fires.
+  The subagent's only job is to invoke `agex pr read --wait` and echo
+  its headline back. The parent triages with `workflow.sh await`
+  when the notification arrives. The user can interrupt with
+  TaskStop.
+
+This pattern was originally borrowed from sibling repo
+[`agentculture/cfafi`](https://github.com/agentculture/cfafi)'s `poll`
+skill. The async guidance is also filed upstream
+([agex-cli#41](https://github.com/agentculture/agex-cli/issues/41)).
+
+## Conventions
+
+`agex pr` emits a **"Next step:"** footer at the end of every command
+that names the right next verb (the same chain `agex learn cicd`
+documents) — follow that rather than memorizing an order. `workflow.sh
+help` mirrors the verb table when you need the steward-flavored
+extensions (`status`, `await`) on top.
+
+Branch naming: `fix/<desc>`, `feat/<desc>`, `docs/<desc>`,
+`skill/<name>`. PR / comment signature: `- <nick> (Claude)`, where
+`<nick>` is resolved by `agex` from the agent's own `culture.yaml`
+(first agent's `suffix`), falling back to the git-repo basename. agex
+auto-appends the signature on `pr open` and `pr reply` only when the
+body isn't already signed.
+
+## Finishing a branch
+
+When implementation on a branch is complete and tests pass, go straight
+to `workflow.sh open` (push the branch + open the PR). Do **not** stop to
+present a *merge / PR / keep / discard* menu and wait for a choice — in
+AgentCulture the standing default is **always "push and create a Pull
+Request."** This overrides the Superpowers `finishing-a-development-branch`
+skill's interactive menu, which otherwise pauses the flow at the moment
+work is ready to integrate. Merge-locally, keep-as-is, and discard happen
+only when the user explicitly asks for one of them.
+
+## Triage rules
+
+For every comment, decide **FIX** or **PUSHBACK** with reasoning.
+
+Default to **FIX** for: portability complaints (always valid for
+Steward — recurring bug class), test or doc requests, style nits
+aligned with workspace conventions.
+
+Default to **PUSHBACK** for: architecture opinions that conflict with
+workspace `CLAUDE.md` or the all-backends rule; greenfield
+false-positives (e.g. "add tests" before there's any source — defer
+to a later PR, don't refuse).
+
+### Alignment-delta rule
+
+If the PR touches `CLAUDE.md`, `culture.yaml`, or anything under
+`.claude/skills/`, run `workflow.sh delta` **before** declaring FIX or
+PUSHBACK on each comment. Note any sibling that needs a follow-up PR
+and mention it in your reply.
+
+## Greenfield-aware steps
+
+The lint and the workflow script are always-on. Stack-specific steps
+are conditional and currently no-op (greenfield repo):
+
+```bash
+[ -d tests ] && [ -f pyproject.toml ] && uv run pytest tests/ -x -q
+[ -f pyproject.toml ] && bump_version_per_project_convention   # see project README
+[ -f .markdownlint-cli2.yaml ] && markdownlint-cli2 "$(git diff --name-only --cached '*.md')"
+```
+
+Revisit each line as the corresponding stack element actually lands.
+A `pr lint --extra=tests,version,markdown` ask is filed upstream
+([agex-cli#41](https://github.com/agentculture/agex-cli/issues/41)).
+
+## Reply etiquette
+
+Every comment must get a reply — no silent fixes. `agex pr reply`
+includes thread-resolve by default. Reference the review-comment IDs
+in the fix-up commit message.
+
+The `status` extension queries SonarCloud directly (it predates the
+upstream Sonar integration in `agex pr read`). Both surfaces are
+trustworthy — `agex pr read` for display in the briefing, `status` for
+the gate. Steward isn't yet a registered mesh agent, so the
+post-merge IRC ping that Culture's `pr-review` includes is still
+skipped — that returns when Steward joins the mesh.

--- a/.claude/skills/cicd/scripts/_resolve-nick.sh
+++ b/.claude/skills/cicd/scripts/_resolve-nick.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the agent's nick for GitHub message signing.
+# Order: first agent's `suffix` in <repo-root>/culture.yaml,
+# then basename of the git repo root.
+# Prints the nick to stdout. Always exits 0 — pr-reply.sh needs *some*
+# nick to sign with — but if a culture.yaml exists and we couldn't
+# extract a suffix from it, emits a stderr warning so a misconfigured
+# manifest doesn't silently mask itself behind the basename fallback.
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+    repo_root="$PWD"
+fi
+
+manifest="$repo_root/culture.yaml"
+
+if [[ -f "$manifest" ]]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "_resolve-nick: python3 not found; cannot parse $manifest, falling back to repo basename" >&2
+    else
+        nick="$(python3 - "$manifest" <<'PY' 2>/dev/null || true
+import re, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    for raw in f:
+        line = raw.rstrip("\n")
+        m = re.match(r"^[\s-]*\s*suffix:\s*(\S+)", line)
+        if m:
+            print(m.group(1).strip("'\""))
+            break
+PY
+)"
+        if [[ -n "$nick" ]]; then
+            printf '%s\n' "$nick"
+            exit 0
+        fi
+        echo "_resolve-nick: $manifest exists but no suffix could be parsed; falling back to repo basename" >&2
+    fi
+fi
+
+basename "$repo_root"

--- a/.claude/skills/cicd/scripts/portability-lint.sh
+++ b/.claude/skills/cicd/scripts/portability-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Portability lint: catch path leaks and per-user config dependencies in
+# committed docs/configs before they ship in a PR. Steward's recurring bug
+# class.
+#
+# Usage: portability-lint.sh [--all]
+#   default: lint files modified vs HEAD (staged + unstaged)
+#   --all:   lint all tracked files
+#
+# Exits 0 if clean, 1 if any leak is found.
+
+set -euo pipefail
+
+mode="${1:-diff}"
+case "$mode" in
+    --all) files=$(git ls-files -- ':(exclude)*.lock') ;;
+    diff|--diff) files=$(git diff --diff-filter=AMR --name-only HEAD -- ':(exclude)*.lock') ;;
+    *) echo "Usage: $(basename "$0") [--all]" >&2; exit 2 ;;
+esac
+
+[ -z "$files" ] && { echo "(no files to check)"; exit 0; }
+
+# ----- Check 1: hard-coded /home/<user>/... paths -----
+hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+
+# ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
+# Carve-outs (allowed, NOT flagged):
+#   - ~/.claude/skills/<x>/scripts/   vendored tool calls
+#   - ~/.culture/                     Culture mesh data this skill is supposed to read
+md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
+if [ -n "$md_yaml" ]; then
+    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+        | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
+        | grep -vE '~/\.culture/' \
+        || true)
+else
+    hits2=""
+fi
+
+fail=0
+if [ -n "$hits1" ]; then
+    echo "❌ Hard-coded /home/<user>/ paths:"
+    echo "$hits1" | sed 's/^/    /'
+    echo "   Fix: use ../sibling, repo URL, or \$WORKSPACE/sibling instead."
+    fail=1
+fi
+if [ -n "$hits2" ]; then
+    [ "$fail" -eq 1 ] && echo
+    echo "❌ Per-user ~/.<dotfile> config refs in committed doc/config:"
+    echo "$hits2" | sed 's/^/    /'
+    echo "   Allowed carve-outs: ~/.claude/skills/.../scripts/ (tool calls), ~/.culture/ (mesh data)."
+    echo "   Otherwise: commit a repo-local config or document a portable lookup."
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "✓ portability lint clean ($(echo "$files" | wc -l | tr -d ' ') files checked)"
+exit $fail

--- a/.claude/skills/cicd/scripts/portability-lint.sh
+++ b/.claude/skills/cicd/scripts/portability-lint.sh
@@ -21,7 +21,9 @@ esac
 [ -z "$files" ] && { echo "(no files to check)"; exit 0; }
 
 # ----- Check 1: hard-coded /home/<user>/... paths -----
-hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+# specifix-divergence: drop GNU-only `xargs -r` (fails on BSD/macOS); `$files`
+# is already guarded non-empty above. Upstream to steward; remove on re-vendor.
+hits1=$(echo "$files" | xargs grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
 
 # ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
 # Carve-outs (allowed, NOT flagged):
@@ -29,7 +31,9 @@ hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null 
 #   - ~/.culture/                     Culture mesh data this skill is supposed to read
 md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
 if [ -n "$md_yaml" ]; then
-    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+    # specifix-divergence: drop GNU-only `xargs -r` (see Check 1); `$md_yaml`
+    # is guarded non-empty by the `if` above. Upstream to steward.
+    hits2=$(echo "$md_yaml" | xargs grep -nE '~/\.[A-Za-z]' 2>/dev/null \
         | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
         | grep -vE '~/\.culture/' \
         || true)

--- a/.claude/skills/cicd/scripts/pr-reply.sh
+++ b/.claude/skills/cicd/scripts/pr-reply.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+PRINT_BODY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        --print-body) PRINT_BODY=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] [--print-body] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ "$PRINT_BODY" != true && -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Sign with the agent's nick. Resolved per invocation so siblings that
+# vendor this skill pick up their own culture.yaml suffix automatically.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NICK="$("$SCRIPT_DIR/_resolve-nick.sh")"
+SIG="- ${NICK} (Claude)"
+if ! printf '%s' "$BODY" | grep -qFx -- "$SIG"; then
+    BODY="${BODY}
+
+${SIG}"
+fi
+
+if [[ "$PRINT_BODY" == true ]]; then
+    printf '%s\n' "$BODY"
+    exit 0
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/cicd/scripts/pr-status.sh
+++ b/.claude/skills/cicd/scripts/pr-status.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# pr-status.sh — one-shot status overview for a Steward PR.
+#
+# Combines five things review feedback usually scatters across:
+#   1. PR state (open / merged / closed) + branch + author
+#   2. CI checks (build / lint / unit / sonarcloud / cf-pages / etc.)
+#   3. Review-bot pipeline status (Copilot, qodo, SonarCloud, Cloudflare)
+#   4. SonarCloud quality gate + open-issue count
+#   5. Inline-thread resolved-vs-unresolved tally
+#
+# Usage: scripts/pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo           auto-detected via `gh repo view`
+#   --sonar-key      derived from repo as `<owner>_<name>` (SonarCloud convention)
+#
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+# Sonar key precedence: explicit --sonar-key flag > SONAR_PROJECT_KEY env >
+# `<owner>_<repo>` derivation. Mirrors pr-comments.sh so SKILL.md's claim
+# that the env var works for both scripts is true.
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${SONAR_PROJECT_KEY:-${REPO%%/*}_${REPO##*/}}"
+fi
+
+# ── 1. PR header ──────────────────────────────────────────────────────────
+PR_JSON=$(gh pr view "$PR_NUMBER" --json \
+    number,title,state,isDraft,mergedAt,mergedBy,baseRefName,headRefName,author,url)
+
+echo "════════════════════════════════════════════════════════════════════"
+echo "$PR_JSON" | jq -r '
+    "PR #\(.number) — \(.title)",
+    "  \(.url)",
+    "  Author:  \(.author.login)",
+    "  Branch:  \(.headRefName)  →  \(.baseRefName)",
+    "  State:   \(if .state == "MERGED" then "MERGED at \(.mergedAt) by \(.mergedBy.login)" elif .state == "OPEN" and .isDraft then "OPEN (draft)" else .state end)"
+'
+echo "════════════════════════════════════════════════════════════════════"
+
+# ── 2. CI checks ──────────────────────────────────────────────────────────
+echo
+echo "── CI checks ─────────────────────────────────────────────────────────"
+# `gh pr checks` exits non-zero when checks are still pending/failing.
+# We don't care about its exit code here; capture and pretty-print.
+CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null || true)
+if [[ -z "$CHECKS" ]]; then
+    echo "  (no checks reported)"
+else
+    echo "$CHECKS" | awk -F'\t' '
+        {
+            name  = $1
+            state = $2
+            dur   = $3
+            sym   = "?"
+            if (state == "pass")            sym = "✅"
+            else if (state == "fail")       sym = "❌"
+            else if (state == "skipping")   sym = "⏭"
+            else if (state == "pending"  || state == "queued"   || state == "in_progress") sym = "…"
+            printf "  %s %-22s %-10s %s\n", sym, name, state, dur
+        }
+    '
+fi
+
+# ── 3. Review bots & comment pipeline ────────────────────────────────────
+echo
+echo "── Review pipeline ───────────────────────────────────────────────────"
+
+# Inline-thread tally via GraphQL (resolved vs unresolved).
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+INLINE_TOTAL=$(echo "$THREADS_JSON" | jq 'length')
+INLINE_RESOLVED=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved)] | length')
+INLINE_PENDING=$((INLINE_TOTAL - INLINE_RESOLVED))
+
+# Per-bot inline counts.
+COPILOT_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("Copilot"))] | length')
+QODO_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("qodo"))] | length')
+
+# Issue-level comments (qodo summary, sonarcloud quality-gate body, cf-pages preview, etc.).
+# Skip --paginate to avoid array concatenation; per_page=100 covers typical PRs.
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100")
+QODO_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("qodo"))] | length')
+SONARQUBE_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("sonarqubecloud"))] | length')
+CFPAGES_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | test("cloudflare"))] | length')
+COPILOT_TOPLEVEL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+    | jq '[.[] | select((.user.login // "") | startswith("copilot")) | select((.body // "") != "")] | length')
+
+# Cloudflare deploy URL hidden in issue-comment bodies (look for pages.dev).
+CF_URL=$(echo "$ISSUE" | jq -r '[.[].body // "" | scan("https?://[a-z0-9.-]+\\.pages\\.dev[^\\s)\"<]*")] | first // ""')
+
+printf "  %-12s %s\n"  "Copilot"     "$([[ "$COPILOT_TOPLEVEL" -gt 0 || "$COPILOT_INLINE" -gt 0 ]] && echo "✅ overview×$COPILOT_TOPLEVEL, inline×$COPILOT_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE" -gt 0 ]] && echo "✅ summary×$QODO_ISSUE, inline×$QODO_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
+
+# ── 4. SonarCloud quality gate + open issues ─────────────────────────────
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+    | jq -r '.total // 0')
+SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+    | jq -r '.paging.total // 0')
+
+case "$SONAR_QG_STATUS" in
+    OK)    SONAR_SYM="✅" ;;
+    ERROR) SONAR_SYM="❌" ;;
+    WARN)  SONAR_SYM="⚠ " ;;
+    *)     SONAR_SYM="?" ;;
+esac
+printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
+    "SonarCloud" "$SONAR_SYM" "$SONAR_QG_STATUS" "$SONAR_OPEN" "$SONAR_HOTSPOTS"
+
+# When SonarCloud has OPEN issues, list them — saves a follow-up curl.
+if [[ "$SONAR_OPEN" != "0" ]]; then
+    echo
+    echo "  SonarCloud OPEN issues:"
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+        | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
+fi
+
+# ── 5. Tally + summary ────────────────────────────────────────────────────
+echo
+echo "── Inline threads ────────────────────────────────────────────────────"
+printf "  Total: %d   Resolved: %d   Unresolved: %d\n" \
+    "$INLINE_TOTAL" "$INLINE_RESOLVED" "$INLINE_PENDING"
+
+if [[ "$INLINE_PENDING" -gt 0 ]]; then
+    echo
+    echo "  Unresolved threads:"
+    echo "$THREADS_JSON" | jq -r '
+        .[] | select(.isResolved == false) |
+        "    • \(.comments.nodes[0].author.login): thread \(.id)"
+    '
+fi
+
+echo
+echo "(For full comment bodies: agex pr read --agent claude-code $PR_NUMBER)"

--- a/.claude/skills/cicd/scripts/workflow.sh
+++ b/.claude/skills/cicd/scripts/workflow.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Steward cicd workflow — thin layer over `agex pr` plus two steward
+# extensions (`status`, `await`) for SonarCloud gating and triage flow.
+#
+# Subcommands:
+#   lint                   `agex pr lint --exit-on-violation`. Same rules
+#                          steward used to vendor in portability-lint.sh
+#                          (which still ships for `steward doctor`).
+#   open  [gh-pr flags]    `agex pr open --delayed-read "$@"`. Creates the
+#                          PR, then polls 180s for an initial briefing.
+#                          Body via --body-file PATH or stdin; --title is
+#                          required.
+#   read  [PR] [--wait N]  `agex pr read "$@"`. One-shot briefing today;
+#                          pass --wait N to poll for reviewer readiness.
+#                          Covers what create-pr-and-wait / pr-comments /
+#                          wait-and-check / poll-readiness used to do.
+#   reply <PR>             `agex pr reply <PR>` (JSONL on stdin). agex
+#                          auto-signs from culture.yaml; same JSONL
+#                          shape as the old pr-batch.sh.
+#   delta                  `agex pr delta`. Sibling alignment dump.
+#
+#   status <PR>            Steward extension: pr-status.sh — SonarCloud
+#                          gate, OPEN issues, hotspots, unresolved
+#                          inline-thread tally, deploy-preview URL.
+#                          Source of truth for the `await` gate.
+#   await  <PR>            Steward extension: `read --wait` for the
+#                          briefing, then `status` for the gate. Exits
+#                          non-zero on SonarCloud ERROR or unresolved
+#                          threads. Tunables:
+#                            STEWARD_PR_AWAIT_WAIT (default 1800)
+#                              — seconds passed to `read --wait`.
+#                            STEWARD_PR_AWAIT_SECONDS (legacy)
+#                              — fixed pre-sleep, deprecated.
+#
+#   help                   print this message
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# agex's `--agent` flag accepts only claude-code|codex|copilot|acp. The
+# workspace culture.yaml convention is `backend: claude`, so we always
+# pass --agent explicitly to insulate steward from that naming gap.
+# Override via STEWARD_AGEX_AGENT if you're running under codex/copilot/acp.
+AGEX_AGENT="${STEWARD_AGEX_AGENT:-claude-code}"
+
+require_agex() {
+    if ! command -v agex >/dev/null 2>&1; then
+        echo "✗ agex not on PATH. Install agex-cli (>=0.1)." >&2
+        echo "  uv tool install agex-cli  # or pip install agex-cli" >&2
+        exit 2
+    fi
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+    lint)
+        require_agex
+        exec agex pr lint --agent "$AGEX_AGENT" --exit-on-violation "$@"
+        ;;
+    open)
+        require_agex
+        exec agex pr open --agent "$AGEX_AGENT" --delayed-read "$@"
+        ;;
+    read)
+        require_agex
+        exec agex pr read --agent "$AGEX_AGENT" "$@"
+        ;;
+    reply)
+        require_agex
+        PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"
+        exec agex pr reply --agent "$AGEX_AGENT" "$PR"
+        ;;
+    delta)
+        require_agex
+        exec agex pr delta --agent "$AGEX_AGENT" "$@"
+        ;;
+    status)
+        PR="${1:?Usage: workflow.sh status <PR>}"
+        exec bash "$SCRIPT_DIR/pr-status.sh" "$PR"
+        ;;
+    await)
+        require_agex
+        PR="${1:?Usage: workflow.sh await <PR>}"
+
+        # Legacy fixed-sleep escape hatch.
+        if [ -n "${STEWARD_PR_AWAIT_SECONDS:-}" ]; then
+            echo "warning: STEWARD_PR_AWAIT_SECONDS is deprecated; prefer STEWARD_PR_AWAIT_WAIT." >&2
+            echo "→ sleeping ${STEWARD_PR_AWAIT_SECONDS}s (legacy fixed-sleep) before agex pr read …" >&2
+            sleep "$STEWARD_PR_AWAIT_SECONDS"
+            WAIT_ARGS=()
+        else
+            WAIT="${STEWARD_PR_AWAIT_WAIT:-1800}"
+            WAIT_ARGS=(--wait "$WAIT")
+        fi
+
+        # 1. agex pr read --wait — readiness loop + briefing.
+        # Capture rc from the command itself (not from the negated test —
+        # `if ! cmd; then rc=$?` would store the if-test status, always 0
+        # in the failure branch, masking the real exit code).
+        echo "── agex pr read ──────────────────────────────────────────────────────" >&2
+        if agex pr read --agent "$AGEX_AGENT" "$PR" "${WAIT_ARGS[@]}"; then
+            READ_RC=0
+        else
+            READ_RC=$?
+        fi
+        if [ "$READ_RC" -ne 0 ]; then
+            echo "✗ agex pr read failed (exit $READ_RC)" >&2
+            exit "$READ_RC"
+        fi
+
+        # 2. pr-status.sh — authoritative gate (Sonar QG, unresolved threads).
+        echo >&2
+        echo "── pr-status ─────────────────────────────────────────────────────────" >&2
+        if STATUS_OUT=$(bash "$SCRIPT_DIR/pr-status.sh" "$PR" 2>&1); then
+            STATUS_RC=0
+        else
+            STATUS_RC=$?
+        fi
+        printf '%s\n' "$STATUS_OUT"
+        if [ "$STATUS_RC" -ne 0 ]; then
+            echo >&2
+            echo "✗ pr-status.sh failed (exit $STATUS_RC) — cannot determine PR state" >&2
+            exit "$STATUS_RC"
+        fi
+
+        # 3. Gate. Markers in pr-status.sh output:
+        #     "Quality Gate ERROR"          → Sonar fail
+        #     "Unresolved: N" with N>0      → unresolved threads
+        SONAR_FAIL=0
+        UNRESOLVED=0
+        if printf '%s\n' "$STATUS_OUT" | grep -qE 'Quality Gate ERROR'; then
+            SONAR_FAIL=1
+        fi
+        if PENDING=$(printf '%s\n' "$STATUS_OUT" | grep -oE 'Unresolved:[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1); then
+            [ -n "${PENDING:-}" ] && [ "$PENDING" -gt 0 ] && UNRESOLVED=1
+        fi
+        if [ "$SONAR_FAIL" -eq 1 ] || [ "$UNRESOLVED" -eq 1 ]; then
+            echo >&2
+            [ "$SONAR_FAIL" -eq 1 ] && echo "✗ SonarCloud quality gate ERROR" >&2
+            [ "$UNRESOLVED" -eq 1 ] && echo "✗ ${PENDING} unresolved review thread(s)" >&2
+            exit 1
+        fi
+        echo >&2
+        echo "✓ no SonarCloud ERROR, no unresolved threads" >&2
+        ;;
+    help|--help|-h)
+        sed -n '4,38p' "${BASH_SOURCE[0]}" | sed 's/^# *//'
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        echo "run '$(basename "$0") help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/.claude/skills/communicate/SKILL.md
+++ b/.claude/skills/communicate/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: communicate
+description: >
+  Cross-repo + mesh communication from steward: file tracked GitHub issues
+  on sibling repos, fetch issues from sibling repos to inline current state
+  into briefs, and send live messages to Culture mesh channels. Use when
+  the next step lives outside steward (a brief for a sibling-repo agent, a
+  status ping for a Culture channel, or pulling an issue body + comments
+  into context). Issue posts auto-sign with `- steward (Claude)`; mesh
+  messages are unsigned (the IRC nick is the speaker). Not for in-steward
+  issues — use `gh issue create` or the `cicd` skill for those. Renamed
+  from `coordinate` in steward 0.8.0; absorbed `gh-issues` in 0.9.1.
+  Issue I/O is backed by `agtag` (>=0.1) starting in 0.11.0.
+---
+
+# Communicate (Cross-Repo + Mesh)
+
+Steward's job is alignment across the AgentCulture mesh; that surfaces in
+four distinct channels:
+
+- **Tracked, async hand-offs** — a gap in another repo (a missing public
+  API, a divergent skill, a documentation ask) where an agent on the
+  other side needs to act, and the ask should outlive the conversation.
+  → `post-issue.sh` (GitHub).
+- **Follow-up on a tracked thread** — a status update, an answer to a
+  question, or a "this is done" note on an issue that's already open.
+  → `post-comment.sh` (GitHub).
+- **Inbound state read** — pulling current issue body + comments from a
+  sibling repo so a brief or plan can inline what's there instead of
+  saying "see issue #N." → `fetch-issues.sh` (GitHub).
+- **Ephemeral coordination** — a status ping, a question, a "PR ready
+  for merge" notice on a Culture mesh channel where the audience is
+  already listening.
+  → `mesh-message.sh` (Culture IRC).
+
+All four live under one skill because they share the same audience
+(sibling-repo agents) and the same red flag (don't double-post the same
+ask across post + mesh — pick one).
+
+## Backed by agtag
+
+The three GitHub verbs (`post-issue.sh`, `post-comment.sh`,
+`fetch-issues.sh`) are thin wrappers around the `agtag` CLI
+(`agtag issue post|reply|fetch`). agtag handles auto-signature
+resolution from the local `culture.yaml` (falling back to repo
+basename), JSON output mode, and a uniform exit-code policy. Read
+`agtag learn` for the agent-facing self-teaching prompt and
+`agtag explain agtag` / `agtag explain issue` for the surface docs —
+this SKILL.md does not re-document agtag's flags.
+
+`mesh-message.sh` stays a `culture channel message` wrapper for now;
+agtag mesh transport is slated for v0.2.
+
+## When to Use
+
+### Issue mode (`post-issue.sh`)
+
+- A gap surfaces in **another repo's surface** (missing public API,
+  wire-format compat fix, divergent skill, documentation ask).
+- You're handing off a self-contained brief to a sibling-repo agent.
+- **(steward-specific — supplier role.)** You're **onboarding a sibling to the
+  stack** — "set it up", "align it", "update it with our stack", "set up the
+  pipelines". The deliverable is an issue with a self-contained brief, **never
+  files written into that repo**. In steward, quote steward's
+  `docs/sibling-pattern.md` (required artifacts) and `docs/skill-sources.md`
+  (the skill set to vendor) into the brief so it stands alone; steward's
+  `CLAUDE.md` "Steward's lane" section is the canonical statement. Downstream
+  vendors of this skill don't onboard siblings — those steward-side docs don't
+  exist in your repo, so skip this bullet.
+- You're asking a question that benefits from a tracked artifact rather
+  than ephemeral chat.
+
+### Broadcast mode (`steward announce-skill-update`)
+
+- You bumped a skill in `.claude/skills/<name>/` and the change is
+  more than identifier-only or doc-only — downstream consumers will
+  benefit from re-vendoring.
+- Don't hand-author the brief — the `steward announce-skill-update`
+  verb (steward-cli) renders the canonical six-section form (what's
+  stale, cite locations, what's in upstream now, recipe, acceptance
+  criteria, references) from the live state of
+  `.claude/skills/<name>/scripts/`, the `CHANGELOG.md`, and
+  `docs/skill-sources.md`'s downstream column. Then it pipes through
+  this skill's `post-issue.sh` per consumer (so the auto-signature
+  stays consistent with hand-authored briefs).
+
+### Mesh mode (`mesh-message.sh`)
+
+- You want to ping a Culture channel with a status update ("PR #N ready
+  for merge", "starting nightly corpus scan").
+- You're asking a question where you expect a fast reply from whoever
+  is listening on the channel right now.
+- You're announcing a decision that doesn't need a tracked artifact.
+
+### Comment mode (`post-comment.sh`)
+
+- An open issue needs a follow-up — a status update, an answer to a
+  maintainer's question, a "this is shipped" note pointing at a PR.
+- You're closing the loop on an `agtag issue post` you sent earlier and
+  the resolution belongs on the same thread (audit trail beats a
+  separate ping).
+- Auto-signed by agtag; do not hand-author the trailing nick.
+
+### Fetch mode (`fetch-issues.sh`)
+
+- You're about to write a brief and want to inline the current state of
+  one or more sibling-repo issues (body + comments) instead of saying
+  "see issue #N."
+- You're triaging a list of cross-repo issues and want their bodies and
+  comments in one shot for context.
+- Avoids the `gh issue view` "Projects (classic) deprecated" error by
+  passing `--json` explicitly to GitHub.
+
+## When NOT to Use
+
+- **In-steward issues** — open them with `gh issue create` directly, or
+  work them through the `cicd` skill.
+- **PR review comments** — that's the `cicd` skill (which already
+  auto-signs replies).
+- **Routine commits** — those don't get cross-repo signatures.
+- **Long-form asks on the mesh** — anything that needs acceptance
+  criteria belongs in an issue, not a channel message.
+
+## Conventions
+
+### 1. Briefs are self-contained
+
+The receiving agent must not need steward-side context to act. Inline
+the relevant content; do not say "see steward's plan."
+
+A brief that says "see steward#NN" is a bug. The receiving agent will
+look at it, get lost in steward-specific context that's irrelevant to
+them, and either ask for clarification (slow round-trip) or guess wrong
+(worse). Inline the ask, the rationale, and concrete acceptance
+criteria. Quote source-of-truth files (path + line numbers + small
+excerpts) when their shape matters to the ask.
+
+### 2. Per-channel signature rules
+
+| Channel | Signature | Why |
+|---------|-----------|-----|
+| GitHub issues / comments | `- <nick> (Claude)` — agtag resolves `<nick>` from the local `culture.yaml`, falling back to repo basename | Cross-repo audit trail — readers can tell at a glance which sibling and that it came from an AI. |
+| Culture mesh | none — unsigned | The IRC nick already identifies the speaker. A trailing `- <nick> (Claude)` would be visual noise that the nick already supplies. |
+
+Vendors do not need to edit a literal — agtag does the resolution.
+`--as NICK` overrides if a vendor needs to sign as something other than
+its `culture.yaml` suffix. Mesh messages stay unsigned across all
+vendors.
+
+### 3. Issue title format
+
+`<verb> <thing> (unblocks <consumer>)` — e.g.,
+`Vendor portability-lint into <repo> (unblocks steward 0.7 doctor --apply)`.
+The parenthetical tells the receiving repo's maintainers what's waiting
+on them. Drop the parenthetical only when the ask isn't blocking
+anything.
+
+## How to Invoke
+
+### File a new issue
+
+```bash
+bash .claude/skills/communicate/scripts/post-issue.sh \
+    --repo agentculture/<sibling> \
+    --title "Vendor portability-lint into <sibling> (unblocks steward 0.7)" \
+    --body-file /tmp/brief.md
+```
+
+Or pass the body on stdin:
+
+```bash
+bash .claude/skills/communicate/scripts/post-issue.sh \
+    --repo agentculture/<sibling> \
+    --title "..." <<'EOF'
+<brief body here, multi-paragraph, with all the inline context the receiving agent needs>
+EOF
+```
+
+The script prints the issue URL on success — capture it for
+cross-references in your spec / plan / PR description. agtag appends
+the signature `- <nick> (Claude)` (resolved from `culture.yaml`).
+
+### Broadcast a skill update to known consumers
+
+This is steward's role specifically — the verb lives in `steward-cli`,
+not in this skill's `scripts/`. Downstream vendors of `communicate`
+(cfafi, culture, auntiepypi, …) do not get a broadcast wrapper because
+they don't broadcast — they only use the primitives above
+(`post-issue.sh`, `fetch-issues.sh`, `mesh-message.sh`).
+
+```bash
+# Default: read consumers from docs/skill-sources.md "Downstream copies"
+# cell for <skill>; render the six-section brief; pipe to post-issue.sh
+# for each consumer.
+steward announce-skill-update --skill cicd --since 0.6.0
+
+# Override the consumer list (skips the ledger lookup entirely):
+steward announce-skill-update --skill cicd \
+    --to agentculture/auntiepypi --to agentculture/cfafi
+
+# Preview without posting:
+steward announce-skill-update --skill cicd \
+    --to agentculture/auntiepypi --dry-run
+
+# Just print the consumer list (for ledger sanity-checks):
+steward announce-skill-update --skill cicd --list
+```
+
+`--since VERSION` controls which CHANGELOG entries get inlined (every
+entry from the top down to but not including the cutoff version).
+Without it, the verb keyword-filters CHANGELOG entries to those
+mentioning the skill name. `--note-file PATH` appends free-text under
+the upstream script list for skill-specific gotchas the generic
+template can't anticipate (e.g. "this skill's `post-issue.sh`
+hard-codes a signature literal — your vendor must change it"). The
+brief is rendered once and reused across consumers; per-consumer
+failures stream to stderr and the verb exits 1 if any failed. The
+template lives at
+`scripts/templates/skill-update-brief.md` so future supplier-role
+repos can render their own briefs from the same shape.
+
+#### Fast recipe — "brief sibling-repo Z on skill X"
+
+This shape of ask is a recipe, not a planning question. Skip plan
+mode. The call site:
+
+```bash
+steward announce-skill-update \
+    --skill <name> --to <owner>/<repo> \
+    --since <last-stable-version> \
+    [--note-file /tmp/note.md] --dry-run
+```
+
+Eyeball the rendered brief; drop `--dry-run` to post. The verb
+prints the issue URL on success and exits non-zero on failure —
+that is the verification. Don't write parallel `gh issue list` /
+`gh issue view` checks unless the verb itself is what you're
+testing. `--to` overrides the ledger, so non-ledger consumers
+don't require a ledger edit first; they enter the ledger later
+when they confirm their vendored shape.
+
+### Comment on an existing issue
+
+```bash
+bash .claude/skills/communicate/scripts/post-comment.sh \
+    --repo agentculture/<sibling> \
+    --number 42 \
+    --body-file /tmp/follow-up.md
+```
+
+Or pipe the body in:
+
+```bash
+bash .claude/skills/communicate/scripts/post-comment.sh \
+    --repo agentculture/<sibling> \
+    --number 42 <<'EOF'
+PR #87 has shipped — closing the loop on this thread.
+EOF
+```
+
+Auto-signed by agtag from `culture.yaml`; do not hand-author the
+trailing nick.
+
+### Send a mesh channel message
+
+```bash
+bash .claude/skills/communicate/scripts/mesh-message.sh \
+    --channel "#general" \
+    --body "PR #42 — all review threads addressed. Ready for merge."
+```
+
+Body can also come from `--body-file PATH` or stdin. The script wraps
+`culture channel message <target> <text>` and forwards exit codes
+unchanged, so failures (no Culture server, agent not connected) surface
+verbatim. No signature is appended — the IRC nick is the speaker.
+
+### Fetch sibling-repo issues
+
+```bash
+bash .claude/skills/communicate/scripts/fetch-issues.sh 191 --repo agentculture/culture
+bash .claude/skills/communicate/scripts/fetch-issues.sh 191-197 --repo agentculture/culture
+bash .claude/skills/communicate/scripts/fetch-issues.sh 191 195 197
+```
+
+Output is one JSON object per issue (separated by header bars) with
+`number`, `title`, `state`, `labels`, `body`, and `comments`. Without
+`--repo`, `gh` resolves the repo from the current git remote. Failures
+on a single issue print `ERROR: Could not fetch issue #N` and continue
+with the next one.
+
+Steward is **not** a registered mesh agent today (see the cicd SKILL.md
+note). The script works once steward has been registered and started
+via `culture agent register` + `culture start spark-steward`; until
+then, calling it will fail with whatever error the Culture CLI returns,
+which is the right behavior — fix the registration, don't paper over it.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/post-issue.sh` | Create a new issue on a target repo. Wraps `agtag issue post`; auto-signs from `culture.yaml`. |
+| `scripts/post-comment.sh` | Comment on an existing issue. Wraps `agtag issue reply`; auto-signs from `culture.yaml`. |
+| `scripts/fetch-issues.sh` | Fetch one or more issues (single / range / list) with body + comments. Wraps `agtag issue fetch`. |
+| `scripts/mesh-message.sh` | Send a message to a Culture mesh channel. Unsigned (IRC nick is the speaker). |
+| `scripts/templates/skill-update-brief.md` | The Markdown template consumed by `steward announce-skill-update` (the broadcast verb lives in steward-cli, not in this skill). Six fixed sections; placeholder syntax `{{NAME}}`. |
+
+More scripts can land here as the communication footprint grows —
+`mesh-ask.sh` for question-shaped pings via `culture channel ask`,
+agtag-mesh wrappers once `agtag message` ships in v0.2, etc. Add them
+when there's a second concrete need; do not pre-build for
+hypotheticals.
+
+## Red Flags
+
+**Never:**
+
+- Scaffold or write files into the *target* repo when the ask is an issue on
+  it. Handing off / onboarding is an **issue, not an edit** — a direct "set
+  them up" is still an instruction to file the brief. (In steward this is the
+  "Steward's lane" rule; the principle holds for any vendor of this skill.)
+- Post a brief that says "see steward's plan" without inlining the
+  content. Briefs must be self-contained.
+- Skip the issue signature. The script enforces it; do not introduce a
+  `--no-signature` flag.
+- Sign mesh messages with `- <nick> (Claude)`. The nick already says
+  who you are.
+- Use this skill for in-steward issues — use `gh issue create` or the
+  `cicd` skill instead.
+- Manually type `- <nick> (Claude)` at the end of an issue or comment
+  body — agtag appends it. Manual typing creates double-signatures.
+- Post the same ask twice across channels (issue + mesh). Pick one.
+  Tracked → issue. Ephemeral → mesh.
+- Use mesh mode for anything that needs acceptance criteria. If the
+  receiving agent has to decide "did I do this right?", you owe them
+  an issue.

--- a/.claude/skills/communicate/scripts/fetch-issues.sh
+++ b/.claude/skills/communicate/scripts/fetch-issues.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Fetch GitHub issues with full body and comments. Thin wrapper around
+# `agtag issue fetch` that keeps this skill's range/list expansion
+# (agtag is single-issue per call).
+#
+# Usage: fetch-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]
+#   fetch-issues.sh 191-197                   # range
+#   fetch-issues.sh 191                       # single
+#   fetch-issues.sh 191 192 195               # list
+#   fetch-issues.sh --repo foo/bar 5          # explicit repo (otherwise gh resolves it from the git remote)
+
+set -euo pipefail
+
+REPO=""
+NUMBERS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --repo requires a value (OWNER/REPO)" >&2
+        echo "Usage: fetch-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]" >&2
+        exit 1
+      fi
+      REPO="$2"
+      shift 2 ;;
+    *-*)  # range like 191-197
+      IFS='-' read -r start end <<< "$1"
+      for ((i=start; i<=end; i++)); do NUMBERS+=("$i"); done
+      shift ;;
+    *)  NUMBERS+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#NUMBERS[@]} -eq 0 ]]; then
+  echo "Usage: fetch-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]" >&2
+  exit 1
+fi
+
+if ! command -v agtag >/dev/null 2>&1; then
+  echo "agtag not found on PATH. Install agtag (>=0.1) to use this skill." >&2
+  exit 2
+fi
+
+# agtag fetch resolves the repo from the local git remote when --repo
+# is omitted, matching the previous gh-based behavior.
+REPO_ARGS=()
+if [[ -n "$REPO" ]]; then
+  REPO_ARGS=(--repo "$REPO")
+fi
+
+for num in "${NUMBERS[@]}"; do
+  echo "========================================"
+  echo "ISSUE #${num}"
+  echo "========================================"
+  agtag issue fetch "${REPO_ARGS[@]}" --number "$num" --json \
+    || echo "ERROR: Could not fetch issue #${num}"
+  echo
+done

--- a/.claude/skills/communicate/scripts/mesh-message.sh
+++ b/.claude/skills/communicate/scripts/mesh-message.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Send a message to a Culture mesh channel.
+# Thin wrapper around `culture channel message <target> <text>`.
+# No signature is appended — the IRC nick is the speaker.
+#
+# Usage:
+#   mesh-message.sh --channel '#general' --body "Hello"
+#   mesh-message.sh --channel '#general' --body-file PATH
+#   mesh-message.sh --channel '#general'  < body-on-stdin
+
+usage() {
+    echo "Usage: mesh-message.sh --channel '#NAME' [--body TEXT | --body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+if ! command -v culture >/dev/null 2>&1; then
+    echo "mesh-message: 'culture' CLI not found on PATH" >&2
+    echo "  Install agentculture/culture and ensure 'culture --version' works." >&2
+    exit 127
+fi
+
+CHANNEL=""
+BODY=""
+BODY_FILE=""
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --channel)    require_value "$@"; CHANNEL="$2"; shift 2 ;;
+        --body)       require_value "$@"; BODY="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$CHANNEL" ]]; then
+    echo "Missing --channel" >&2
+    usage
+fi
+
+if [[ -n "$BODY" && -n "$BODY_FILE" ]]; then
+    echo "Pass at most one of --body / --body-file (stdin is the third option)" >&2
+    usage
+fi
+
+if [[ -z "$BODY" ]]; then
+    if [[ -n "$BODY_FILE" ]]; then
+        BODY="$(cat "$BODY_FILE")"
+    elif [[ ! -t 0 ]]; then
+        BODY="$(cat)"
+    else
+        echo "No --body / --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body 'text', --body-file PATH, or pipe the body in." >&2
+        exit 2
+    fi
+fi
+
+if [[ -z "$BODY" ]]; then
+    echo "Empty message body" >&2
+    exit 2
+fi
+
+# Forward exit code from culture; if the agent isn't running or the
+# server is unreachable, the operator should see that error verbatim.
+exec culture channel message "$CHANNEL" "$BODY"

--- a/.claude/skills/communicate/scripts/post-comment.sh
+++ b/.claude/skills/communicate/scripts/post-comment.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Comment on an existing cross-repo issue. Thin wrapper around
+# `agtag issue reply` that mirrors `post-issue.sh`'s ergonomics.
+#
+# Signature: agtag resolves the signing nick from the local
+# `culture.yaml` (falling back to repo basename), so vendors do not
+# need to edit a literal here.
+#
+# Usage:
+#   post-comment.sh --repo OWNER/REPO --number N --body-file PATH
+#   post-comment.sh --repo OWNER/REPO --number N  < body-on-stdin
+
+usage() {
+    echo "Usage: post-comment.sh --repo OWNER/REPO --number N [--body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+REPO=""
+NUMBER=""
+BODY_FILE=""
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --number)     require_value "$@"; NUMBER="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$REPO" || -z "$NUMBER" ]]; then
+    usage
+fi
+
+if ! command -v agtag >/dev/null 2>&1; then
+    echo "agtag not found on PATH. Install agtag (>=0.1) to use this skill." >&2
+    exit 2
+fi
+
+if [[ -z "$BODY_FILE" ]]; then
+    if [[ -t 0 ]]; then
+        echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body-file PATH or pipe the body in." >&2
+        exit 2
+    fi
+    TMP_BODY=$(mktemp -t communicate-post-comment-body.XXXXXX)
+    trap 'rm -f "$TMP_BODY"' EXIT
+    cat > "$TMP_BODY"
+    BODY_FILE="$TMP_BODY"
+fi
+
+# Don't `exec` here: see post-issue.sh for the rationale (stdin-spooled
+# tempfile + EXIT trap; exec would skip the trap and leak the body).
+agtag issue reply --repo "$REPO" --number "$NUMBER" --body-file "$BODY_FILE"
+exit $?

--- a/.claude/skills/communicate/scripts/post-issue.sh
+++ b/.claude/skills/communicate/scripts/post-issue.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post a cross-repo issue. Thin wrapper around `agtag issue post` that
+# preserves this skill's stable script path so existing callers
+# (e.g. steward-cli's `announce-skill-update`) keep working unchanged.
+#
+# Signature: agtag resolves the signing nick from the local
+# `culture.yaml` (falling back to repo basename), so vendors do not
+# need to edit a literal here.
+#
+# Usage:
+#   post-issue.sh --repo OWNER/REPO --title "Title" --body-file PATH
+#   post-issue.sh --repo OWNER/REPO --title "Title"  < body-on-stdin
+
+usage() {
+    echo "Usage: post-issue.sh --repo OWNER/REPO --title TITLE [--body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+REPO=""
+TITLE=""
+BODY_FILE=""
+
+# Require a value to follow each flag (otherwise `--repo` with no argument
+# would crash on `$2` under `set -u` instead of printing usage).
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$REPO" || -z "$TITLE" ]]; then
+    usage
+fi
+
+if ! command -v agtag >/dev/null 2>&1; then
+    echo "agtag not found on PATH. Install agtag (>=0.1) to use this skill." >&2
+    exit 2
+fi
+
+# agtag has no stdin mode — spool body to a tempfile so both call shapes
+# (--body-file and stdin) reach agtag as --body-file.
+if [[ -z "$BODY_FILE" ]]; then
+    if [[ -t 0 ]]; then
+        echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body-file PATH or pipe the body in." >&2
+        exit 2
+    fi
+    TMP_BODY=$(mktemp -t communicate-post-issue-body.XXXXXX)
+    trap 'rm -f "$TMP_BODY"' EXIT
+    cat > "$TMP_BODY"
+    BODY_FILE="$TMP_BODY"
+fi
+
+# Don't `exec` here: when stdin spooled the body to a tempfile we set an
+# EXIT trap to delete it, and exec would replace the shell before the trap
+# could run, leaking the spooled body on disk.
+agtag issue post --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE"
+exit $?

--- a/.claude/skills/communicate/scripts/templates/skill-update-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-update-brief.md
@@ -1,0 +1,101 @@
+<!-- markdownlint-disable MD041 -->
+<!-- This file is a template rendered by announce-skill-update.sh. -->
+<!-- It posts as an issue body where GitHub supplies the title, so -->
+<!-- there's no H1 here on purpose. Placeholders use `{{NAME}}` syntax. -->
+
+## What's stale
+
+Your repo's `.claude/skills/{{SKILL}}/` (or its older vendored
+name — see your `docs/skill-sources.md` if you keep a provenance
+ledger) is a vendored copy of the steward skill that has since
+moved on. Relevant CHANGELOG entries from steward:
+
+{{CHANGELOG_BLOCK}}
+
+## Cite locations (source of truth)
+
+- Local sibling checkout (preferred when available):
+  `../steward/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local steward checkout:
+  <https://github.com/agentculture/steward/tree/main/.claude/skills/{{SKILL}}>
+
+The directory ships with a `SKILL.md` and a `scripts/` directory
+per the AgentCulture skills-portability rule (each skill is
+self-contained; nothing reaches across skill boundaries at
+runtime).
+
+## What's in the upstream now
+
+`{{SKILL}}/scripts/` ({{UPSTREAM_SCRIPT_COUNT}} files):
+
+{{UPSTREAM_SCRIPT_LIST}}
+
+{{DELTA_BLOCK}}
+
+{{NOTE_BLOCK}}
+
+## What to do
+
+```bash
+# 0. Branch.
+git checkout -b skill/{{SKILL}}-resync
+
+# 1. Replace your vendored copy with the current upstream.
+#    If your old vendored name differs (e.g. pr-review → cicd),
+#    `git rm` the old dir first.
+git rm -r .claude/skills/<old-name-if-different>   # skip if name is already {{SKILL}}
+cp -R ../steward/.claude/skills/{{SKILL}} .claude/skills/
+chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
+
+# 2. Adapt identifiers per the existing "identifier-only adapted"
+#    pattern in your docs/skill-sources.md (if you keep one):
+#    - SKILL.md prose framing: replace "steward" with your repo
+#      name where it identifies the consumer (NOT where it cites
+#      steward as the upstream).
+#    - For any script that hard-codes a signature literal, change it
+#      to `- <your-repo> (Claude)`. (The communicate skill no longer
+#      hard-codes one — agtag resolves the nick from your local
+#      `culture.yaml`. If your repo is missing one, add it or pass
+#      `--as <your-repo>` at the call site.)
+
+# 3. Update docs/skill-sources.md (if present) to point at the
+#    new path; drop any stale row for the old name.
+
+# 4. Sweep for stale references:
+grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
+#    Replace any survivors with `{{SKILL}}`.
+
+# 5. Bump version per project convention (CI version-check
+#    enforces in AgentCulture siblings); add CHANGELOG entry.
+```
+
+## Acceptance criteria
+
+- `.claude/skills/{{SKILL}}/SKILL.md` is present with frontmatter
+  `name: {{SKILL}}`.
+- `.claude/skills/{{SKILL}}/scripts/` contains the
+  {{UPSTREAM_SCRIPT_COUNT}} files listed above (and only those
+  files, unless your repo intentionally adds extras — record
+  divergence in the SKILL.md frontmatter `description` per the
+  AgentCulture vendoring policy).
+- All scripts are executable (`chmod +x`).
+- If the skill hard-codes a signature literal anywhere, your
+  vendored copy uses your repo's signature, not `- steward (Claude)`.
+- If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with
+  the upstream `../steward/.claude/skills/{{SKILL}}/`; no row
+  remains for the old vendored name.
+- `grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md`
+  returns zero hits, or only historical mentions in CHANGELOG.
+- `CHANGELOG.md` has a new version entry describing the resync;
+  the version is bumped per project convention; CI's
+  `version-check` job is green.
+
+## References
+
+- Steward CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/steward/blob/main/CHANGELOG.md>
+- `{{SKILL}}` SKILL.md:
+  <https://github.com/agentculture/steward/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+- AgentCulture skills-portability rule (why each vendor adapts
+  signature literals locally): the `communicate` SKILL.md
+  "Per-channel signature rules" + "Conventions in use" sections.

--- a/.claude/skills/doc-test-alignment/SKILL.md
+++ b/.claude/skills/doc-test-alignment/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: doc-test-alignment
+description: >
+  Verify that committed docs (README.md, CLAUDE.md, SKILL.md descriptions) still
+  describe what the code and tests actually do. Use at the end of a plan, before
+  PR creation, or when the user says "check doc-test alignment", "verify docs",
+  or "do the docs still match the code". STUB — `scripts/check.sh` exits with a
+  not-yet-implemented error today; the contract for what it will do lives in
+  this file.
+---
+
+# doc-test-alignment (stub)
+
+This skill is a stub. The real workflow is intentionally not yet implemented —
+the file exists so that `steward verify` can find it and so contributors who
+land here know it is on the roadmap, not forgotten.
+
+## How to run
+
+`scripts/check.sh` is the entry point. Today it prints a not-yet-implemented
+notice and exits non-zero. When the workflow lands, the script will gate
+PR-readiness on the alignment contract below; until then, treat any green
+exit code from this script as a bug.
+
+## What it will check
+
+The skill is the contract for four narrow alignments. README.md command
+examples must still execute against the current checkout and produce output
+that matches the surrounding prose. The "build/test/publish" command lines in
+CLAUDE.md must do the same. For each `.claude/skills/<name>/`, the SKILL.md
+`description` frontmatter must agree with what the scripts under
+`scripts/` actually do — surfacing disagreements (e.g. SKILL.md claims the
+skill bumps versions but `scripts/` has no bump script). And for each test,
+the test name should still describe the assertions the test makes — flagging
+drift where the name advertises a feature the assertions no longer touch.
+
+## Why it ships as a stub
+
+Each of those four checks is independently non-trivial. Shipping a partial
+implementation would either silently pass when it shouldn't, or false-positive
+on intentional doc-vs-code differences. The right path is to land the checks
+one at a time, with their own tests, behind a
+`steward verify --check doc-test-alignment` flag. The parent verbs (`verify`,
+`doctor`) are named in the "Roadmap" section of `CLAUDE.md`; the broader
+sibling-pattern contract lives in `docs/sibling-pattern.md`.
+
+## What this stub guarantees today
+
+- The skill directory exists, so `steward verify`'s skills-convention check
+  finds the standard layout (SKILL.md + `scripts/` with an entry-point).
+- `scripts/check.sh` is the entry-point script, satisfying the steward skills
+  convention requirement that every skill ships an executable script.
+- This `SKILL.md` is the contract for what the skill will do — when the
+  implementation lands, it must satisfy this description or the description
+  must move first.

--- a/.claude/skills/doc-test-alignment/scripts/check.sh
+++ b/.claude/skills/doc-test-alignment/scripts/check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# doc-test-alignment skill — entry point.
+#
+# STUB: the real workflow is not implemented yet. This script exists so the
+# steward skills convention is satisfied (every skill ships an executable
+# entry-point script); when the real implementation lands here, it must
+# satisfy the contract documented in ../SKILL.md.
+#
+# Exits 2 (EXIT_USER_ERROR-ish for "you asked for something that isn't
+# wired up yet") so callers can tell the difference between "checks passed"
+# (would be 0) and "stub".
+
+set -euo pipefail
+
+cat >&2 <<'EOF'
+doc-test-alignment: not yet implemented.
+
+This skill is a stub; the contract for what `check.sh` will assert lives in
+.claude/skills/doc-test-alignment/SKILL.md. Until the implementation lands,
+treat any green exit code from this script as a bug.
+
+Roadmap: see CLAUDE.md ("Roadmap (CLI surface)") and docs/sibling-pattern.md.
+EOF
+exit 2

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: run-tests
+description: Run pytest with parallel execution and coverage. Use when running tests, verifying changes, or the user says "run tests", "test", or "pytest".
+---
+
+# Run Tests
+
+Run the project's pytest suite with optional parallelism (pytest-xdist) and coverage.
+Coverage targets are read from `pyproject.toml`'s `[tool.coverage.run]` section,
+so the same script works in any sibling repo without modification.
+
+## Usage
+
+```bash
+# Default: parallel + verbose (recommended)
+bash .claude/skills/run-tests/scripts/test.sh -p
+
+# Quick check: parallel + quiet
+bash .claude/skills/run-tests/scripts/test.sh -p -q
+
+# Full CI mode: parallel + coverage + xml report
+bash .claude/skills/run-tests/scripts/test.sh --ci
+
+# Specific test file
+bash .claude/skills/run-tests/scripts/test.sh -p tests/test_socket_server.py
+
+# Without parallelism (for debugging test ordering issues)
+bash .claude/skills/run-tests/scripts/test.sh tests/test_rooms.py
+
+# With coverage
+bash .claude/skills/run-tests/scripts/test.sh -p -c
+```
+
+## Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--parallel` | `-p` | Run with `-n auto` (pytest-xdist, uses all CPU cores) |
+| `--coverage` | `-c` | Enable coverage reporting to terminal |
+| `--ci` | | Full CI mode: parallel + coverage + XML report + verbose |
+| `--quick` | `-q` | Quiet output (no verbose, no coverage) |
+
+Extra arguments are passed through to pytest (e.g., `-x` for stop-on-first-failure, `-k "pattern"` for filtering).
+
+## When to Use Which Mode
+
+- **After code changes:** `bash test.sh -p` — fast parallel run, verbose output
+- **Quick sanity check:** `bash test.sh -p -q` — minimal output
+- **Before PR / release:** `bash test.sh --ci` — matches CI exactly
+- **Debugging flaky test:** `bash test.sh tests/test_flaky.py` — sequential, single file

--- a/.claude/skills/run-tests/scripts/test.sh
+++ b/.claude/skills/run-tests/scripts/test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run pytest with optional parallelism and coverage.
+# Usage: bash test.sh [OPTIONS] [PYTEST_ARGS...]
+#
+# Options:
+#   --parallel, -p    Run with -n auto (pytest-xdist)
+#   --coverage, -c    Enable coverage reporting
+#   --ci              Mimic full CI invocation (-n auto + coverage + xml)
+#   --quick, -q       Quick mode: no coverage, quiet output
+#
+# When --coverage or --ci is passed, this script invokes pytest-cov with --cov
+# (no module spec). pytest-cov / coverage.py then resolve the source set via
+# the standard config lookup — typically [tool.coverage.run] source in
+# pyproject.toml — so the same script works in any sibling without edits.
+#
+# Extra args are passed through to pytest.
+
+set -euo pipefail
+
+PARALLEL=""
+COVERAGE=""
+CI_MODE=""
+QUIET=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --parallel|-p) PARALLEL=1; shift ;;
+        --coverage|-c) COVERAGE=1; shift ;;
+        --ci)          CI_MODE=1; shift ;;
+        --quick|-q)    QUIET=1; shift ;;
+        *)             EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+CMD=(uv run pytest)
+
+if [[ -n "$CI_MODE" ]]; then
+    CMD+=(-n auto --cov --cov-report=xml:coverage.xml --cov-report=term -v)
+elif [[ -n "$QUIET" ]]; then
+    CMD+=(-q)
+    [[ -n "$PARALLEL" ]] && CMD+=(-n auto)
+else
+    [[ -n "$PARALLEL" ]] && CMD+=(-n auto)
+    [[ -n "$COVERAGE" ]] && CMD+=(--cov --cov-report=term)
+    CMD+=(-v)
+fi
+
+CMD+=("${EXTRA_ARGS[@]}")
+
+echo "Running: ${CMD[*]}"
+exec "${CMD[@]}"

--- a/.claude/skills/sonarclaude/SKILL.md
+++ b/.claude/skills/sonarclaude/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: sonarclaude
+description: >
+  Query SonarCloud API for code quality data. Use when: checking quality gate status,
+  fetching code issues or security hotspots, reviewing metrics (coverage, bugs, code smells),
+  or the user says "sonar", "quality gate", "code quality", "sonarclaude".
+---
+
+# SonarClaude
+
+Query SonarCloud projects for quality gate status, issues, metrics, and security hotspots.
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `curl` — talks to the SonarCloud REST API
+- `jq` — parses responses and URL-encodes accept comments
+
+## Environment
+
+Requires `SONAR_TOKEN` environment variable. Set the project key per-repo via
+the `SONAR_PROJECT` environment variable (or pass `--project KEY` on each
+invocation).
+
+## Usage
+
+```bash
+# Quality gate status (pass/fail)
+bash .claude/skills/sonarclaude/scripts/sonar.sh status
+
+# List issues (bugs, vulnerabilities, code smells)
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues
+
+# Filter issues by severity and type
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --severity CRITICAL --type BUG
+
+# Key metrics (coverage, bugs, code smells, duplication, LOC)
+bash .claude/skills/sonarclaude/scripts/sonar.sh metrics
+
+# Security hotspots
+bash .claude/skills/sonarclaude/scripts/sonar.sh hotspots
+
+# Accept (won't-fix) an OPEN issue with a rationale comment
+bash .claude/skills/sonarclaude/scripts/sonar.sh accept \
+  --issue AZ3Ep83i4ywi8V_l99p0 \
+  --comment "Pushback: rule premise doesn't fit our test fixture pattern."
+
+# Different project
+bash .claude/skills/sonarclaude/scripts/sonar.sh status --project OtherOrg_OtherProject
+
+# Raw JSON output
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --raw
+
+# Limit results
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --limit 10
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | `$SONAR_PROJECT` | SonarCloud project key |
+| `--severity` | all | Filter: `BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO` |
+| `--type` | all | Filter: `BUG`, `VULNERABILITY`, `CODE_SMELL` |
+| `--limit` | `25` | Max results returned |
+| `--raw` | off | Output raw JSON instead of formatted summary |
+| `--issue` | — | Issue key (required for `accept`) |
+| `--comment` | — | Rationale comment (required for `accept`) |
+
+## When to use `accept`
+
+Sonar rules occasionally flag patterns where the rule's premise does not fit the
+code (e.g. test fixtures with intentional bad-password literals, contradictory
+rule pairs like S7494 vs S7500). After deciding pushback in PR review, run
+`sonar.sh accept` with a rationale comment instead of leaving the issue OPEN —
+this moves it to ACCEPTED/WONTFIX in SonarCloud history (visible to future
+maintainers) while clearing the quality-gate signal. Always include a `--comment`
+explaining why; silent dismissals are not acceptable curation.
+
+Do not call SonarCloud's HTTP API directly from other skills or one-off
+scripts — `sonar.sh accept` is the supported entry point so the rationale
+flow stays consistent.

--- a/.claude/skills/sonarclaude/scripts/sonar.sh
+++ b/.claude/skills/sonarclaude/scripts/sonar.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SonarCloud API client for Claude Code.
+# Requires SONAR_TOKEN environment variable.
+# Project key resolves from --project flag, then $SONAR_PROJECT.
+
+BASE_URL="https://sonarcloud.io"
+
+# --- Defaults ---
+PROJECT="${SONAR_PROJECT:-}"
+SEVERITY=""
+TYPE=""
+LIMIT=25
+RAW=false
+COMMAND=""
+ISSUE_KEY=""
+ACCEPT_COMMENT=""
+
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    echo "Run sonar.sh --help for usage." >&2
+    exit 1
+  fi
+}
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    status|issues|metrics|hotspots|accept)
+      COMMAND="$1"; shift ;;
+    --project|-p)   require_value "$1" "$#"; PROJECT="$2";        shift 2 ;;
+    --severity|-s)  require_value "$1" "$#"; SEVERITY="$2";       shift 2 ;;
+    --type|-t)      require_value "$1" "$#"; TYPE="$2";           shift 2 ;;
+    --limit|-l)     require_value "$1" "$#"; LIMIT="$2";          shift 2 ;;
+    --raw|-r)       RAW=true;                                     shift ;;
+    --issue|-i)     require_value "$1" "$#"; ISSUE_KEY="$2";      shift 2 ;;
+    --comment|-c)   require_value "$1" "$#"; ACCEPT_COMMENT="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: sonar.sh <command> [options]"
+      echo ""
+      echo "Commands:"
+      echo "  status    Quality gate status (pass/fail)"
+      echo "  issues    List code issues (bugs, vulnerabilities, code smells)"
+      echo "  metrics   Key code metrics (coverage, bugs, duplication, LOC)"
+      echo "  hotspots  Security hotspots"
+      echo "  accept    Mark an OPEN issue as ACCEPTED with a rationale comment"
+      echo ""
+      echo "Options:"
+      echo "  --project, -p KEY       Project key (default: \$SONAR_PROJECT)"
+      echo "  --severity, -s LEVEL    Filter: BLOCKER, CRITICAL, MAJOR, MINOR, INFO"
+      echo "  --type, -t TYPE         Filter: BUG, VULNERABILITY, CODE_SMELL"
+      echo "  --limit, -l N           Max results (default: 25)"
+      echo "  --raw, -r               Output raw JSON"
+      echo "  --issue, -i KEY         Issue key (required for 'accept')"
+      echo "  --comment, -c TEXT      Rationale comment (required for 'accept')"
+      echo "  --help, -h              Show this help"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- Validate ---
+if [[ -z "${SONAR_TOKEN:-}" ]]; then
+  echo "Error: SONAR_TOKEN environment variable is not set." >&2
+  exit 1
+fi
+
+if [[ -z "$COMMAND" ]]; then
+  echo "Error: No command provided." >&2
+  echo "Usage: sonar.sh <status|issues|metrics|hotspots|accept> [options]" >&2
+  exit 1
+fi
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: No project key. Set \$SONAR_PROJECT or pass --project KEY." >&2
+  exit 1
+fi
+
+# --- API helper ---
+api_get() {
+  local endpoint="$1"
+  curl -s -f -H "Authorization: Bearer $SONAR_TOKEN" "${BASE_URL}${endpoint}"
+}
+
+# --- Commands ---
+
+cmd_status() {
+  local response
+  response=$(api_get "/api/qualitygates/project_status?projectKey=${PROJECT}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local status conditions
+  status=$(echo "$response" | jq -r '.projectStatus.status')
+  conditions=$(echo "$response" | jq -r '.projectStatus.conditions[]? | "  \(.metricKey): \(.actualValue) (threshold: \(.errorThreshold), status: \(.status))"')
+
+  if [[ "$status" == "OK" ]]; then
+    echo "Quality Gate: PASSED"
+  elif [[ "$status" == "ERROR" ]]; then
+    echo "Quality Gate: FAILED"
+  else
+    echo "Quality Gate: $status"
+  fi
+
+  if [[ -n "$conditions" ]]; then
+    echo ""
+    echo "Conditions:"
+    echo "$conditions"
+  fi
+}
+
+cmd_issues() {
+  local params="componentKeys=${PROJECT}&ps=${LIMIT}"
+  [[ -n "$SEVERITY" ]] && params="${params}&severities=${SEVERITY}"
+  [[ -n "$TYPE" ]] && params="${params}&types=${TYPE}"
+
+  local response
+  response=$(api_get "/api/issues/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.total')
+  echo "Issues: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.issues[]? | "[\(.severity)] \(.type) — \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Rule: \(.rule)\n"'
+}
+
+# Convert SonarCloud numeric rating to letter grade
+rating_letter() {
+  case "$1" in
+    1|1.0) echo "A" ;;
+    2|2.0) echo "B" ;;
+    3|3.0) echo "C" ;;
+    4|4.0) echo "D" ;;
+    5|5.0) echo "E" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+cmd_metrics() {
+  local metric_keys="bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,ncloc,sqale_rating,reliability_rating,security_rating,alert_status"
+
+  local response
+  response=$(api_get "/api/measures/component?component=${PROJECT}&metricKeys=${metric_keys}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  echo "Metrics for: $PROJECT"
+  echo ""
+
+  echo "$response" | jq -r '.component.measures[]? | "\(.metric): \(.value)"' | while IFS=: read -r key val; do
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+    case "$key" in
+      alert_status)
+        echo "  Quality Gate:     $val" ;;
+      bugs)
+        echo "  Bugs:             $val" ;;
+      vulnerabilities)
+        echo "  Vulnerabilities:  $val" ;;
+      code_smells)
+        echo "  Code Smells:      $val" ;;
+      coverage)
+        echo "  Coverage:         ${val}%" ;;
+      duplicated_lines_density)
+        echo "  Duplication:      ${val}%" ;;
+      ncloc)
+        echo "  Lines of Code:    $val" ;;
+      sqale_rating)
+        echo "  Maintainability:  $(rating_letter "$val")" ;;
+      reliability_rating)
+        echo "  Reliability:      $(rating_letter "$val")" ;;
+      security_rating)
+        echo "  Security:         $(rating_letter "$val")" ;;
+      *)
+        echo "  $key: $val" ;;
+    esac
+  done
+}
+
+cmd_hotspots() {
+  local params="projectKey=${PROJECT}&ps=${LIMIT}"
+
+  local response
+  response=$(api_get "/api/hotspots/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.paging.total')
+  echo "Security Hotspots: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.hotspots[]? | "[\(.vulnerabilityProbability)] \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Status: \(.status)\n"'
+}
+
+cmd_accept() {
+  if [[ -z "$ISSUE_KEY" ]]; then
+    echo "Error: 'accept' requires --issue KEY" >&2
+    exit 1
+  fi
+  if [[ -z "$ACCEPT_COMMENT" ]]; then
+    echo "Error: 'accept' requires --comment 'rationale text'" >&2
+    exit 1
+  fi
+
+  # 1. Transition issue to ACCEPTED.
+  local transition_resp
+  transition_resp=$(curl -s -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/do_transition" \
+    -d "issue=${ISSUE_KEY}&transition=accept")
+
+  local status
+  status=$(echo "$transition_resp" | jq -r '.issue.issueStatus // "UNKNOWN"')
+
+  # 2. Attach rationale comment (URL-encode via jq).
+  local encoded comment_resp comment_status
+  encoded=$(jq -rn --arg s "$ACCEPT_COMMENT" '$s|@uri')
+  comment_resp=$(curl -sS -w $'\n%{http_code}' -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/add_comment" \
+    -d "issue=${ISSUE_KEY}&text=${encoded}")
+  comment_status=$(printf '%s\n' "$comment_resp" | tail -n 1)
+  if [[ "$comment_status" -lt 200 || "$comment_status" -ge 300 ]]; then
+    echo "Error: failed to attach rationale comment (HTTP $comment_status)" >&2
+    echo "Response body:" >&2
+    printf '%s\n' "$comment_resp" | sed '$d' >&2
+    exit 1
+  fi
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$transition_resp" | jq .
+  else
+    echo "Issue $ISSUE_KEY -> $status"
+  fi
+}
+
+# --- Dispatch ---
+case "$COMMAND" in
+  status)   cmd_status   ;;
+  issues)   cmd_issues   ;;
+  metrics)  cmd_metrics  ;;
+  hotspots) cmd_hotspots ;;
+  accept)   cmd_accept   ;;
+  *)        echo "Unknown command: $COMMAND" >&2; exit 1 ;;
+esac

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: version-bump
+description: >
+  Bump the semver version in pyproject.toml (major, minor, or patch) and
+  prepend a Keep-a-Changelog entry to CHANGELOG.md. Use when preparing a
+  release, before creating a PR (the version-check CI job blocks merge if
+  you don't), or when the user says "bump version", "release", or
+  "increment version".
+---
+
+# Version Bump
+
+Bump the semver version in `pyproject.toml` and prepend a new entry to
+`CHANGELOG.md`. Mirrors the AgentCulture workflow used by `culture`,
+`afi-cli`, `cfafi`, and other org repos; vendored here so the repo is
+self-contained.
+
+## Usage
+
+Run from the repo root.
+
+```bash
+# With changelog content (pipe JSON via stdin):
+echo '{"added":["New X"],"changed":["Refactored Y"],"fixed":["Bug in Z"]}' \
+  | python3 .claude/skills/version-bump/scripts/bump.py minor
+
+# Without changelog content (inserts empty ### Added/Changed/Fixed stubs):
+python3 .claude/skills/version-bump/scripts/bump.py patch
+
+# Check current version without bumping:
+python3 .claude/skills/version-bump/scripts/bump.py show
+```
+
+## Bump Types
+
+| Type    | Example        | When to use                                                       |
+|---------|----------------|-------------------------------------------------------------------|
+| `major` | 0.1.0 → 1.0.0  | Breaking changes, namespace restructures, CLI surface breaks      |
+| `minor` | 0.1.0 → 0.2.0  | New features, new commands, new modules                           |
+| `patch` | 0.1.0 → 0.1.1  | Bug fixes, doc updates, dependency bumps, CI-only changes         |
+| `show`  | prints `0.1.0` | Read-only — no files changed                                      |
+
+## Changelog JSON Format
+
+Pass via stdin. All fields are optional — only non-empty sections are rendered.
+
+```json
+{
+  "added":   ["List of new features"],
+  "changed": ["List of changes to existing functionality"],
+  "fixed":   ["List of bug fixes"]
+}
+```
+
+## What it touches
+
+- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
+  `steward/__init__.py` reads it via `importlib.metadata`, so there's no
+  separate `__version__` literal to keep in sync).
+- `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
+
+The script does the rest. Pick a bump type from the diff (patch for fixes,
+minor for new features, major for breaking changes), summarize the diff into
+`added` / `changed` / `fixed` lists, pipe as JSON, and commit the resulting
+`pyproject.toml` + `CHANGELOG.md` alongside the code change so the
+`version-check` CI job sees a consistent bump.

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Bump the version in pyproject.toml and CHANGELOG.md.
+
+If the package's ``__init__.py`` contains a literal ``__version__ = "..."``
+assignment, the script also rewrites that value. In repos that read
+``__version__`` from package metadata (the steward-cli convention), the
+``__init__.py`` step is a no-op.
+
+Usage:
+    bump.py major    # 0.1.0 -> 1.0.0
+    bump.py minor    # 0.1.0 -> 0.2.0
+    bump.py patch    # 0.1.0 -> 0.1.1
+    bump.py show     # print current version
+
+Changelog entries are passed via stdin as a JSON object:
+    {
+      "added": ["New CLI command", "Observer module"],
+      "changed": ["Restructured namespace"],
+      "fixed": ["WHO reply index bug"]
+    }
+
+If no stdin is provided, an empty stub is inserted.
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def find_pyproject() -> Path:
+    """Walk up from cwd to find pyproject.toml."""
+    current = Path.cwd()
+    while current != current.parent:
+        candidate = current / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+    print("ERROR: pyproject.toml not found", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_version(path: Path) -> str:
+    """Extract version string from pyproject.toml."""
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: version field not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """Bump the specified part of a semver version."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"ERROR: version '{version}' is not semver (x.y.z)", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        print(f"ERROR: unknown bump type '{part}' (use major, minor, or patch)", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_version(path: Path, old: str, new: str) -> None:
+    """Replace old version with new in pyproject.toml."""
+    text = path.read_text()
+    updated = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    path.write_text(updated)
+
+
+def read_changelog_entries() -> dict:
+    """Read changelog entries from stdin as JSON."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print("WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr)
+        return {}
+
+
+def format_changelog_section(new: str, entries: dict) -> str:
+    """Format a changelog section from entries dict.
+
+    Output uses single blank lines between elements (markdownlint MD012
+    compliant). Trailing blank line before the next existing entry is
+    included.
+    """
+    today = date.today().isoformat()
+    chunks = [f"## [{new}] - {today}\n"]
+
+    for section in ("added", "changed", "fixed"):
+        items = entries.get(section, [])
+        if items:
+            chunks.append(f"\n### {section.capitalize()}\n\n")
+            chunks.extend(f"- {item}\n" for item in items)
+
+    # If no entries at all, emit empty section stubs.
+    if not any(entries.get(s) for s in ("added", "changed", "fixed")):
+        chunks.append("\n### Added\n\n### Changed\n\n### Fixed\n")
+
+    chunks.append("\n")  # blank line before the next existing entry
+    return "".join(chunks)
+
+
+def update_changelog(project_root: Path, new: str, entries: dict) -> None:
+    """Insert a new changelog entry into CHANGELOG.md."""
+    changelog = project_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print("No CHANGELOG.md found — skipping")
+        return
+
+    text = changelog.read_text()
+    new_entry = format_changelog_section(new, entries)
+
+    marker = "## ["
+    idx = text.find(marker)
+    if idx > 0:
+        changelog.write_text(text[:idx] + new_entry + text[idx:])
+        print(f"Updated CHANGELOG.md with [{new}]")
+    else:
+        print("WARNING: could not find insertion point in CHANGELOG.md", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    part = sys.argv[1].lower()
+    path = find_pyproject()
+    current = read_version(path)
+
+    if part == "show":
+        print(current)
+        sys.exit(0)
+
+    # Read changelog entries before bumping
+    entries = read_changelog_entries()
+
+    new = bump(current, part)
+    write_version(path, current, new)
+
+    # Also update __init__.py if it has __version__
+    init_candidates = [
+        path.parent / path.parent.name / "__init__.py",
+    ]
+    for init in init_candidates:
+        if init.exists():
+            init_text = init.read_text()
+            if f'__version__ = "{current}"' in init_text:
+                init.write_text(init_text.replace(
+                    f'__version__ = "{current}"',
+                    f'__version__ = "{new}"',
+                ))
+                print(f"Updated {init.relative_to(path.parent)}")
+
+    # Update changelog
+    update_changelog(path.parent, new, entries)
+
+    print(f"{current} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+[flake8]
+max-line-length = 100
+extend-select = B
+extend-ignore =
+    # whitespace before ':' — conflicts with black
+    E203,
+    # line break before binary operator — conflicts with black
+    W503
+exclude =
+    .venv,
+    .git,
+    __pycache__,
+    dist,
+    build
+per-file-ignores =
+    # Bandit S-rules are noisy in tests (assert, subprocess, etc.) — mute them.
+    tests/*:S101,S404,S603

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "specifix/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "specifix/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - run: uv run pytest -n auto -v
+
+  test-publish:
+    # Skip on fork PRs — no OIDC/environment context is available there.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: test
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Set dev version
+        run: |
+          BASE=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Publishing ${DEV_VERSION} to TestPyPI"
+
+      - name: Build and publish to TestPyPI
+        run: |
+          uv build
+          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
+
+      - name: Print install commands
+        if: always()
+        run: |
+          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match specifix-cli==${DEV_VERSION}"
+
+  publish:
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Build and publish to PyPI
+        run: |
+          uv build
+          uv publish --trusted-publishing always --check-url https://pypi.org/simple/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Print install commands
         if: always()
         run: |
-          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match specifix-cli==${DEV_VERSION}"
+          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match specifix==${DEV_VERSION}"
 
   publish:
     if: github.event_name == 'push'

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,41 @@
+name: Security Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight
+  workflow_dispatch:
+
+jobs:
+  security-scans:
+    name: Security Scans
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Run Bandit
+        run: uv run bandit -r specifix/ -f json -o bandit-results.json -c pyproject.toml
+        continue-on-error: true
+
+      - name: Run Pylint
+        run: uv run pylint specifix/ --output-format=json:pylint-results.json,text
+        continue-on-error: true
+
+      - name: Upload Security Results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: security-results
+          path: |
+            bandit-results.json
+            pylint-results.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,93 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Promote a presence flag (not the secret) to job env so the SonarCloud
+    # step can gate on it — secrets.* isn't allowed in `if:`.
+    env:
+      SONAR_TOKEN_PRESENT: ${{ secrets.SONAR_TOKEN != '' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Sonar needs full git history for accurate "new code" blame attribution.
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - run: uv run flake8 --config=.flake8 specifix/ tests/
+
+      - run: uv run pytest -n auto --cov=specifix --cov-report=xml:coverage.xml --cov-report=term -v
+
+      - name: SonarCloud Scan
+        if: env.SONAR_TOKEN_PRESENT == 'true'
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+
+  version-check:
+    # Only run on PR events. On push to main the comparison would always
+    # fail (PR_VERSION == MAIN_VERSION) and there is no PR number.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - run: git fetch origin main
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Check version bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # AgentCulture rule: every PR bumps the version — even docs/config/CI.
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAIN_VERSION=$(git show origin/main:pyproject.toml 2>/dev/null | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])" 2>/dev/null || echo "")
+
+          if [ -z "$MAIN_VERSION" ]; then
+            echo "No pyproject.toml on main yet — skipping version check (initial scaffold)."
+            exit 0
+          fi
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            MARKER="<!-- version-check -->"
+            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Bump before merging to avoid a failed PyPI publish.
+
+          $MARKER"
+
+            EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --jq '.[] | select(.body | contains("<!-- version-check -->")) | .id' | head -1)
+
+            if [ -n "$EXISTING" ]; then
+              gh api repos/${{ github.repository }}/issues/comments/$EXISTING \
+                -X PATCH -f body="$BODY" > /dev/null
+            else
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" || true
+            fi
+
+            echo "::error::Version $PR_VERSION matches main. Bump before merging."
+            exit 1
+          else
+            echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ __marimo__/
 
 # AgentCulture: per-machine skill config (committed as .example only)
 .claude/skills.local.yaml
+
+# agex local working state (PR cache, event log)
+.agex/

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# AgentCulture: per-machine skill config (committed as .example only)
+.claude/skills.local.yaml

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,22 @@
+# markdownlint-cli2 config for specifix.
+# markdownlint-cli2 stops walking at the git root, so a global
+# markdownlint config in the user's home directory isn't picked up from
+# inside the repo. Keep this file aligned with the global preset.
+
+config:
+  default: true
+  # MD013: Line length — disabled. Prose lines wrap at the reader.
+  MD013: false
+  # MD060: Table pipe spacing — disabled (stylistic preference).
+  MD060: false
+  # MD024: Duplicate headings — allow under different parents so Keep a
+  # Changelog entries can each have ### Added / ### Changed / ### Fixed.
+  MD024:
+    siblings_only: true
+
+ignores:
+  - "node_modules/**"
+  - ".local/**"
+  - ".venv/**"
+  - ".claude/skills/**"
+  - "docs/superpowers/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-ast
+      - id: detect-private-key
+
+  - repo: local
+    hooks:
+      - id: markdownlint-cli2
+        name: markdownlint-cli2 (check)
+        description: Lint markdown (no auto-fix).
+        entry: markdownlint-cli2
+        language: system
+        types: [markdown]
+
+      - id: flake8
+        name: flake8
+        entry: uv run flake8 --config=.flake8
+        language: system
+        types: [python]
+
+      - id: isort
+        name: isort
+        entry: uv run isort
+        language: system
+        types: [python]
+
+      - id: black
+        name: black
+        entry: uv run black
+        language: system
+        types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/). This project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-05-22
+
+### Added
+
+- AgentCulture sibling scaffold: the `specifix` package (hatchling,
+  Python >=3.12, zero runtime deps) with the afi-cli CLI chassis —
+  structured errors, a strict stdout/stderr split, and `--json` support.
+- Placeholder agent-first verbs `learn` / `explain` / `whoami` — honest
+  "not yet implemented; specifix is greenfield" stubs.
+- CI workflows: `tests.yml` (pytest + coverage + flake8 + SonarCloud +
+  version-check), `security-checks.yml` (bandit + pylint), `publish.yml`
+  (TestPyPI on PR, PyPI on main, via OIDC Trusted Publishing).
+- `culture.yaml` declaring the `specifix` agent nick (`backend: claude`).
+- Vendored skills from steward: `cicd`, `communicate`, `version-bump`,
+  `run-tests`, `sonarclaude`, `doc-test-alignment`. Provenance tracked in
+  `docs/skill-sources.md`.
+- Repo-local lint configs: `.flake8`, `.markdownlint-cli2.yaml`,
+  `.pre-commit-config.yaml`; `sonar-project.properties`; the
+  `.claude/skills.local.yaml.example` per-machine config template.
+
+Resolves #2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Status
 
 **Scaffolded (greenfield product).** The AgentCulture sibling skeleton has
-landed: a `specifix-cli` package with the argparse CLI chassis, tests, CI, the
+landed: the `specifix` package with the argparse CLI chassis, tests, CI, the
 six vendored skills, and `culture.yaml`. The CLI verbs (`learn` / `explain` /
 `whoami`) are **honest placeholder stubs** — the actual spec-creation product is
 not implemented yet. Run `git ls-files` to see the real surface rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-**Pre-implementation.** The tracked surface is only `README.md`, `LICENSE`, and a
-standard Python `.gitignore` — there is no source code, `pyproject.toml`, test
-suite, or `culture.yaml` yet. Treat any task here as greenfield: there is nothing
-existing to conform to. Run `git ls-files` to see the real surface rather than
+**Scaffolded (greenfield product).** The AgentCulture sibling skeleton has
+landed: a `specifix-cli` package with the argparse CLI chassis, tests, CI, the
+six vendored skills, and `culture.yaml`. The CLI verbs (`learn` / `explain` /
+`whoami`) are **honest placeholder stubs** — the actual spec-creation product is
+not implemented yet. Run `git ls-files` to see the real surface rather than
 trusting a layout described here.
+
+Real commands (verify against `pyproject.toml`): `uv sync`;
+`uv run specifix --version`; `python -m specifix`; `uv run pytest -n auto`
+(single test: `uv run pytest tests/<file>::<node> -v`);
+`uv run flake8 --config=.flake8 specifix/ tests/`; `markdownlint-cli2 "**/*.md"`.
 
 ## Project intent
 
@@ -75,6 +81,19 @@ isort`; `bandit` + `pylint` in CI; `markdownlint-cli2 "**/*.md"`.
   once a `culture.yaml` (with the repo nick) exists, otherwise `- Claude`. Inside
   the `cicd` flow, the scripts append the signature — don't sign the body manually
   there.
+
+## Finishing a branch: default to a PR, never pause for the menu
+
+When work on a branch is complete and tests pass, **proceed directly to pushing
+the branch and opening a Pull Request** — do not present an interactive "what
+would you like to do?" menu and wait for a choice. This overrides the
+Superpowers `finishing-a-development-branch` skill, whose default is to stop and
+ask the user to pick among *merge locally / create PR / keep as-is / discard*.
+That pause breaks the flow. In specifix — and in every AgentCulture sibling —
+the standing choice is **always "push and open a Pull Request,"** done via the
+`cicd` skill (`agex pr open`). Merge-locally / keep-as-is / discard happen only
+on explicit user request. (Standing rule carried by the `cicd` skill since
+steward 0.18.0.)
 
 ## What not to invent
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # specifix
-Agent owner for specifix to create specs for changes
+
+An AgentCulture agent that owns spec creation for changes.
+
+Greenfield: the CLI scaffold (`specifix learn` / `explain` / `whoami`) ships as
+honest "not yet implemented" stubs. See `CLAUDE.md` for project shape and
+commands.

--- a/culture.yaml
+++ b/culture.yaml
@@ -1,0 +1,3 @@
+agents:
+- suffix: specifix
+  backend: claude

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -1,0 +1,27 @@
+# Skill sources — vendored skill provenance
+
+specifix vendors cross-sibling skills from `steward`, the AgentCulture skill
+supplier. This follows the **cite, don't import** pattern: each skill is
+copied into `.claude/skills/`, owned locally, and may diverge. Nothing
+imports across repos at runtime.
+
+This file is the upstream/downstream map. When upstream changes, re-sync
+explicitly — these copies do not auto-update.
+
+| Skill | Re-vendor from | Vendored | Runtime backing & notes |
+|-------|----------------|----------|-------------------------|
+| `cicd` | `steward` (`../steward/.claude/skills/cicd/`) | 2026-05-22 | **Runtime:** core PR-lifecycle verbs (`lint` / `open` / `read` / `reply` / `delta`) delegate to `agex pr` from `agentculture/agex-cli` — `agex` must be installed (`uv tool install agex-cli`). Steward keeps two extensions on top — `status` (SonarCloud gate + hotspots + unresolved-thread tally) and `await`. **Divergence:** none — vendored verbatim. SKILL.md body cites steward-specific constructs (e.g. `steward doctor`) as inherited upstream context, not specifix-actionable. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known `pr-status.sh` `--repo` fix may need a local patch if `gh pr view` misbehaves. |
+| `communicate` | `steward` (`../steward/.claude/skills/communicate/`) | 2026-05-22 | **Runtime:** GitHub issue-I/O verbs (`post-issue` / `post-comment` / `fetch-issues`) wrap `agtag` (>=0.1) — `agtag` must be installed. Signatures resolve from the local `culture.yaml` first-agent `suffix` (here: `specifix`), overridable via `agtag --as NICK`; mesh messages stay unsigned. **Divergence:** none — vendored verbatim. The `steward announce-skill-update` broadcast verb referenced in the body is steward-cli-only and not available to specifix. |
+| `version-bump` | `steward` (`../steward/.claude/skills/version-bump/`) | 2026-05-22 | Pure Python (`scripts/bump.py`), no per-repo customization. **Divergence:** none — vendored verbatim. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known insertion-point bug (`idx > 0` vs `idx != -1`) can mis-handle a `CHANGELOG.md` that starts directly with a `## [` entry; apply the documented local patch only if a bump fails. |
+| `run-tests` | `steward` (`../steward/.claude/skills/run-tests/`) | 2026-05-22 | None — portable verbatim. Coverage source resolves from `[tool.coverage.run]` in `pyproject.toml`. |
+| `sonarclaude` | `steward` (`../steward/.claude/skills/sonarclaude/`) | 2026-05-22 | None — portable verbatim. Project key resolves from `$SONAR_PROJECT` / `--project` (here: `agentculture_specifix`). |
+| `doc-test-alignment` | `steward` (`../steward/.claude/skills/doc-test-alignment/`) | 2026-05-22 | **Stub upstream** — `scripts/check.sh` exits with a not-yet-implemented error today; the contract for what it will do lives in its `SKILL.md`. Vendored verbatim to carry the contract. |
+
+## Vendoring policy
+
+- **Cite, don't import.** Skills are copied, not symlinked or installed as
+  a dependency.
+- **Re-sync explicitly.** When upstream changes, re-vendor from
+  `../steward/.claude/skills/<name>/`.
+- **Diverge intentionally.** Record any divergence in the table above and
+  in the downstream `SKILL.md` frontmatter `description`.

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -8,9 +8,17 @@ imports across repos at runtime.
 This file is the upstream/downstream map. When upstream changes, re-sync
 explicitly — these copies do not auto-update.
 
+**Upstream provenance.** All six skills come from
+[`agentculture/steward`](https://github.com/agentculture/steward), **MIT**-licensed
+(the same license as specifix). They were vendored from the local steward checkout
+at commit [`21414a9`](https://github.com/agentculture/steward/commit/21414a9)
+(2026-05-22). The table records each skill's re-vendor path, the vendoring date,
+and any local divergence; license (MIT) and upstream repo are shared across all
+rows.
+
 | Skill | Re-vendor from | Vendored | Runtime backing & notes |
 |-------|----------------|----------|-------------------------|
-| `cicd` | `steward` (`../steward/.claude/skills/cicd/`) | 2026-05-22 | **Runtime:** core PR-lifecycle verbs (`lint` / `open` / `read` / `reply` / `delta`) delegate to `agex pr` from `agentculture/agex-cli` — `agex` must be installed (`uv tool install agex-cli`). Steward keeps two extensions on top — `status` (SonarCloud gate + hotspots + unresolved-thread tally) and `await`. **Divergence:** none — vendored verbatim. SKILL.md body cites steward-specific constructs (e.g. `steward doctor`) as inherited upstream context, not specifix-actionable. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known `pr-status.sh` `--repo` fix may need a local patch if `gh pr view` misbehaves. |
+| `cicd` | `steward` (`../steward/.claude/skills/cicd/`) | 2026-05-22 | **Runtime:** core PR-lifecycle verbs (`lint` / `open` / `read` / `reply` / `delta`) delegate to `agex pr` from `agentculture/agex-cli` — `agex` must be installed (`uv tool install agex-cli`). Steward keeps two extensions on top — `status` (SonarCloud gate + hotspots + unresolved-thread tally) and `await`. **Divergence:** local patch — `scripts/portability-lint.sh` drops GNU-only `xargs -r` in both grep pipelines (it fails on BSD/macOS; empties are already guarded) so the portability gate runs cross-platform; marked with `# specifix-divergence:`. Should be upstreamed to steward; drop on next re-vendor. SKILL.md body cites steward-specific constructs (e.g. `steward doctor`) as inherited upstream context, not specifix-actionable. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known `pr-status.sh` `--repo` fix may need a local patch if `gh pr view` misbehaves. |
 | `communicate` | `steward` (`../steward/.claude/skills/communicate/`) | 2026-05-22 | **Runtime:** GitHub issue-I/O verbs (`post-issue` / `post-comment` / `fetch-issues`) wrap `agtag` (>=0.1) — `agtag` must be installed. Signatures resolve from the local `culture.yaml` first-agent `suffix` (here: `specifix`), overridable via `agtag --as NICK`; mesh messages stay unsigned. **Divergence:** none — vendored verbatim. The `steward announce-skill-update` broadcast verb referenced in the body is steward-cli-only and not available to specifix. |
 | `version-bump` | `steward` (`../steward/.claude/skills/version-bump/`) | 2026-05-22 | Pure Python (`scripts/bump.py`), no per-repo customization. **Divergence:** none — vendored verbatim. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known insertion-point bug (`idx > 0` vs `idx != -1`) can mis-handle a `CHANGELOG.md` that starts directly with a `## [` entry; apply the documented local patch only if a bump fails. |
 | `run-tests` | `steward` (`../steward/.claude/skills/run-tests/`) | 2026-05-22 | None — portable verbatim. Coverage source resolves from `[tool.coverage.run]` in `pyproject.toml`. |

--- a/docs/superpowers/plans/2026-05-22-specifix-onboarding.md
+++ b/docs/superpowers/plans/2026-05-22-specifix-onboarding.md
@@ -1,0 +1,54 @@
+# specifix Onboarding Implementation Plan
+
+**Goal:** Scaffold `specifix` into a healthy AgentCulture sibling — package,
+CLI chassis with placeholder verbs, CI, lint configs, `culture.yaml`, and six
+vendored skills — in a single PR that closes issue #2.
+
+**Architecture:** Mirror the `appsec` greenfield sibling. A hatchling-built
+`specifix-cli` package exposes a `specifix` CLI: a real argparse chassis
+(`specifix/cli/`) with structured errors, a strict stdout/stderr split, and
+`--json` support, plus three honest placeholder verbs (`learn` / `explain` /
+`whoami`). Six canonical skills are copied verbatim from the local `../steward`
+checkout. CI runs pytest + coverage + flake8 + SonarCloud + a version-check,
+with bandit/pylint in a separate workflow and PyPI publishing via OIDC.
+
+**Tech stack:** Python ≥3.12, `uv`, hatchling, pytest + pytest-cov +
+pytest-xdist, flake8/black/isort/bandit/pylint, GitHub Actions, SonarCloud.
+
+## Build sequence
+
+Single branch (`onboard-sibling-pattern`), single PR. Each step verified
+before the next.
+
+1. **Package + CLI chassis** — `specifix/__init__.py`, `__main__.py`,
+   `cli/{__init__,_errors,_output}.py`, `cli/_commands/{learn,explain,whoami}.py`.
+   Verify: `uv run python -m specifix --version` works; each verb exits 0.
+2. **Tests** — `tests/test_{package,cli_errors,cli_output,cli_chassis,cli_stubs}.py`.
+   Verify: `uv run pytest -n auto` green; coverage above `fail_under = 70`.
+3. **Toolchain + config** — `pyproject.toml`, `.flake8`,
+   `.markdownlint-cli2.yaml`, `.pre-commit-config.yaml`,
+   `sonar-project.properties`, `CHANGELOG.md`, `culture.yaml`, `.gitignore`
+   carve-out. Verify: `uv run flake8 --config=.flake8 specifix/ tests/` and
+   `markdownlint-cli2 "**/*.md"` clean.
+4. **CI workflows** — `tests.yml`, `security-checks.yml`, `publish.yml`.
+5. **Vendor six skills** — `cp -R` from `../steward` (`cicd`, `communicate`,
+   `version-bump`, `run-tests`, `sonarclaude`, `doc-test-alignment`),
+   `chmod +x` script entry points, write `docs/skill-sources.md` and
+   `.claude/skills.local.yaml.example`. Verify: each `SKILL.md` `name:`
+   matches its directory.
+6. **Docs + CLAUDE.md** — this plan + the design spec; refresh `CLAUDE.md`
+   Status and add the branch-finishing default.
+7. **Verify as a sibling** — `uv sync`, full test/lint suite, then
+   `steward doctor ../specifix` from a steward checkout; fix anything flagged.
+8. **Open the PR** — via the vendored `cicd` skill (`agex pr`) so the
+   `- specifix (Claude)` signature is auto-applied. Body resolves #2. One
+   version bump: `0.1.0`.
+
+## Known not-green at merge (tracked, not blockers)
+
+- `publish.yml` runs red until PyPI Trusted Publishing is configured for
+  `specifix-cli`.
+- The SonarCloud quality gate does not report until `agentculture_specifix`
+  is registered (scan step gated on `SONAR_TOKEN_PRESENT`).
+- CLI verbs are placeholder stubs; the specifix spec-creation product is
+  undefined and deferred to a later effort.

--- a/docs/superpowers/plans/2026-05-22-specifix-onboarding.md
+++ b/docs/superpowers/plans/2026-05-22-specifix-onboarding.md
@@ -5,7 +5,7 @@ CLI chassis with placeholder verbs, CI, lint configs, `culture.yaml`, and six
 vendored skills — in a single PR that closes issue #2.
 
 **Architecture:** Mirror the `appsec` greenfield sibling. A hatchling-built
-`specifix-cli` package exposes a `specifix` CLI: a real argparse chassis
+`specifix` package exposes a `specifix` CLI: a real argparse chassis
 (`specifix/cli/`) with structured errors, a strict stdout/stderr split, and
 `--json` support, plus three honest placeholder verbs (`learn` / `explain` /
 `whoami`). Six canonical skills are copied verbatim from the local `../steward`
@@ -47,7 +47,7 @@ before the next.
 ## Known not-green at merge (tracked, not blockers)
 
 - `publish.yml` runs red until PyPI Trusted Publishing is configured for
-  `specifix-cli`.
+  `specifix`.
 - The SonarCloud quality gate does not report until `agentculture_specifix`
   is registered (scan step gated on `SONAR_TOKEN_PRESENT`).
 - CLI verbs are placeholder stubs; the specifix spec-creation product is

--- a/docs/superpowers/specs/2026-05-22-specifix-onboarding-design.md
+++ b/docs/superpowers/specs/2026-05-22-specifix-onboarding-design.md
@@ -34,7 +34,7 @@ sibling agents) is a separate later effort.
 |----------|--------|
 | Scope | Onboarding infrastructure only; agent product deferred. |
 | CLI verbs | `learn` / `explain` / `whoami` as honest placeholder stubs — each prints one "not yet implemented; specifix is greenfield" line and exits 0, with a structured `--json` payload. |
-| Scaffold model | Mirror the `appsec` sibling — the most recent greenfield sibling that resolved this exact onboarding. Package name `specifix-cli`, import `specifix`, console script `specifix` (per issue §1, mirroring `steward-cli`/`steward`). |
+| Scaffold model | Mirror the `appsec` sibling — the most recent greenfield sibling that resolved this exact onboarding. PyPI distribution `specifix`, import `specifix`, console script `specifix`. (Issue §1 suggested `specifix-cli`, but the bare `specifix` name matches the registered PyPI Trusted-Publishing project and what `appsec` actually shipped.) |
 | Skills | Vendor all **six** canonical skills directly from `../steward` (not from appsec — avoids inheriting appsec's documented divergences): `cicd`, `communicate`, `version-bump`, `run-tests`, `sonarclaude`, `doc-test-alignment`. Vendored verbatim — no divergence to record. |
 | PR strategy | One PR for everything: full scaffold + all six vendored skills + provenance ledger. One version bump (`0.1.0`). Closes issue #2. Pushed and opened directly per the branch-finishing default. |
 
@@ -43,7 +43,7 @@ sibling agents) is a separate later effort.
 The repo mirrors the established sibling skeleton:
 
 - **Package + CLI chassis** (`specifix/`): `__init__.py` (`__version__` via
-  `importlib.metadata.version("specifix-cli")`), `__main__.py`
+  `importlib.metadata.version("specifix")`), `__main__.py`
   (`python -m specifix`), and `cli/` with `__init__.py` (argparse dispatch,
   structured-error routing, `--json` hint), `_errors.py` (`SpecifixError` +
   exit-code policy), `_output.py` (strict stdout/stderr split), and
@@ -85,7 +85,7 @@ The repo mirrors the established sibling skeleton:
 ### Known not-green at merge (not blockers)
 
 - `publish.yml` runs red until PyPI Trusted Publishing is configured for
-  `specifix-cli` (a manual maintainer step: register on PyPI/TestPyPI,
+  `specifix` (a manual maintainer step: register on PyPI/TestPyPI,
   configure the OIDC publisher, create the `pypi` / `testpypi` environments).
 - The SonarCloud quality gate does not report until `agentculture_specifix`
   is registered on sonarcloud.io and the GitHub App is installed. The scan

--- a/docs/superpowers/specs/2026-05-22-specifix-onboarding-design.md
+++ b/docs/superpowers/specs/2026-05-22-specifix-onboarding-design.md
@@ -1,0 +1,100 @@
+# specifix onboarding — AgentCulture sibling scaffold
+
+**Date:** 2026-05-22
+**Status:** Approved (design)
+**Closes:** agentculture/specifix issue #2
+
+## Problem
+
+`specifix` is a brand-new AgentCulture sibling repo — the agent that *owns
+spec creation for changes*. Today it contains only `CLAUDE.md`, `LICENSE`,
+`README.md`, `.gitignore`, and `.claude/settings.local.json` — no package,
+no build config, no CI, no `culture.yaml`, no vendored skills.
+
+Issue #2 ("the works") is the onboarding contract: bring `specifix` up to the
+full shared sibling shape (the 12 required artifacts from steward's
+`docs/sibling-pattern.md`, the quality pipeline, and the inherited
+conventions) so agents and humans can move between AgentCulture repos without
+relearning the layout.
+
+## Scope
+
+**In scope:** the onboarding *infrastructure* only — make `specifix` a
+"healthy sibling" per steward's `docs/sibling-pattern.md`.
+
+**Out of scope:** the actual specifix spec-creation product. The `learn` /
+`explain` / `whoami` CLI verbs ship as honest placeholder stubs; designing
+what the agent *does* (and where it sits relative to the
+`superpowers:brainstorming` / `writing-plans` / `writing-skills` skills and
+sibling agents) is a separate later effort.
+
+## Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Scope | Onboarding infrastructure only; agent product deferred. |
+| CLI verbs | `learn` / `explain` / `whoami` as honest placeholder stubs — each prints one "not yet implemented; specifix is greenfield" line and exits 0, with a structured `--json` payload. |
+| Scaffold model | Mirror the `appsec` sibling — the most recent greenfield sibling that resolved this exact onboarding. Package name `specifix-cli`, import `specifix`, console script `specifix` (per issue §1, mirroring `steward-cli`/`steward`). |
+| Skills | Vendor all **six** canonical skills directly from `../steward` (not from appsec — avoids inheriting appsec's documented divergences): `cicd`, `communicate`, `version-bump`, `run-tests`, `sonarclaude`, `doc-test-alignment`. Vendored verbatim — no divergence to record. |
+| PR strategy | One PR for everything: full scaffold + all six vendored skills + provenance ledger. One version bump (`0.1.0`). Closes issue #2. Pushed and opened directly per the branch-finishing default. |
+
+## Architecture
+
+The repo mirrors the established sibling skeleton:
+
+- **Package + CLI chassis** (`specifix/`): `__init__.py` (`__version__` via
+  `importlib.metadata.version("specifix-cli")`), `__main__.py`
+  (`python -m specifix`), and `cli/` with `__init__.py` (argparse dispatch,
+  structured-error routing, `--json` hint), `_errors.py` (`SpecifixError` +
+  exit-code policy), `_output.py` (strict stdout/stderr split), and
+  `_commands/{learn,explain,whoami}.py` (placeholder stubs, each with a
+  `register(sub)`).
+- **Tests** (`tests/`): package smoke test, error/output unit tests, chassis
+  tests (`--version`, no-args help, unknown-verb error, `python -m`), and
+  per-verb stub tests (exit 0 + output + `--json`).
+- **Toolchain + config**: `pyproject.toml` (hatchling, py≥3.12, zero runtime
+  deps, dev group), `.flake8`, `.markdownlint-cli2.yaml`,
+  `.pre-commit-config.yaml`, `sonar-project.properties`
+  (`agentculture_specifix`), `CHANGELOG.md` (Keep-a-Changelog `[0.1.0]`),
+  `culture.yaml` (`suffix: specifix`, `backend: claude`), `.gitignore`
+  skills.local carve-out.
+- **CI** (`.github/workflows/`): `tests.yml` (pytest + coverage + flake8 +
+  SonarCloud + version-check), `security-checks.yml` (bandit + pylint),
+  `publish.yml` (TestPyPI on PR, PyPI on main, OIDC Trusted Publishing).
+- **Vendored skills** (`.claude/skills/`): the six skills + the committed
+  `.claude/skills.local.yaml.example`; provenance in `docs/skill-sources.md`.
+
+## Acceptance criteria
+
+- `pyproject.toml` (hatchling, py≥3.12); `python -m specifix` and
+  `specifix --version` both work.
+- `specifix/cli/` chassis with `_errors.py`, `_output.py`,
+  `_commands/{whoami,learn,explain}.py` as honest stubs; `--json` supported.
+- `tests/` with a passing pytest-xdist suite; `tests.yml` + `publish.yml`
+  (incl. `version-check`, which auto-passes on the initial PR — no
+  `pyproject.toml` on `main` yet).
+- `culture.yaml` declares `backend: claude` and the nick `specifix`;
+  `CLAUDE.md` agrees (backend-consistency).
+- All six skills vendored under `.claude/skills/` (matching `name:`
+  frontmatter + `scripts/`); provenance in `docs/skill-sources.md`.
+- `.claude/skills.local.yaml.example` committed; `.flake8` and
+  `.markdownlint-cli2.yaml` repo-local.
+- `CHANGELOG.md` started; version bumped to `0.1.0` on the onboarding PR.
+- `steward doctor ../specifix` exits clean.
+
+### Known not-green at merge (not blockers)
+
+- `publish.yml` runs red until PyPI Trusted Publishing is configured for
+  `specifix-cli` (a manual maintainer step: register on PyPI/TestPyPI,
+  configure the OIDC publisher, create the `pypi` / `testpypi` environments).
+- The SonarCloud quality gate does not report until `agentculture_specifix`
+  is registered on sonarcloud.io and the GitHub App is installed. The scan
+  step is gated on `SONAR_TOKEN_PRESENT`, so CI won't break if absent.
+
+## References
+
+- `steward/docs/sibling-pattern.md` — the 12 required artifacts and the
+  `steward doctor` invariants.
+- `steward/docs/skill-sources.md` — canonical upstream for each skill.
+- `appsec/` — the greenfield scaffold exemplar.
+- agentculture/specifix issue #2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,76 @@
+[project]
+name = "specifix-cli"
+version = "0.1.0"
+description = "specifix — owns spec creation for changes (greenfield AgentCulture sibling)."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [{name = "AgentCulture"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development",
+    "Intended Audience :: Developers",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/agentculture/specifix"
+Issues = "https://github.com/agentculture/specifix/issues"
+
+[project.scripts]
+specifix = "specifix.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["specifix"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.0",
+    "pytest-cov>=4.1",
+    "coverage>=7.2.0",
+    "bandit>=1.7.5",
+    "pylint>=2.17.0",
+    "flake8>=6.1",
+    "flake8-bandit>=4.1.1",
+    "flake8-bugbear>=23.7.10",
+    "black>=23.7.0",
+    "isort>=5.12.0",
+    "pre-commit>=3.5.0",
+]
+
+[tool.coverage.run]
+source = ["specifix"]
+omit = ["specifix/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+known_first_party = ["specifix"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "specifix-cli"
+name = "specifix"
 version = "0.1.0"
 description = "specifix — owns spec creation for changes (greenfield AgentCulture sibling)."
 readme = "README.md"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+# SonarCloud project identity. The project must be registered on
+# sonarcloud.io under the agentculture organization, and the SonarCloud
+# GitHub App installed on this repo, before the scan produces a quality gate.
+sonar.projectKey=agentculture_specifix
+sonar.organization=agentculture
+
+# Source layout — package lives at the top level (no src/ wrapper).
+sonar.sources=specifix
+sonar.tests=tests
+
+# Coverage report produced in CI by `uv run pytest --cov-report=xml:coverage.xml`.
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.12
+
+sonar.exclusions=**/__pycache__/**,**/.venv/**,uv.lock

--- a/specifix/__init__.py
+++ b/specifix/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _v
 
 try:
-    __version__ = _v("specifix-cli")
+    __version__ = _v("specifix")
 except PackageNotFoundError:  # pragma: no cover  — editable install without metadata
     __version__ = "0.0.0+local"
 

--- a/specifix/__init__.py
+++ b/specifix/__init__.py
@@ -1,0 +1,11 @@
+"""specifix — owns spec creation for changes (greenfield AgentCulture sibling)."""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _v
+
+try:
+    __version__ = _v("specifix-cli")
+except PackageNotFoundError:  # pragma: no cover  — editable install without metadata
+    __version__ = "0.0.0+local"
+
+__all__ = ["__version__"]

--- a/specifix/__main__.py
+++ b/specifix/__main__.py
@@ -1,0 +1,8 @@
+"""Allow running specifix as ``python -m specifix``."""
+
+import sys
+
+from specifix.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specifix/cli/__init__.py
+++ b/specifix/cli/__init__.py
@@ -1,0 +1,105 @@
+"""Unified CLI entry point for specifix.
+
+Error-propagation contract: every handler raises
+:class:`specifix.cli._errors.SpecifixError` on failure; ``main()`` catches it
+via :func:`_dispatch` and routes through :mod:`specifix.cli._output`. Unknown
+exceptions are wrapped into a ``SpecifixError`` so no Python traceback leaks.
+
+Argparse errors (unknown verb, missing required arg) also route through the
+structured format — :class:`_SpecifixArgumentParser` overrides ``.error()``.
+Whether errors render as text or JSON depends on whether ``--json`` appears in
+the raw argv (:func:`main` sets ``_SpecifixArgumentParser._json_hint`` before
+``parse_args``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from specifix import __version__
+from specifix.cli._errors import EXIT_USER_ERROR, SpecifixError
+from specifix.cli._output import emit_error
+
+
+class _SpecifixArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that routes errors through :func:`emit_error`."""
+
+    _json_hint: bool = False
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        err = SpecifixError(
+            code=EXIT_USER_ERROR,
+            message=message,
+            remediation=f"run '{self.prog} --help' to see valid arguments",
+        )
+        emit_error(err, json_mode=type(self)._json_hint)
+        raise SystemExit(err.code)
+
+
+def _argv_has_json(argv: list[str] | None) -> bool:
+    tokens = argv if argv is not None else sys.argv[1:]
+    return any(t == "--json" or t.startswith("--json=") for t in tokens)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = _SpecifixArgumentParser(
+        prog="specifix",
+        description="specifix — owns spec creation for changes (greenfield).",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    sub = parser.add_subparsers(dest="command", parser_class=_SpecifixArgumentParser)
+
+    from specifix.cli._commands import explain as _explain_cmd
+    from specifix.cli._commands import learn as _learn_cmd
+    from specifix.cli._commands import whoami as _whoami_cmd
+
+    _learn_cmd.register(sub)
+    _explain_cmd.register(sub)
+    _whoami_cmd.register(sub)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    """Invoke the registered handler and translate exceptions to exit codes.
+
+    A handler may return ``None`` (treated as success, exit 0) or an ``int``
+    used directly as the exit code. Failures MUST raise :class:`SpecifixError`;
+    any other exception is wrapped so no Python traceback leaks.
+    """
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        rc = args.func(args)
+    except SpecifixError as err:
+        emit_error(err, json_mode=json_mode)
+        return err.code
+    except Exception as err:  # noqa: BLE001 - last-resort; wrap and route cleanly
+        wrapped = SpecifixError(
+            code=EXIT_USER_ERROR,
+            message=f"unexpected: {err.__class__.__name__}: {err}",
+            remediation="file a bug at https://github.com/agentculture/specifix/issues",
+        )
+        emit_error(wrapped, json_mode=json_mode)
+        return wrapped.code
+    return rc if rc is not None else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _SpecifixArgumentParser._json_hint = _argv_has_json(argv)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    return _dispatch(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specifix/cli/_commands/explain.py
+++ b/specifix/cli/_commands/explain.py
@@ -1,0 +1,40 @@
+"""``specifix explain`` — placeholder verb.
+
+See :mod:`specifix.cli._commands.learn` for why the verbs are stubs.
+``explain`` will eventually print docs for a given topic / command path; today
+it prints an honest "not yet implemented" line.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from specifix import __version__
+from specifix.cli._output import emit_result
+
+_TEXT = "specifix explain — not yet implemented; specifix is greenfield. See CLAUDE.md."
+
+
+def _json_payload() -> dict[str, object]:
+    return {
+        "tool": "specifix",
+        "version": __version__,
+        "status": "greenfield",
+        "verb": "explain",
+        "message": _TEXT,
+    }
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    if json_mode:
+        emit_result(_json_payload(), json_mode=True)
+    else:
+        emit_result(_TEXT, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("explain", help="Explain a specifix topic or command (stub).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_explain)

--- a/specifix/cli/_commands/learn.py
+++ b/specifix/cli/_commands/learn.py
@@ -1,0 +1,44 @@
+"""``specifix learn`` — placeholder verb.
+
+specifix is a greenfield AgentCulture sibling: the scaffold (package, CLI
+chassis, CI, vendored skills) is in place but the spec-creation agent itself is
+not implemented yet. This verb prints an honest status line so a probing agent
+or human gets a clear signal rather than a misleading response.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from specifix import __version__
+from specifix.cli._output import emit_result
+
+_TEXT = (
+    "specifix — owns spec creation for changes. Not yet implemented; specifix "
+    "is a greenfield AgentCulture sibling. See CLAUDE.md."
+)
+
+
+def _json_payload() -> dict[str, object]:
+    return {
+        "tool": "specifix",
+        "version": __version__,
+        "status": "greenfield",
+        "verb": "learn",
+        "message": _TEXT,
+    }
+
+
+def cmd_learn(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    if json_mode:
+        emit_result(_json_payload(), json_mode=True)
+    else:
+        emit_result(_TEXT, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("learn", help="Print specifix's self-teaching status line.")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_learn)

--- a/specifix/cli/_commands/whoami.py
+++ b/specifix/cli/_commands/whoami.py
@@ -1,0 +1,40 @@
+"""``specifix whoami`` — placeholder verb.
+
+See :mod:`specifix.cli._commands.learn` for why the verbs are stubs.
+``whoami`` will eventually be the smallest identity / auth probe; today it
+prints an honest "not yet implemented" line.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from specifix import __version__
+from specifix.cli._output import emit_result
+
+_TEXT = "specifix — not yet implemented; specifix is greenfield. See CLAUDE.md."
+
+
+def _json_payload() -> dict[str, object]:
+    return {
+        "tool": "specifix",
+        "version": __version__,
+        "status": "greenfield",
+        "verb": "whoami",
+        "message": _TEXT,
+    }
+
+
+def cmd_whoami(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    if json_mode:
+        emit_result(_json_payload(), json_mode=True)
+    else:
+        emit_result(_TEXT, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("whoami", help="Print specifix's identity probe (stub).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_whoami)

--- a/specifix/cli/_errors.py
+++ b/specifix/cli/_errors.py
@@ -1,0 +1,39 @@
+"""SpecifixError and exit-code policy.
+
+Every failure inside specifix raises :class:`SpecifixError`. The top-level
+``main()`` catches it, formats via :mod:`specifix.cli._output`, and exits with
+:attr:`SpecifixError.code`. This centralises the exit-code policy and
+guarantees no Python traceback leaks to stderr.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Exit-code policy:
+#   0  = success
+#   1  = user-input error (bad flag, missing required arg, unknown path)
+#   2  = environment / setup error (tool not installed, file unreadable)
+#   3+ = reserved for future categorisation
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 1
+EXIT_ENV_ERROR = 2
+
+
+@dataclass
+class SpecifixError(Exception):
+    """Structured error raised within specifix; carries a remediation hint."""
+
+    code: int
+    message: str
+    remediation: str = ""
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "remediation": self.remediation,
+        }

--- a/specifix/cli/_output.py
+++ b/specifix/cli/_output.py
@@ -1,0 +1,45 @@
+"""stdout / stderr helpers with a strict split.
+
+Rule: **results go to stdout, diagnostics and errors go to stderr.** Agents
+parsing specifix output can rely on this invariant. JSON mode routes structured
+payloads to the same streams — it never mixes them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, TextIO
+
+from specifix.cli._errors import SpecifixError
+
+
+def emit_result(data: Any, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write a command result to stdout (text or JSON), newline-terminated."""
+    s = stream if stream is not None else sys.stdout
+    if json_mode:
+        json.dump(data, s, ensure_ascii=False)
+        s.write("\n")
+        return
+    text = data if isinstance(data, str) else str(data)
+    s.write(text)
+    if not text.endswith("\n"):
+        s.write("\n")
+
+
+def emit_error(err: SpecifixError, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write a :class:`SpecifixError` to stderr (text or JSON)."""
+    s = stream if stream is not None else sys.stderr
+    if json_mode:
+        json.dump(err.to_dict(), s, ensure_ascii=False)
+        s.write("\n")
+        return
+    s.write(f"error: {err.message}\n")
+    if err.remediation:
+        s.write(f"hint: {err.remediation}\n")
+
+
+def emit_diagnostic(message: str, *, stream: TextIO | None = None) -> None:
+    """Write a human diagnostic (progress, summary) to stderr."""
+    s = stream if stream is not None else sys.stderr
+    s.write(message if message.endswith("\n") else message + "\n")

--- a/tests/test_cli_chassis.py
+++ b/tests/test_cli_chassis.py
@@ -1,0 +1,48 @@
+"""Tests for the specifix CLI chassis."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from specifix import __version__
+from specifix.cli import main
+
+
+def test_version_flag_exits_zero_and_prints_version(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--version"])
+    assert exc.value.code == 0
+    assert __version__ in capsys.readouterr().out
+
+
+def test_no_args_prints_help_and_returns_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main([])
+    assert rc == 0
+    assert "usage: specifix" in capsys.readouterr().out
+
+
+def test_unknown_verb_routes_through_structured_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["definitely-not-a-verb"])
+    assert exc.value.code == 1
+    assert "error:" in capsys.readouterr().err
+
+
+def test_python_dash_m_invocation() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "specifix", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert __version__ in result.stdout

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,36 @@
+"""Tests for SpecifixError and the exit-code policy."""
+
+from __future__ import annotations
+
+from specifix.cli._errors import (
+    EXIT_ENV_ERROR,
+    EXIT_SUCCESS,
+    EXIT_USER_ERROR,
+    SpecifixError,
+)
+
+
+def test_exit_code_constants() -> None:
+    assert EXIT_SUCCESS == 0
+    assert EXIT_USER_ERROR == 1
+    assert EXIT_ENV_ERROR == 2
+
+
+def test_specifix_error_is_an_exception() -> None:
+    err = SpecifixError(code=1, message="bad input", remediation="try --help")
+    assert isinstance(err, Exception)
+    assert str(err) == "bad input"
+
+
+def test_specifix_error_to_dict() -> None:
+    err = SpecifixError(code=2, message="missing tool", remediation="install it")
+    assert err.to_dict() == {
+        "code": 2,
+        "message": "missing tool",
+        "remediation": "install it",
+    }
+
+
+def test_remediation_defaults_to_empty() -> None:
+    err = SpecifixError(code=1, message="x")
+    assert err.remediation == ""

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,57 @@
+"""Tests for the stdout/stderr output helpers."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from specifix.cli._errors import SpecifixError
+from specifix.cli._output import emit_diagnostic, emit_error, emit_result
+
+
+def test_emit_result_text_adds_trailing_newline() -> None:
+    buf = io.StringIO()
+    emit_result("hello", json_mode=False, stream=buf)
+    assert buf.getvalue() == "hello\n"
+
+
+def test_emit_result_json() -> None:
+    buf = io.StringIO()
+    emit_result({"a": 1}, json_mode=True, stream=buf)
+    assert json.loads(buf.getvalue()) == {"a": 1}
+
+
+def test_emit_error_text_with_remediation() -> None:
+    buf = io.StringIO()
+    emit_error(
+        SpecifixError(code=1, message="bad", remediation="fix it"),
+        json_mode=False,
+        stream=buf,
+    )
+    assert buf.getvalue() == "error: bad\nhint: fix it\n"
+
+
+def test_emit_error_text_without_remediation() -> None:
+    buf = io.StringIO()
+    emit_error(SpecifixError(code=1, message="bad"), json_mode=False, stream=buf)
+    assert buf.getvalue() == "error: bad\n"
+
+
+def test_emit_error_json() -> None:
+    buf = io.StringIO()
+    emit_error(
+        SpecifixError(code=2, message="bad", remediation="fix"),
+        json_mode=True,
+        stream=buf,
+    )
+    assert json.loads(buf.getvalue()) == {
+        "code": 2,
+        "message": "bad",
+        "remediation": "fix",
+    }
+
+
+def test_emit_diagnostic_adds_newline() -> None:
+    buf = io.StringIO()
+    emit_diagnostic("working", stream=buf)
+    assert buf.getvalue() == "working\n"

--- a/tests/test_cli_stubs.py
+++ b/tests/test_cli_stubs.py
@@ -1,0 +1,69 @@
+"""Tests for the placeholder CLI verbs (learn / explain / whoami).
+
+specifix is greenfield — these verbs are honest stubs. The tests pin the
+contract: each verb exits 0, prints a 'not yet implemented' signal, and
+honours --json with a structured payload.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from specifix.cli import main
+
+
+def test_learn_exits_zero_and_signals_greenfield(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["learn"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "specifix" in out
+    assert "not yet implemented" in out.lower()
+
+
+def test_learn_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["learn", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tool"] == "specifix"
+    assert payload["status"] == "greenfield"
+    assert payload["verb"] == "learn"
+
+
+def test_explain_exits_zero_and_signals_greenfield(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["explain"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "specifix" in out
+    assert "not yet implemented" in out.lower()
+
+
+def test_explain_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verb"] == "explain"
+    assert payload["status"] == "greenfield"
+
+
+def test_whoami_exits_zero_and_signals_greenfield(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["whoami"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "specifix" in out
+    assert "not yet implemented" in out.lower()
+
+
+def test_whoami_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["whoami", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verb"] == "whoami"
+    assert payload["status"] == "greenfield"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,10 @@
+"""Package-level smoke test."""
+
+from __future__ import annotations
+
+import specifix
+
+
+def test_version_is_a_nonempty_string() -> None:
+    assert isinstance(specifix.__version__, str)
+    assert specifix.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,646 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5", size = 219967, upload-time = "2026-05-10T18:00:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662", size = 220329, upload-time = "2026-05-10T18:00:15.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cf/a8f4b43a16e194b0261257ad28ded5853ec052570afef4a84e1d81189f3b/coverage-7.14.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b4f07cf7edcb7ec39431a5074d7ea83b29a9f71fcfc494f0f40af4e65180420f", size = 251839, upload-time = "2026-05-10T18:00:17.16Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67", size = 254576, upload-time = "2026-05-10T18:00:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9", size = 255690, upload-time = "2026-05-10T18:00:20.648Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5af63f636cc62a4a2b1b3ba9146f6ee6f53a35a50d5cefc54d5670f60999/coverage-7.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b2bb6c9d7e769360d0f20a0f219603fd64f0c8f97de17ab25853261602be0fb", size = 257949, upload-time = "2026-05-10T18:00:22.28Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d3/a225317bd2012132a27e1176d51660b826f99bb975876463c44ea0d7ee5a/coverage-7.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c9ed6ef99f88fb8c14aa8e2bf8eb0fe55fa2edfea68f8675d78741df1a5ac0e", size = 252242, upload-time = "2026-05-10T18:00:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3", size = 253608, upload-time = "2026-05-10T18:00:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/1522b524a35bdad22b2b8c4f9d32d0a104b524726ec380b2db68db1746f5/coverage-7.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8b013632cc1ce1d09dbe4f32667b4d320ec2f54fc326ebeffcd0b0bcc2bb6c4", size = 251753, upload-time = "2026-05-10T18:00:27.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/cdf00d38817742c541ade405e115a3f7bf36e6f2a8b99d4f209861b85a2d/coverage-7.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1733198802d71ec4c524f322e2867ee05c62e9e75df86bdca545407a221827d1", size = 255823, upload-time = "2026-05-10T18:00:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fc/5e7877cf5f902d08a17ff1c532511476d87e1bea355bd5028cb97f902e79/coverage-7.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:72a305291fa8ee01332f1aaf38b348ca34097f6aa0b0ef627eef2837e57bbba5", size = 251323, upload-time = "2026-05-10T18:00:30.647Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595", size = 253197, upload-time = "2026-05-10T18:00:32.211Z" },
+    { url = "https://files.pythonhosted.org/packages/00/3f/6f61ffe6439df266c3cf60f5c99cfaa21103d0210d706a42fc6c30683ff8/coverage-7.14.0-cp312-cp312-win32.whl", hash = "sha256:5ac83957a80d0701310e96d8bec68cdcf4f90a7674b7d13f15a344315b41ab27", size = 222515, upload-time = "2026-05-10T18:00:33.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2", size = 223324, upload-time = "2026-05-10T18:00:35.172Z" },
+    { url = "https://files.pythonhosted.org/packages/74/18/9f7fe62f659f24b7a82a0be56bf94c1bd0a89e0ae7ab4c668f6e82404294/coverage-7.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:91b993743d959b8be85b4abf9d5478216a69329c321efe5be0433c1a841d691d", size = 221944, upload-time = "2026-05-10T18:00:37.014Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef", size = 219990, upload-time = "2026-05-10T18:00:38.887Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66", size = 220365, upload-time = "2026-05-10T18:00:40.864Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6f/9ad575d505b4d805b254febc8a5b338a2efe278f8786e56ff1cb8413f9c3/coverage-7.14.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:22a7e06a5f11a757cdfe79018e9095f9f69ae283c5cd8123774c788deec8717b", size = 251363, upload-time = "2026-05-10T18:00:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca", size = 253961, upload-time = "2026-05-10T18:00:44.079Z" },
+    { url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7", size = 255193, upload-time = "2026-05-10T18:00:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7b/5bfd7ac1df3b881c2ac7a5cbc99c7609e6296c402f5ef587cd81c6f355b3/coverage-7.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a841fae2fadcae4f438d43b6ccc4aac2ad609f47cdb6cfdce60cbb3fe5ca7bc2", size = 257326, upload-time = "2026-05-10T18:00:47.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/38/1d37d316b174fad3843a1d76dbdfe4398771c9ecd0515935dd9ece9cd627/coverage-7.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c79d2319cabef1fe8e86df73371126931550804738f78ad7d31e3aad85a67367", size = 251582, upload-time = "2026-05-10T18:00:49.152Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9", size = 253325, upload-time = "2026-05-10T18:00:51.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b9/bbe87206d9687b192352f893797825b5f5b15ecd3aa9c68fbff0c074d77b/coverage-7.14.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:55d3089079ce181a4566b1065ab28d2575eb76d8ac8f81f4fcda2bf037fee087", size = 251291, upload-time = "2026-05-10T18:00:52.816Z" },
+    { url = "https://files.pythonhosted.org/packages/46/57/b8cdb12ac0d73ef0243218bd5e22c9df8f92edab8018213a86aec67c5324/coverage-7.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:49c005cba1e2f9677fb2845dcdf9a2e72a52a17d63e8231aaaae35d9f50215ef", size = 255448, upload-time = "2026-05-10T18:00:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d4/5002019538b2036ce3c84340f54d2fd5100d55b0a6b0894eee56128d03c7/coverage-7.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9117377b823daa28aa8635fbb08cda1cd6be3d7143257345459559aeef852d52", size = 251110, upload-time = "2026-05-10T18:00:56.122Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe", size = 252885, upload-time = "2026-05-10T18:00:57.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ab/3cf6427ac9c1f1db747dbb1ce71dde47984876d4c2cfd018a3fef0a78d4d/coverage-7.14.0-cp313-cp313-win32.whl", hash = "sha256:fb609b3658479e33f9516d46f1a89dbb9b6c261366e3a11844a96ec487533dae", size = 222539, upload-time = "2026-05-10T18:00:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e", size = 223344, upload-time = "2026-05-10T18:01:01.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/99/118daa192f95e3a6cb2740100fbf8797cda1734b4134ef0b5d501a7fa8f3/coverage-7.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:b4e26a0f1b696faf283bffe5b8569e44e336c582439df5d53281ab89ee0cba96", size = 221966, upload-time = "2026-05-10T18:01:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f1/a46cc0c013be170216253184a32366d7cbdb9252feaec866b05c2d12a894/coverage-7.14.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:953f521ca9445300397e65fda3dca58b2dbd68fee983777420b57ac3c77e9f90", size = 220679, upload-time = "2026-05-10T18:01:05.058Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8c/9c30a3d311a34177fa432995be7fbfc64477d8bac5630bd38055b1c9b424/coverage-7.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:98af83fd65ae24b1fdd03aaead967a9f523bcd2f1aab2d4f3ffda65bb568a6f1", size = 221033, upload-time = "2026-05-10T18:01:07.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/3fb5e06c3badefd0c1b47e2044fdca67f8220a4ec2e7fcfb476aa0a67c6c/coverage-7.14.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:668b92e6958c4db7cf92e81caac328dfbbdbb215db2850ad28f0cbe1eea0bfbd", size = 262333, upload-time = "2026-05-10T18:01:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e6/fbc322325c7294d3e22c1ad6b79e45d0806b25228c8e5842aed6d8169aa7/coverage-7.14.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9fbd898551762dea00d3fef2b1c4f99afd2c6a3ff952ea07d60a9bd5ed4f34bc", size = 264410, upload-time = "2026-05-10T18:01:10.531Z" },
+    { url = "https://files.pythonhosted.org/packages/08/92/c497b264bec1673c47cc77e26f760fcda4654cabf1f39546d1a23a3b8c35/coverage-7.14.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68af363c07ecd8d4b7d4043d85cb376d7d227eceb54e5323ee45da73dbd3e426", size = 266836, upload-time = "2026-05-10T18:01:12.19Z" },
+    { url = "https://files.pythonhosted.org/packages/78/fc/045da320987f401af5d2815d351e8aa799aec859f60e29f445e3089eeedb/coverage-7.14.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e57054a583da8ac55edf24117ea4c9133032cfc4cf72aa2d48c1e5d4b52f899", size = 267974, upload-time = "2026-05-10T18:01:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ae/227b1e379497fb7a4fc3286e620f80c8a1e7cec66d45695a01639eb1af65/coverage-7.14.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3499459bbcdd51a65b64c35ab7ed2764eaf3cba826e0df3f1d7fe2e102b70b", size = 261578, upload-time = "2026-05-10T18:01:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f5/3570342900f2acea31d33ff1590c5d8bac1a8e1a2e1c6d34a5d5e61de681/coverage-7.14.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:45899ec2138a4346ed34d601dedf5076fb74edf2d1dd9dc76a78e82397edee90", size = 264394, upload-time = "2026-05-10T18:01:17.607Z" },
+    { url = "https://files.pythonhosted.org/packages/16/29/de1bbc01c935b28f89b1dc3db85b011c055e843a8e5e3b83141c3f80af7f/coverage-7.14.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8767486808c436f05b23ab98eb963fb29185e32a9357a166971685cb3459900f", size = 262022, upload-time = "2026-05-10T18:01:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/35/95/f53890b0bf2fc10ab168e05d38869215e73ca24c4cb521c3bb0eb62fe16b/coverage-7.14.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a3b5ddfd6aa7ddad53ee3edb231e88a2151507a43229b7d71b953916deca127d", size = 265732, upload-time = "2026-05-10T18:01:21.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ea/c919e259081dd2bdf0e43b87209709ba7ec2e4117c2a7f5185379c43463c/coverage-7.14.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:63df0fe568e698e1045792399f8ab6da3a6c2dce3182813fb92afa2641087b47", size = 260921, upload-time = "2026-05-10T18:01:23.533Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2c/c2831889705a81dc5d1c6ca12e4d8e9b95dfc146d153488a6c0ea685d28e/coverage-7.14.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:827d6397dbd95144939b18f89edf31f63e1f99633e8d5f32f22ba8bdda567477", size = 263109, upload-time = "2026-05-10T18:01:25.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a9/2fcae5003cac3d63fe344d2166243c2756935f48420863c5272b240d550b/coverage-7.14.0-cp313-cp313t-win32.whl", hash = "sha256:7bf43e000d24012599b879791cff41589af90674722421ef11b11a5431920bab", size = 223212, upload-time = "2026-05-10T18:01:27.157Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/bb/18e94d7b14b9b398164197114a587a04ab7c9fdbe1d237eef57311c5e883/coverage-7.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3f5549365af25d770e06b1f8f5682d9a5637d06eb494db91c6fa75d3950cc917", size = 224272, upload-time = "2026-05-10T18:01:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/db/56/4f14fad782b035c81c4ffd09159e7103d42bb1d93ac8496d04b90a11b7da/coverage-7.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6d160217ec6fe890f16ad3a9531761589443749e448f91986c972714fad361c8", size = 222530, upload-time = "2026-05-10T18:01:31.151Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
+    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "flake8-bandit"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bandit" },
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/1c/4f66a7a52a246d6c64312b5c40da3af3630cd60b27af81b137796af3c0bc/flake8_bandit-4.1.1.tar.gz", hash = "sha256:068e09287189cbfd7f986e92605adea2067630b75380c6b5733dab7d87f9a84e", size = 5403, upload-time = "2022-08-29T13:48:41.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/5f/55bab0ac89f9ad9f4c6e38087faa80c252daec4ccb7776b4dac216ca9e3f/flake8_bandit-4.1.1-py3-none-any.whl", hash = "sha256:4c8a53eb48f23d4ef1e59293657181a3c989d0077c9952717e98a0eace43e06d", size = 4828, upload-time = "2022-08-29T13:48:39.737Z" },
+]
+
+[[package]]
+name = "flake8-bugbear"
+version = "25.11.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/2a996e2fca7810bd1b031901d65fc4292630895afcb946ebd00568bdc669/flake8_bugbear-25.11.29.tar.gz", hash = "sha256:b5d06710f3d26e595541ad303ad4d5cb52578bd4bccbb2c2c0b2c72e243dafc8", size = 84896, upload-time = "2025-11-29T20:51:57.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/42/c18f199780d99a6f6a64c4a36f4ad28a445d9e11968a6025b21d0c8b6802/flake8_bugbear-25.11.29-py3-none-any.whl", hash = "sha256:9bf15e2970e736d2340da4c0a70493db964061c9c38f708cfe1f7b2d87392298", size = 37861, upload-time = "2025-11-29T20:51:56.439Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "specifix-cli"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "black" },
+    { name = "coverage" },
+    { name = "flake8" },
+    { name = "flake8-bandit" },
+    { name = "flake8-bugbear" },
+    { name = "isort" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.7.5" },
+    { name = "black", specifier = ">=23.7.0" },
+    { name = "coverage", specifier = ">=7.2.0" },
+    { name = "flake8", specifier = ">=6.1" },
+    { name = "flake8-bandit", specifier = ">=4.1.1" },
+    { name = "flake8-bugbear", specifier = ">=23.7.10" },
+    { name = "isort", specifier = ">=5.12.0" },
+    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "pylint", specifier = ">=2.17.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ wheels = [
 ]
 
 [[package]]
-name = "specifix-cli"
+name = "specifix"
 version = "0.1.0"
 source = { editable = "." }
 


### PR DESCRIPTION
## Onboard specifix to the AgentCulture sibling pattern ("the works")

Brings `specifix` up to the full shared sibling shape per steward's
`docs/sibling-pattern.md`, so agents and humans can move between AgentCulture
repos without relearning the layout. **Scope: onboarding infrastructure only** —
the spec-creation product is deferred; the CLI verbs are honest
"not yet implemented; specifix is greenfield" stubs.

### What landed

- **Package + CLI chassis** — `specifix-cli` (hatchling, py≥3.12, zero runtime
  deps); the afi-cli chassis (`SpecifixError` + exit-code policy, strict
  stdout/stderr split, `--json`); agent-first verbs `learn` / `explain` /
  `whoami` as honest stubs. `python -m specifix` and `specifix --version` work.
- **Tests** — pytest-xdist suite, 21 tests, 94% coverage.
- **CI** — `tests.yml` (pytest + coverage + flake8 + SonarCloud + version-check),
  `security-checks.yml` (bandit + pylint), `publish.yml` (TestPyPI on PR / PyPI
  on main via OIDC Trusted Publishing).
- **Config** — `culture.yaml` (`suffix: specifix`, `backend: claude`),
  `sonar-project.properties` (`agentculture_specifix`), repo-local `.flake8` /
  `.markdownlint-cli2.yaml` / `.pre-commit-config.yaml`, `CHANGELOG.md`
  (`[0.1.0]`), `.claude/skills.local.yaml.example`.
- **Six vendored skills** (cite-don't-import, verbatim from `../steward`):
  `cicd`, `communicate`, `version-bump`, `run-tests`, `sonarclaude`,
  `doc-test-alignment`. Provenance in `docs/skill-sources.md`.
- **CLAUDE.md** — refreshed Status; added the steward-0.18.0 branch-finishing
  default (push + PR, don't pause for the menu).

### Verification (local)

- `uv run pytest -n auto` → 21 passed, 93.79% coverage.
- `uv run flake8` / `black --check` / `isort --check` / `bandit` → clean.
- `markdownlint-cli2 "**/*.md"` → 0 errors.
- `steward doctor ../specifix` → clean (4 checks: portability,
  skills-convention, prompt-file-present, backend-consistency).

### Known not-green at merge (not blockers)

- `publish.yml` runs red until PyPI Trusted Publishing is configured for
  `specifix-cli` (register on PyPI/TestPyPI, configure the OIDC publisher,
  create the `pypi` / `testpypi` environments — a manual maintainer step).
- The SonarCloud quality gate won't report until `agentculture_specifix` is
  registered on sonarcloud.io and the GitHub App is installed; the scan step is
  gated on `SONAR_TOKEN_PRESENT`, so CI won't break if absent.

Resolves #2.

- specifix (Claude)
