### PR TITLE
Add spec→plan engine; split /devague skill into /think + /spec-to-plan

### DIFF
--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: spec-to-plan
+description: >
+  Turn a converged devague spec into a buildable plan by working forwards (the
+  spec→plan leg; drives the `devague plan` CLI group). Seed a plan from a
+  converged frame, add tasks that collectively cover every coverage target (the
+  frame's confirmed claims + honesty conditions), give each task acceptance
+  criteria and an honest dependency order, park genuine unknowns as first-class
+  risks, and export a plan only once it *converges*. Use when the user says
+  "spec to plan", "stp", "turn this spec into a plan", "plan this spec", "make a
+  build plan", or after the /think skill exports a spec. Authored and maintained
+  in agentculture/devague (origin = devague); steward pulls this skill from here
+  and broadcasts it to the AgentCulture mesh — it is NOT vendored from steward
+  like the other skills here.
+---
+
+# spec-to-plan — work a converged spec forwards into a buildable plan
+
+The skill is named **`spec-to-plan`**; the product/CLI it drives is the
+**`devague plan`** command group. (The prior leg — turning a vague idea into a
+spec — is the sibling **`/think`** skill.) It is the **forward** peer of the
+working-backwards spec engine: where `/think` converges on *what* to build,
+`/spec-to-plan` converges on *how* to build it.
+
+A plan is seeded from a **converged frame** and tracks **tasks** against the
+spec's **coverage targets**. The CLI is **deterministic and move-driven** — you
+(the agent) choose the next move; the CLI tracks state and tells you what's still
+missing. Run `devague plan learn` for the method and `devague plan explain
+<move>` for any single move.
+
+## How to run
+
+The entry point is `scripts/spec-to-plan.sh`. Invoke it from the repository you
+are speccing (plans persist under `.devague/` in the current directory, alongside
+the frames they derive from):
+
+```bash
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh <move> [args...]
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` inside the devague checkout, else an
+install hint. Every move except `status` is forwarded verbatim as `devague plan
+<move>`, so you can equally call the CLI directly (`devague plan <move> …`).
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new --frame <slug>` | Seed a plan from a **converged** frame. Derives the coverage targets (`c*`/`h*`) the plan must satisfy. Refuses an unconverged frame. |
+| `task "<summary>"` | Add a task. `--accept "<crit>"`, `--dep <tN>`, `--covers <c*/h*>` (each repeatable); `--origin llm` lands it `proposed`. |
+| `accept <tN> "<crit>"` | Add an acceptance criterion to a task. |
+| `depend <tN> --on <tM>` | Record that task `tN` depends on `tM`. |
+| `cover <tN> --target <c*/h*>` | Mark a task as covering a coverage target. |
+| `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** |
+| `risk "<text>" --kind <kind>` | Record a first-class plan risk (`--task <tN>` to attach). |
+| `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
+| `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
+| `show` / `list` | Render a plan / list plans (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Risk kinds (shared with the frame engine): `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+### `status` — the next-move helper
+
+`status` is a wrapper-only verb. It reads `devague plan converge --json` +
+`devague plan list --json` and prints where the current plan stands, the
+remaining gaps, and the recommended next move derived from the first gap.
+
+```text
+plan: my-feature    (1 plan total)
+convergence: NOT passed — 2 gap(s):
+  - coverage target c5 (boundary) has no confirmed task
+  - task t2 has no acceptance criteria
+
+recommended next move (first gap):
+  cover c5: devague plan task "<summary>" --covers c5 --accept "<...>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **Seed from a converged spec only.** `plan new` refuses a frame that hasn't
+  converged. The plan's coverage targets *are* the spec's confirmed claims and
+  honesty conditions — there is nothing honest to plan against until the spec
+  converges.
+- **LLM proposals stay proposed.** A task captured with `--origin llm` lands as
+  `proposed`. **Never `confirm` your own proposal.** Confirmation is a user-only
+  decision — surface the proposed task and let the user confirm or reject it.
+- **Cover every target; criteria on every task.** The gate requires every
+  coverage target to be covered by a confirmed task, and every confirmed task to
+  carry at least one acceptance criterion. Don't hand-wave a task as "done-ish."
+- **Keep the graph honest.** Dependencies must reference real tasks and form an
+  acyclic graph; the gate rejects dangling deps and cycles.
+- **Park real unknowns as risks; don't paper over them.** A genuinely unknown
+  decision is an `unknown_blocking` risk — it holds back convergence, by design.
+- **Converge against the live frame.** `converge`/`export` re-load the source
+  frame every time. If the frame was deleted or has regressed below convergence,
+  they refuse — re-converge the spec (in `/think`) first.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload.
+Exit code `0` on success, non-zero on user error (with a `hint:` line). Plans
+live under `.devague/plans/` in the current directory; the exported plan-md lands
+in `docs/plans/`.
+
+## Worked example
+
+Picking up after `/think` exported a spec for the frame `my-feature`:
+
+```bash
+p() { bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh "$@"; }
+
+p new --frame my-feature        # seeds the plan + its coverage targets
+p show                          # see the c*/h* targets you must cover
+
+p task "Build the core engine" --accept "engine has a convergence gate" \
+    --covers c1 --covers c3
+p task "Pressure-test honesty conditions" --dep t1 --covers h1 --covers h2 \
+    --accept "every honesty condition maps to a test"
+
+# Park a genuine unknown instead of guessing:
+p risk "exact rollout sequencing" --kind unknown_nonblocking
+
+p status        # what's left + the next move
+p converge      # gate; resolve any listed gaps
+p export        # writes docs/plans/my-feature.md once converged
+```
+
+The exported plan-md is a buildable artifact: topologically ordered tasks, each
+with acceptance criteria and the spec targets it covers. It feeds directly into
+implementation (or `superpowers:writing-plans`).
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding), next to
+its sibling `/think`. It is the *inverse* of the other skills under
+`.claude/skills/`, which devague vendors **from** steward. When ready, steward
+pulls it **from** devague and broadcasts it to the rest of the AgentCulture mesh.
+The `cite, don't import` policy still holds: downstream repos copy it, they don't
+symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+#
+# The skill is named `spec-to-plan`; the product/CLI it drives is `devague` (the
+# idea→spec half lives in the sibling /think skill). This wrapper forwards every
+# move to `devague plan <move>` verbatim, and adds one value-add subcommand —
+# `status` — that reads the plan convergence gate and names the recommended next
+# move. It is the forward leg: seed a plan from a *converged* frame, then work it
+# into a buildable plan.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory (alongside frames), so
+# run from the repo you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+
+Usage:
+  spec-to-plan.sh <move> [args...]   forward a `devague plan` move
+  spec-to-plan.sh status [--plan S]  where the plan stands + the next move
+  spec-to-plan.sh help               this help
+
+Moves (forwarded to `devague plan`; run `devague plan learn` for the method):
+  new          start a plan from a CONVERGED frame (--frame <slug>)
+  task         add a task (--accept / --dep / --covers, --origin user|llm)
+  accept       add an acceptance criterion to a task
+  depend       record that a task depends on another (--on)
+  cover        mark a task as covering a coverage target (c*/h*)
+  confirm      confirm a task                          (USER-only decision)
+  reject       reject a task
+  risk         record a first-class plan risk
+  converge     check whether the plan can export
+  export       write the buildable plan (only after converge passes)
+  show / list  render a plan / list plans
+  learn        teach the method   |   explain <move>  explain one move
+
+Plans persist under .devague/ in the current directory — run from the repo you
+are speccing. Results go to stdout, diagnostics to stderr; pass --json to any
+move for structured output.
+
+Note: `status` is a wrapper-only verb; everything else is forwarded verbatim as
+`devague plan <move>`, so new plan moves work without editing this script.
+
+Prior leg: a plan is seeded from a converged frame produced by the /think skill.
+EOF
+}
+
+# ── status: read the plan convergence gate and recommend the next move ──────
+cmd_status() {
+    local list_json conv_out conv_err conv_rc req_plan="" prev="" tmp_err
+
+    for arg in "$@"; do
+        case "$prev" in --plan) req_plan="$arg" ;; esac
+        case "$arg" in --plan=*) req_plan="${arg#--plan=}" ;; esac
+        prev="$arg"
+    done
+
+    list_json="$("${DEVAGUE[@]}" plan list --json 2>/dev/null || true)"
+
+    tmp_err="$(mktemp)"
+    set +e
+    conv_out="$("${DEVAGUE[@]}" plan converge --json "$@" 2>"$tmp_err")"
+    conv_rc=$?
+    set -e
+    conv_err="$(cat "$tmp_err")"
+    rm -f "$tmp_err"
+
+    DEVAGUE_LIST_JSON="$list_json" \
+        DEVAGUE_CONV_JSON="$conv_out" \
+        DEVAGUE_CONV_ERR="$conv_err" \
+        DEVAGUE_CONV_RC="$conv_rc" \
+        DEVAGUE_REQ_PLAN="$req_plan" \
+        python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+
+def load(name):
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+lst = load("DEVAGUE_LIST_JSON") or {}
+conv = load("DEVAGUE_CONV_JSON")
+conv_err = os.environ.get("DEVAGUE_CONV_ERR", "").strip()
+req_plan = os.environ.get("DEVAGUE_REQ_PLAN", "").strip()
+try:
+    conv_rc = int(os.environ.get("DEVAGUE_CONV_RC", "0") or "0")
+except ValueError:
+    conv_rc = 0
+
+plans = lst.get("plans") or []
+current = lst.get("current")
+
+if not plans:
+    print("no plans yet — seed one from a converged frame:")
+    print('  devague plan new --frame "<slug>"')
+    print("  (the frame must have converged in the /think skill first)")
+    sys.exit(0)
+
+shown = req_plan or current or "(none selected)"
+total = len(plans)
+print(f"plan: {shown}    ({total} plan{'s' if total != 1 else ''} total)")
+
+if conv is None:
+    # A non-zero converge exit is a real error (deleted/regressed source frame,
+    # bad --plan) — relay devague's own error:/hint: lines instead of masking it.
+    if conv_rc != 0 and conv_err:
+        sys.stderr.write(conv_err + "\n")
+        sys.exit(conv_rc)
+    print("convergence: unknown (could not evaluate the plan)")
+    print("next move: devague plan show     # inspect the plan")
+    sys.exit(0)
+
+if conv.get("passed"):
+    print("convergence: PASSED ✓")
+    print("next move: devague plan export   # write the buildable plan")
+    sys.exit(0)
+
+missing = conv.get("missing") or []
+print(f"convergence: NOT passed — {len(missing)} gap(s):")
+for gap in missing:
+    print(f"  - {gap}")
+
+
+def suggest(gap):
+    if "no tasks yet" in gap:
+        return 'devague plan task "<summary>" --covers <c*/h*> --accept "<criterion>"'
+    m = re.search(r"coverage target (\w+) ", gap)
+    if m:
+        tid = m.group(1)
+        return (
+            f'cover {tid}: devague plan task "<summary>" --covers {tid} --accept "<...>"'
+            f"   (or: devague plan cover <tN> --target {tid})"
+        )
+    m = re.search(r"task (t\d+) has no acceptance", gap)
+    if m:
+        return f'devague plan accept {m.group(1)} "<acceptance criterion>"'
+    m = re.search(r"task (t\d+) still proposed", gap)
+    if m:
+        tid = m.group(1)
+        return (
+            f"this is an LLM proposal — the USER decides:"
+            f" devague plan confirm {tid}   (or: devague plan reject {tid})"
+        )
+    m = re.search(r"task (t\d+) depends on unknown task (t\d+)", gap)
+    if m:
+        return f"fix {m.group(1)}'s dependency on missing {m.group(2)} (add it, or drop the dep)"
+    if "dependency cycle" in gap:
+        return "break the dependency cycle: re-point one task's --dep so the graph is acyclic"
+    m = re.search(r"blocking risk (r\d+)", gap)
+    if m:
+        return f"resolve {m.group(1)}: cover it with a task, or re-record it as non-blocking"
+    return "devague plan show     # inspect and decide"
+
+
+if missing:
+    print()
+    print("recommended next move (first gap):")
+    print(f"  {suggest(missing[0])}")
+PY
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        status)
+            shift
+            resolve_devague
+            cmd_status "$@"
+            ;;
+        *)
+            # Forward everything else to `devague plan <move>` verbatim, so the
+            # CLI's own parser owns the plan surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -1,21 +1,26 @@
 ---
-name: devague
+name: think
 description: >
-  Operate the devague working-backwards spec tool: turn a vague feature idea
-  into a buildable, pressure-tested spec by starting from the announcement
-  ("pretend it shipped"), capturing and classifying claims, interrogating them
-  with honesty conditions and hard questions, parking open vagueness as a
-  first-class object, and exporting a spec only once the frame *converges*. Use
-  when the user says "spec this", "work backwards", "turn this idea into a
-  spec", "announcement frame", or "devague", or when a feature request is too
-  vague to build yet. Authored and maintained in agentculture/devague (origin =
-  devague); steward pulls this skill from here and broadcasts it to the
+  Think a vague feature idea into a buildable spec by working backwards (the
+  idea→spec leg; drives the `devague` CLI). Start from the announcement
+  ("pretend it shipped"), capture and classify claims, interrogate them with
+  honesty conditions and hard questions, park open vagueness as a first-class
+  object, and export a spec only once the frame *converges*. Use when the user
+  says "think this through", "spec this", "work backwards", "turn this idea into
+  a spec", "announcement frame", or "devague", or when a feature request is too
+  vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
+  skill to turn it into a plan. Authored and maintained in agentculture/devague
+  (origin = devague); steward pulls this skill from here and broadcasts it to the
   AgentCulture mesh — it is NOT vendored from steward like the other skills here.
 ---
 
-# devague — work an idea backwards into a buildable spec
+# think — work an idea backwards into a buildable spec
 
-`devague` turns a vague feature idea into a buildable spec by **working
+The skill is named **`think`**; the product/CLI it drives is **`devague`**. (The
+forward leg — turning a converged spec into a plan — is the sibling
+**`/spec-to-plan`** skill, which drives `devague plan`.)
+
+`think` turns a vague feature idea into a buildable spec by **working
 backwards**: you start from the announcement you'd make if it had already
 shipped, then build an **Announcement Frame** by capturing claims, pressure
 -testing them, parking what's still genuinely unknown, and only exporting once
@@ -31,12 +36,12 @@ reads the convergence gate and tells you the recommended next move.
 
 ## How to run
 
-The entry point is `scripts/devague.sh`. Invoke it from the repository you are
+The entry point is `scripts/think.sh`. Invoke it from the repository you are
 speccing (frames persist under `.devague/` in the current directory):
 
 ```bash
-bash .claude/skills/devague/scripts/devague.sh <move> [args...]
-bash .claude/skills/devague/scripts/devague.sh status
+bash .claude/skills/think/scripts/think.sh <move> [args...]
+bash .claude/skills/think/scripts/think.sh status
 ```
 
 It resolves the CLI portably — an installed `devague` on `PATH` (the normal
@@ -129,7 +134,7 @@ A short end-to-end session (the kind you'd run to spec a feature like
 [devague#5](https://github.com/agentculture/devague/issues/5)):
 
 ```bash
-d() { bash .claude/skills/devague/scripts/devague.sh "$@"; }
+d() { bash .claude/skills/think/scripts/think.sh "$@"; }
 
 d new "Devague ships a documented spec contract"
 d capture --kind audience "devague + the assisting LLM"
@@ -150,8 +155,10 @@ d converge      # gate; resolve any listed gaps
 d export        # writes docs/specs/<slug>.md once converged
 ```
 
-The exported spec-md is a buildable artifact; it can feed directly into
-`superpowers:writing-plans` or a normal implementation PR.
+The exported spec-md is a buildable artifact. The next leg is the sibling
+**`/spec-to-plan`** skill: `devague plan new --frame <slug>` seeds a plan from the
+converged frame and works it forward into a buildable plan (it can equally feed
+`superpowers:writing-plans` or a normal implementation PR).
 
 ## Provenance
 

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# devague.sh — operate the devague working-backwards spec tool.
+# think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
 #
+# The skill is named `think`; the product/CLI it drives is `devague` (the spec→plan
+# half lives in the sibling /spec-to-plan skill, which drives `devague plan`).
 # devague turns a vague feature idea into a buildable spec by working backwards.
 # This wrapper is the agent-facing operator for the deterministic devague CLI:
 # it resolves the CLI portably, forwards every move verbatim, and adds one
@@ -47,12 +49,12 @@ EOF
 
 usage() {
     cat <<'EOF'
-devague.sh — operate the devague working-backwards spec tool.
+think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
 
 Usage:
-  devague.sh <move> [args...]    forward a devague move
-  devague.sh status [--frame S]  where the frame stands + the next move
-  devague.sh help                this help
+  think.sh <move> [args...]    forward a devague move
+  think.sh status [--frame S]  where the frame stands + the next move
+  think.sh help                this help
 
 Moves (forwarded to the devague CLI; run `devague learn` for the full method):
   new          start a frame from the announcement ("pretend it shipped")
@@ -73,6 +75,9 @@ any move for structured output.
 Note: `status` is a wrapper-only verb (the CLI has no `status`); everything
 else is forwarded verbatim, so new devague moves work without editing this
 script.
+
+Next leg: once a frame exports a spec, hand off to the /spec-to-plan skill
+(`devague plan ...`) to turn that spec into a buildable plan.
 EOF
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-23
+
+### Added
+
+- **Spec→plan engine** — a deterministic structural peer of the working-backwards frame engine that turns a converged spec into a buildable plan. New modules: `devague/plan.py` (Plan / Task / PlanRisk / CoverageTarget domain), `plan_convergence.py` (coverage + acceptance + acyclic-dependency + blocking-risk gate, reusing `ConvergenceResult`), `plan_store.py` (`.devague/plans/`), and `render/plan_md.py` (topologically-ordered buildable plan).
+- Nested `devague plan` CLI group (`new` / `task` / `accept` / `depend` / `cover` / `confirm` / `reject` / `risk` / `converge` / `export` / `show` / `list` / `learn` / `explain`), all with `--json`. `plan new` requires a converged source frame; `converge`/`export` re-evaluate against the **live** frame and refuse on frame drift (deleted or regressed).
+- New first-party **`/spec-to-plan`** skill (`.claude/skills/spec-to-plan/`): a portable wrapper (`scripts/spec-to-plan.sh`) forwarding to `devague plan` plus a `status` next-move helper over the plan gate.
+
+### Changed
+
+- **Renamed the `devague` skill to `think`** (`.claude/skills/think/`, `scripts/think.sh`) — clearer idea→spec framing and to pair with the new `/spec-to-plan` sibling. The product/CLI/repo name stays `devague`; only the skill identity changed. `docs/skill-sources.md` and downstream steward re-vendoring must relearn the new name. ("devague" remains a trigger keyword on `/think`.)
+
 ## [0.3.3] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-**Working-backwards engine landed (v0.3.0).** The full deterministic spec
-engine is implemented: Frame domain model, persistent JSON store, convergence
-gate, pluggable renderer registry, and all CLI moves — `new` / `capture` /
-`interrogate` / `confirm` / `reject` / `park` / `converge` / `export` / `show`
-/ `list` — plus real `learn` / `explain` bodies that teach the method.
-Coverage is 94 %; all linters pass. Run `git ls-files` to see the real surface.
+**Spec→plan engine landed (v0.4.0).** Both deterministic engines now ship.
+The **frame engine** (idea→spec) — Frame domain model, JSON store, convergence
+gate, renderer registry, and the flat moves `new` / `capture` / `interrogate` /
+`confirm` / `reject` / `park` / `converge` / `export` / `show` / `list` /
+`learn` / `explain`. The **plan engine** (spec→plan) is its structural peer:
+`devague/plan.py`, `plan_convergence.py`, `plan_store.py`, `render/plan_md.py`,
+and the nested group `devague plan <move>` (`new` / `task` / `accept` / `depend`
+/ `cover` / `confirm` / `reject` / `risk` / `converge` / `export` / `show` /
+`list` / `learn` / `explain`). The two operator skills are `/think` (idea→spec,
+renamed from `/devague`) and `/spec-to-plan` (spec→plan). Coverage ≥ 95 %; all
+linters pass. Run `git ls-files` to see the real surface.
 
 Real commands: `uv sync`; `uv run devague --version`; `python -m devague`;
 `uv run pytest -n auto` (single test: `uv run pytest tests/<file>::<node> -v`);
@@ -39,15 +44,44 @@ itself. The workflow:
 
 Full design: `docs/superpowers/specs/2026-05-23-devague-working-backwards-design.md`.
 
+## Spec→plan method (the forward leg)
+
+The **plan engine** is the structural peer of the frame engine — same chassis,
+same anti-fabrication rules, no LLM inside the CLI. It is namespaced under the
+`devague plan` subcommand group (the *skill* is `/spec-to-plan`; the CLI verb is
+`plan` — they intentionally differ, mirroring how `/think` drives the flat
+verbs). The workflow:
+
+1. `devague plan new --frame <slug>` — seed a plan from a **converged** frame.
+   Derives **coverage targets** (the frame's confirmed claims + honesty
+   conditions). Refuses an unconverged frame; refuses to clobber an existing plan.
+2. `devague plan task "<summary>" [--accept … --dep … --covers … --origin]` —
+   add tasks; `--origin llm` lands `proposed` (user must `confirm`). Refine with
+   `accept` / `depend` / `cover`.
+3. `devague plan risk "<text>" --kind <kind>` — park a genuine unknown as a
+   first-class plan risk instead of guessing.
+4. `devague plan converge` — re-evaluates the gate **against the live frame**
+   (catches frame drift); lists gaps. A plan converges when every target is
+   covered by a confirmed task, every confirmed task has acceptance criteria, the
+   dependency graph is acyclic, and no blocking risk remains.
+5. `devague plan export` — only after `converge` passes; writes a buildable
+   plan-md (topologically ordered) to `docs/plans/`.
+
+Full design: `docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md`.
+
 ## Project intent
 
 **devague** — an AgentCulture agent that turns a vague feature idea into a
-**buildable spec** by working backwards. The method: start from the
-announcement ("pretend it shipped — what would you announce?"), build an
-**Announcement Frame** by capturing and classifying claims, pressure-testing
-them with honesty conditions and hard questions, parking unresolved uncertainty
-as first-class "open vagueness," and only exporting a buildable spec once the
-frame *converges*.
+**buildable spec**, then that spec into a **buildable plan**, by working
+backwards then forwards. The spec method: start from the announcement ("pretend
+it shipped — what would you announce?"), build an **Announcement Frame** by
+capturing and classifying claims, pressure-testing them with honesty conditions
+and hard questions, parking unresolved uncertainty as first-class "open
+vagueness," and only exporting a buildable spec once the frame *converges*. The
+plan method: seed a plan from that converged frame and converge it on coverage,
+acceptance criteria, and an acyclic dependency order before exporting a plan.
+Two operator skills cover the two legs: **`/think`** (idea→spec) and
+**`/spec-to-plan`** (spec→plan); the product/CLI for both is **`devague`**.
 
 This is a **state machine over claims, honesty conditions, open vagueness, and
 convergence** driven by LLM-chosen moves — not a linear wizard. The CLI is
@@ -85,8 +119,12 @@ that unless the user asks otherwise. The established sibling shape is:
   `DevagueError` + exit-code policy) and `_output.py` (strict stdout/stderr
   split, `--json` support).
 - `devague/cli/_commands/` — one module per verb, each exposing `register()`.
-  Implemented verbs: `new`, `capture`, `interrogate`, `confirm`, `reject`,
-  `park`, `converge`, `export`, `show`, `list`, `learn`, `explain`.
+  Frame verbs: `new`, `capture`, `interrogate`, `confirm`, `reject`, `park`,
+  `converge`, `export`, `show`, `list`, `learn`, `explain`. The plan engine adds
+  one module, `_commands/plan.py`, registering the nested `plan` subcommand group.
+- Frame engine: `devague/frame.py`, `convergence.py`, `store.py`,
+  `render/{spec_md,frame_md}.py`. Plan engine (its peer): `devague/plan.py`,
+  `plan_convergence.py`, `plan_store.py`, `render/plan_md.py`, `cli/_plans.py`.
 - `pyproject.toml`, `CHANGELOG.md`, `tests/`, `docs/`, `culture.yaml`,
   `sonar-project.properties`, `uv.lock`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # devague
 
-An AgentCulture agent that turns a vague feature idea into a buildable spec by working backwards.
+**`devague` is a command-line tool** that turns a vague feature idea into a
+buildable **spec**, then that spec into a buildable **plan** — by working
+backwards, then forwards. It is a small, deterministic Python CLI (no LLM calls
+inside it, fully unit-tested) — not an agent, service, or daemon. You install it
+and run `devague` from the repository you are speccing; state is plain JSON under
+`.devague/`.
 
-Greenfield: the CLI scaffold (`devague learn` / `explain`) ships as honest
-"not yet implemented" stubs. See `CLAUDE.md` for project shape and commands.
+```text
+vague idea ──▶ buildable spec ──▶ buildable plan ──▶ build
+```
+
+## Install
+
+```bash
+uv tool install devague      # or: pipx install devague / pip install devague
+devague --version
+```
+
+## Two engines, one CLI
+
+- **Frame engine** (idea→spec) — start from the announcement ("pretend it
+  shipped"), capture and pressure-test claims, park open vagueness, and `export`
+  a spec only once the frame *converges*. Flat verbs: `devague new` /
+  `capture` / `interrogate` / `confirm` / `converge` / `export` / …
+- **Plan engine** (spec→plan) — seed a plan from a converged frame, cover every
+  target with tasks that carry acceptance criteria and an acyclic dependency
+  order, and `export` a plan only once it *converges*. Nested group:
+  `devague plan new` / `task` / `cover` / `converge` / `export` / …
+
+Run `devague learn` (or `devague plan learn`) to learn the method, and `devague
+explain <move>` for any single move.
+
+## Driving it from an agent
+
+Inside AgentCulture, an assistant drives this CLI through two operator skills —
+**`/think`** (idea→spec) and **`/spec-to-plan`** (spec→plan) — which add a
+portable wrapper and a `status` next-move helper over the convergence gate. The
+CLI is the deterministic affordance; the agent decides the next move. See
+`CLAUDE.md` for that workflow and `docs/superpowers/specs/` for the design docs.

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -64,6 +64,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import list_frames as _list_cmd
     from devague.cli._commands import new as _new_cmd
     from devague.cli._commands import park as _park_cmd
+    from devague.cli._commands import plan as _plan_cmd
     from devague.cli._commands import reject as _reject_cmd
     from devague.cli._commands import show as _show_cmd
 
@@ -77,6 +78,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _park_cmd.register(sub)
     _converge_cmd.register(sub)
     _export_cmd.register(sub)
+    _plan_cmd.register(sub)
     _show_cmd.register(sub)
     _list_cmd.register(sub)
 

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -28,6 +28,9 @@ from devague.render import plan_md
 
 PLANS_OUT_DIR = Path("docs/plans")
 
+_JSON_HELP = "Emit structured JSON."
+_TASK_ID_HELP = "Task id."
+
 PLAN_MOVES = {
     "new": "Start a plan from a converged frame (derives coverage targets).",
     "task": "Add a task; optionally --accept / --dep / --covers inline.",
@@ -275,13 +278,13 @@ def cmd_plan_show(args: argparse.Namespace) -> int:
     plan = resolve_plan(args.plan)
     if getattr(args, "json", False):
         emit_result(to_dict(plan), json_mode=True)
-        return 0
-    # Render needs the source frame for context, but degrade gracefully if it is gone.
-    try:
-        frame = store.load(plan.frame_slug)
-    except (FileNotFoundError, ValueError):
-        frame = None
-    emit_result(plan_md.render_plan(plan, frame), json_mode=False)
+    else:
+        # Render needs the source frame for context; degrade gracefully if it's gone.
+        try:
+            frame = store.load(plan.frame_slug)
+        except (FileNotFoundError, ValueError):
+            frame = None
+        emit_result(plan_md.render_plan(plan, frame), json_mode=False)
     return 0
 
 
@@ -342,7 +345,7 @@ def _cmd_plan_help(args: argparse.Namespace) -> int:
 # ── registration ─────────────────────────────────────────────────────────────
 def _plan_opt(p: argparse.ArgumentParser) -> None:
     p.add_argument("--plan", help="Plan slug (default: current).")
-    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.add_argument("--json", action="store_true", help=_JSON_HELP)
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -357,7 +360,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     pn = psub.add_parser("new", help="Start a plan from a converged frame.")
     pn.add_argument("--frame", help="Source frame slug (default: current).")
     pn.add_argument("--title", help="Plan title (defaults to the frame title).")
-    pn.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pn.add_argument("--json", action="store_true", help=_JSON_HELP)
     pn.set_defaults(func=cmd_plan_new)
 
     pt = psub.add_parser("task", help="Add a task.")
@@ -382,18 +385,18 @@ def register(sub: argparse._SubParsersAction) -> None:
     pd.set_defaults(func=cmd_plan_depend)
 
     pc = psub.add_parser("cover", help="Mark a task as covering a coverage target.")
-    pc.add_argument("id", help="Task id.")
+    pc.add_argument("id", help=_TASK_ID_HELP)
     pc.add_argument("--target", required=True, help="Coverage target id (c*/h*).")
     _plan_opt(pc)
     pc.set_defaults(func=cmd_plan_cover)
 
     pcf = psub.add_parser("confirm", help="Confirm a task (user-only).")
-    pcf.add_argument("id", help="Task id.")
+    pcf.add_argument("id", help=_TASK_ID_HELP)
     _plan_opt(pcf)
     pcf.set_defaults(func=cmd_plan_confirm)
 
     prj = psub.add_parser("reject", help="Reject a task.")
-    prj.add_argument("id", help="Task id.")
+    prj.add_argument("id", help=_TASK_ID_HELP)
     _plan_opt(prj)
     prj.set_defaults(func=cmd_plan_reject)
 
@@ -418,16 +421,16 @@ def register(sub: argparse._SubParsersAction) -> None:
     psh.set_defaults(func=cmd_plan_show)
 
     pls = psub.add_parser("list", help="List plans.")
-    pls.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pls.add_argument("--json", action="store_true", help=_JSON_HELP)
     pls.set_defaults(func=cmd_plan_list)
 
     pln = psub.add_parser("learn", help="Teach the spec-to-plan method.")
-    pln.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pln.add_argument("--json", action="store_true", help=_JSON_HELP)
     pln.set_defaults(func=cmd_plan_learn)
 
     pxp = psub.add_parser("explain", help="Explain one plan move.")
     pxp.add_argument("move", help="A plan move name.")
-    pxp.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pxp.add_argument("--json", action="store_true", help=_JSON_HELP)
     pxp.set_defaults(func=cmd_plan_explain)
 
     p.set_defaults(func=_cmd_plan_help, _plan_parser=p)

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -1,0 +1,433 @@
+"""``devague plan`` — the plan engine: turn a converged spec into a buildable plan.
+
+This is the structural peer of the frame moves, exposed as a nested subcommand group
+(``devague plan <move>``) so it never collides with the flat frame verbs. A plan is
+seeded from a *converged* frame; tasks must collectively cover every coverage target
+(the frame's confirmed claims + honesty conditions), carry acceptance criteria, and
+form an acyclic dependency graph before the plan converges and can export.
+
+The convergence gate is re-evaluated against the **live** source frame every time, so
+a frame that changed or regressed after the plan was seeded is caught (frame drift).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from devague import plan_store, store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
+from devague.cli._frames import resolve as resolve_frame
+from devague.cli._output import emit_result
+from devague.cli._plans import resolve_plan
+from devague.convergence import evaluate as evaluate_frame
+from devague.frame import Frame
+from devague.plan import RISK_KINDS, Plan, targets_from_frame, to_dict
+from devague.plan_convergence import evaluate as evaluate_plan
+from devague.render import plan_md
+
+PLANS_OUT_DIR = Path("docs/plans")
+
+PLAN_MOVES = {
+    "new": "Start a plan from a converged frame (derives coverage targets).",
+    "task": "Add a task; optionally --accept / --dep / --covers inline.",
+    "accept": "Add an acceptance criterion to a task.",
+    "depend": "Record that a task depends on another (--on).",
+    "cover": "Mark a task as covering a coverage target (c*/h*).",
+    "confirm": "Confirm a task (user-only — no fabricated rigor).",
+    "reject": "Reject a task.",
+    "risk": "Record a first-class plan risk instead of papering over it.",
+    "converge": "Check whether the plan can export, against the live frame.",
+    "export": "Write the buildable plan — only once the plan converges.",
+    "show": "Render the plan.",
+    "list": "List plans.",
+}
+
+
+# ── shared helpers ──────────────────────────────────────────────────────────
+def _load_source_frame(slug: str) -> Frame:
+    try:
+        return store.load(slug)
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"invalid source frame slug: {slug!r}",
+            "the plan's frame_slug is corrupt",
+        ) from exc
+    except FileNotFoundError:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"source frame '{slug}' no longer exists",
+            "the plan was built from a frame that has since been deleted",
+        ) from None
+
+
+def _live(plan: Plan):
+    """Re-load the source frame and re-derive targets; guard against frame drift."""
+    frame = _load_source_frame(plan.frame_slug)
+    fres = evaluate_frame(frame)
+    if not fres.passed:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"source frame '{frame.slug}' has regressed below convergence",
+            f"re-converge the frame first: devague converge --frame {frame.slug}",
+        )
+    return frame, targets_from_frame(frame)
+
+
+def _require_task(plan: Plan, tid: str):
+    task = plan.find_task(tid)
+    if task is None:
+        raise DevagueError(EXIT_USER_ERROR, f"no such task: {tid}", "run 'devague plan show'")
+    return task
+
+
+def _require_target(plan: Plan, target_id: str) -> None:
+    if plan.find_target(target_id) is None:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"unknown coverage target: {target_id}",
+            "run 'devague plan show' to see targets (c*/h*)",
+        )
+
+
+# ── moves ───────────────────────────────────────────────────────────────────
+def cmd_plan_new(args: argparse.Namespace) -> int:
+    frame = resolve_frame(args.frame)
+    result = evaluate_frame(frame)
+    if not result.passed:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"frame '{frame.slug}' has not converged; cannot start a plan",
+            "resolve: " + "; ".join(result.missing),
+        )
+    if plan_store.path_for(frame.slug).exists():
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"a plan for frame '{frame.slug}' already exists",
+            f"inspect it: devague plan show --plan {frame.slug}",
+        )
+    plan = Plan(
+        slug=frame.slug,
+        title=args.title or frame.title,
+        frame_slug=frame.slug,
+        targets=targets_from_frame(frame),
+    )
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result(
+            {"slug": plan.slug, "frame": plan.frame_slug, "targets": len(plan.targets)},
+            json_mode=True,
+        )
+    else:
+        emit_result(
+            f"created plan '{plan.slug}' from frame '{frame.slug}' "
+            f"({len(plan.targets)} coverage target(s))",
+            json_mode=False,
+        )
+    return 0
+
+
+def cmd_plan_task(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    for tid in args.covers or []:
+        _require_target(plan, tid)
+    task = plan.add_task(args.summary, origin=args.origin)
+    for crit in args.accept or []:
+        plan.add_acceptance(task, crit)
+    for dep in args.dep or []:
+        plan.add_dep(task, dep)
+    for tid in args.covers or []:
+        plan.add_cover(task, tid)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result(
+            {
+                "id": task.id,
+                "status": task.status,
+                "acceptance": len(task.acceptance_criteria),
+                "deps": task.deps,
+                "covers": task.covers,
+            },
+            json_mode=True,
+        )
+    else:
+        emit_result(f"added {task.id} ({task.status})", json_mode=False)
+    return 0
+
+
+def cmd_plan_accept(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    task = _require_task(plan, args.id)
+    plan.add_acceptance(task, args.text)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"id": task.id, "acceptance": len(task.acceptance_criteria)}, json_mode=True)
+    else:
+        emit_result(f"{task.id}: +acceptance criterion", json_mode=False)
+    return 0
+
+
+def cmd_plan_depend(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    task = _require_task(plan, args.id)
+    plan.add_dep(task, args.on)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"id": task.id, "deps": task.deps}, json_mode=True)
+    else:
+        emit_result(f"{task.id} depends on {args.on}", json_mode=False)
+    return 0
+
+
+def cmd_plan_cover(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    task = _require_task(plan, args.id)
+    _require_target(plan, args.target)
+    plan.add_cover(task, args.target)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"id": task.id, "covers": task.covers}, json_mode=True)
+    else:
+        emit_result(f"{task.id} covers {args.target}", json_mode=False)
+    return 0
+
+
+def _transition(args: argparse.Namespace, status: str) -> int:
+    plan = resolve_plan(args.plan)
+    if not plan.set_status(args.id, status):
+        raise DevagueError(EXIT_USER_ERROR, f"no such task: {args.id}", "run 'devague plan show'")
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"id": args.id, "status": status}, json_mode=True)
+    else:
+        emit_result(f"{args.id} -> {status}", json_mode=False)
+    return 0
+
+
+def cmd_plan_confirm(args: argparse.Namespace) -> int:
+    return _transition(args, "confirmed")
+
+
+def cmd_plan_reject(args: argparse.Namespace) -> int:
+    return _transition(args, "rejected")
+
+
+def cmd_plan_risk(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    if args.task is not None:
+        _require_task(plan, args.task)
+    risk = plan.add_risk(args.text, args.kind, task_id=args.task)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"id": risk.id, "kind": risk.kind, "task": risk.task_id}, json_mode=True)
+    else:
+        emit_result(f"recorded risk {risk.id} ({risk.kind})", json_mode=False)
+    return 0
+
+
+def cmd_plan_converge(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    _frame, targets = _live(plan)
+    plan.targets = targets  # refresh the snapshot from the live frame
+    result = evaluate_plan(plan, targets=targets)
+    if result.passed and plan.status == "drafting":
+        plan.status = "converged"
+    elif not result.passed and plan.status == "converged":
+        plan.status = "drafting"
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"passed": result.passed, "missing": result.missing}, json_mode=True)
+    elif result.passed:
+        emit_result("converged ✓", json_mode=False)
+    else:
+        emit_result(
+            "not converged:\n" + "\n".join(f"  - {m}" for m in result.missing), json_mode=False
+        )
+    return 0
+
+
+def cmd_plan_export(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    frame, targets = _live(plan)
+    plan.targets = targets
+    result = evaluate_plan(plan, targets=targets)
+    if not result.passed:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "plan has not converged; cannot export",
+            "resolve: " + "; ".join(result.missing),
+        )
+    plan.status = "exported"
+    text = plan_md.render_plan(plan, frame)
+    PLANS_OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = PLANS_OUT_DIR / f"{plan.slug}.md"
+    out_path.write_text(text, encoding="utf-8")
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result({"path": str(out_path), "format": args.format}, json_mode=True)
+    else:
+        emit_result(f"exported plan to {out_path}", json_mode=False)
+    return 0
+
+
+def cmd_plan_show(args: argparse.Namespace) -> int:
+    plan = resolve_plan(args.plan)
+    if getattr(args, "json", False):
+        emit_result(to_dict(plan), json_mode=True)
+        return 0
+    # Render needs the source frame for context, but degrade gracefully if it is gone.
+    try:
+        frame = store.load(plan.frame_slug)
+    except (FileNotFoundError, ValueError):
+        frame = None
+    emit_result(plan_md.render_plan(plan, frame), json_mode=False)
+    return 0
+
+
+def cmd_plan_list(args: argparse.Namespace) -> int:
+    slugs = plan_store.list_slugs()
+    current = plan_store.current_slug()
+    if getattr(args, "json", False):
+        emit_result({"plans": slugs, "current": current}, json_mode=True)
+    elif not slugs:
+        emit_result("no plans yet", json_mode=False)
+    else:
+        emit_result("\n".join(("* " if s == current else "  ") + s for s in slugs), json_mode=False)
+    return 0
+
+
+def cmd_plan_learn(args: argparse.Namespace) -> int:
+    text = (
+        "devague plan turns a converged spec into a buildable plan — the forward leg\n"
+        "after working backwards into a spec. Seed a plan from a converged frame, then\n"
+        "add tasks that collectively cover every coverage target (the frame's confirmed\n"
+        "claims and honesty conditions). Each task earns acceptance criteria and an\n"
+        "honest dependency order; genuine unknowns are parked as first-class risks.\n\n"
+        "LLM-proposed tasks stay 'proposed' until the user confirms them — same\n"
+        "anti-fabrication rule as claims. A plan exports only once it converges:\n"
+        "every target covered by a confirmed task, every confirmed task has acceptance\n"
+        "criteria, the dependency graph is acyclic, and no blocking risk remains.\n\n"
+        "Moves:\n" + "\n".join(f"  {name:<9} {desc}" for name, desc in PLAN_MOVES.items())
+    )
+    if getattr(args, "json", False):
+        emit_result(
+            {"tool": "devague plan", "moves": list(PLAN_MOVES), "summary": text}, json_mode=True
+        )
+    else:
+        emit_result(text, json_mode=False)
+    return 0
+
+
+def cmd_plan_explain(args: argparse.Namespace) -> int:
+    desc = PLAN_MOVES.get(args.move)
+    if desc is None:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"unknown plan move: {args.move}",
+            "moves: " + ", ".join(PLAN_MOVES),
+        )
+    if getattr(args, "json", False):
+        emit_result({"move": args.move, "description": desc}, json_mode=True)
+    else:
+        emit_result(f"{args.move}: {desc}", json_mode=False)
+    return 0
+
+
+def _cmd_plan_help(args: argparse.Namespace) -> int:
+    args._plan_parser.print_help()
+    return 0
+
+
+# ── registration ─────────────────────────────────────────────────────────────
+def _plan_opt(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--plan", help="Plan slug (default: current).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    # Lazy import keeps the chassis' deferred-import discipline (avoids a cycle).
+    from devague.cli import _DevagueArgumentParser
+
+    p = sub.add_parser(
+        "plan", help="Turn a converged spec into a buildable plan (the plan engine)."
+    )
+    psub = p.add_subparsers(dest="plan_command", parser_class=_DevagueArgumentParser)
+
+    pn = psub.add_parser("new", help="Start a plan from a converged frame.")
+    pn.add_argument("--frame", help="Source frame slug (default: current).")
+    pn.add_argument("--title", help="Plan title (defaults to the frame title).")
+    pn.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pn.set_defaults(func=cmd_plan_new)
+
+    pt = psub.add_parser("task", help="Add a task.")
+    pt.add_argument("summary", help="What the task delivers.")
+    pt.add_argument("--accept", action="append", help="An acceptance criterion (repeatable).")
+    pt.add_argument("--dep", action="append", help="A task id this depends on (repeatable).")
+    pt.add_argument("--covers", action="append", help="A coverage target id c*/h* (repeatable).")
+    pt.add_argument("--origin", choices=("user", "llm"), default="user", help="Who proposed it.")
+    _plan_opt(pt)
+    pt.set_defaults(func=cmd_plan_task)
+
+    pa = psub.add_parser("accept", help="Add an acceptance criterion to a task.")
+    pa.add_argument("id", help="Task id (e.g. t1).")
+    pa.add_argument("text", help="The acceptance criterion.")
+    _plan_opt(pa)
+    pa.set_defaults(func=cmd_plan_accept)
+
+    pd = psub.add_parser("depend", help="Record that a task depends on another.")
+    pd.add_argument("id", help="The dependent task id.")
+    pd.add_argument("--on", required=True, help="The task id it depends on.")
+    _plan_opt(pd)
+    pd.set_defaults(func=cmd_plan_depend)
+
+    pc = psub.add_parser("cover", help="Mark a task as covering a coverage target.")
+    pc.add_argument("id", help="Task id.")
+    pc.add_argument("--target", required=True, help="Coverage target id (c*/h*).")
+    _plan_opt(pc)
+    pc.set_defaults(func=cmd_plan_cover)
+
+    pcf = psub.add_parser("confirm", help="Confirm a task (user-only).")
+    pcf.add_argument("id", help="Task id.")
+    _plan_opt(pcf)
+    pcf.set_defaults(func=cmd_plan_confirm)
+
+    prj = psub.add_parser("reject", help="Reject a task.")
+    prj.add_argument("id", help="Task id.")
+    _plan_opt(prj)
+    prj.set_defaults(func=cmd_plan_reject)
+
+    prk = psub.add_parser("risk", help="Record a first-class plan risk.")
+    prk.add_argument("text", help="The risk.")
+    prk.add_argument("--kind", required=True, choices=RISK_KINDS, help="Risk kind.")
+    prk.add_argument("--task", help="Task id this risk attaches to (optional).")
+    _plan_opt(prk)
+    prk.set_defaults(func=cmd_plan_risk)
+
+    pcv = psub.add_parser("converge", help="Check whether the plan can export.")
+    _plan_opt(pcv)
+    pcv.set_defaults(func=cmd_plan_converge)
+
+    pex = psub.add_parser("export", help="Export the buildable plan (requires convergence).")
+    pex.add_argument("--format", default="plan-md", choices=("plan-md",), help="Renderer format.")
+    _plan_opt(pex)
+    pex.set_defaults(func=cmd_plan_export)
+
+    psh = psub.add_parser("show", help="Render the plan.")
+    _plan_opt(psh)
+    psh.set_defaults(func=cmd_plan_show)
+
+    pls = psub.add_parser("list", help="List plans.")
+    pls.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pls.set_defaults(func=cmd_plan_list)
+
+    pln = psub.add_parser("learn", help="Teach the spec-to-plan method.")
+    pln.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pln.set_defaults(func=cmd_plan_learn)
+
+    pxp = psub.add_parser("explain", help="Explain one plan move.")
+    pxp.add_argument("move", help="A plan move name.")
+    pxp.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    pxp.set_defaults(func=cmd_plan_explain)
+
+    p.set_defaults(func=_cmd_plan_help, _plan_parser=p)

--- a/devague/cli/_plans.py
+++ b/devague/cli/_plans.py
@@ -1,0 +1,29 @@
+"""Resolve the target plan for a move: explicit --plan, else the current plan."""
+
+from __future__ import annotations
+
+from devague import plan_store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
+from devague.plan import Plan
+
+
+def resolve_plan(slug: str | None) -> Plan:
+    slug = slug or plan_store.current_slug()
+    if not slug:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "no plan selected",
+            "run 'devague plan new --frame <slug>' or pass --plan <slug>",
+        )
+    try:
+        return plan_store.load(slug)
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"invalid plan slug: {slug!r}",
+            "slugs are lowercase letters, digits, and hyphens — no path separators",
+        ) from exc
+    except FileNotFoundError:
+        raise DevagueError(
+            EXIT_USER_ERROR, f"no such plan: {slug}", "run 'devague plan list' to see plans"
+        ) from None

--- a/devague/plan.py
+++ b/devague/plan.py
@@ -1,0 +1,179 @@
+"""The Plan domain model — tasks, acceptance criteria, dependencies, risks.
+
+The *plan engine* is the structural peer of the *frame engine* (:mod:`devague.frame`):
+where a Frame turns a vague idea into a buildable spec, a Plan turns that converged
+spec into a buildable plan. Pure data + transitions, no I/O — persistence lives in
+:mod:`devague.plan_store`, the convergence gate in :mod:`devague.plan_convergence`.
+
+A Plan is seeded from a converged Frame: :func:`targets_from_frame` derives the
+**coverage targets** (the frame's confirmed spec-affecting claims and confirmed
+honesty conditions) that every task collectively must cover before the plan converges.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Optional
+
+from devague.frame import SPEC_AFFECTING_KINDS, VAGUENESS_KINDS, Frame
+
+TASK_STATUSES = ("proposed", "confirmed", "rejected")
+# Risks reuse the frame's open-vagueness kinds: a plan risk is the task-level peer of
+# a frame's open vagueness. (NB: frame `interrogate --risk` records a non-blocking
+# hard question on a *claim*; a PlanRisk is first-class and attaches to a *task*.)
+RISK_KINDS = VAGUENESS_KINDS
+
+
+@dataclass
+class Task:
+    id: str
+    summary: str
+    origin: str = "user"  # user | llm
+    status: str = "confirmed"  # proposed | confirmed | rejected
+    acceptance_criteria: list[str] = field(default_factory=list)
+    deps: list[str] = field(default_factory=list)  # task ids this task depends on
+    covers: list[str] = field(default_factory=list)  # frame claim/honesty ids (c*/h*)
+
+
+@dataclass
+class PlanRisk:
+    id: str
+    text: str
+    kind: str  # one of RISK_KINDS
+    task_id: Optional[str] = None
+
+
+@dataclass
+class CoverageTarget:
+    """A requirement the plan must cover, derived from a confirmed frame element.
+
+    ``id`` mirrors the frame id verbatim (``c3``, ``h2``) so a task's ``covers``
+    refs stay stable against the source frame.
+    """
+
+    id: str
+    kind: str  # a claim kind, or "honesty" for an honesty condition
+    text: str
+
+
+@dataclass
+class Plan:
+    slug: str
+    title: str
+    frame_slug: str
+    status: str = "drafting"  # drafting | converged | exported
+    created: str = ""
+    updated: str = ""
+    targets: list[CoverageTarget] = field(default_factory=list)
+    tasks: list[Task] = field(default_factory=list)
+    risks: list[PlanRisk] = field(default_factory=list)
+
+    @staticmethod
+    def _next(items: list, prefix: str) -> str:
+        n = 0
+        for it in items:
+            if it.id.startswith(prefix):
+                try:
+                    n = max(n, int(it.id[len(prefix) :]))
+                except ValueError:
+                    pass
+        return f"{prefix}{n + 1}"
+
+    def add_task(self, summary: str, origin: str = "user") -> Task:
+        status = "proposed" if origin == "llm" else "confirmed"
+        task = Task(
+            id=self._next(self.tasks, "t"),
+            summary=summary,
+            origin=origin,
+            status=status,
+        )
+        self.tasks.append(task)
+        return task
+
+    def find_task(self, tid: str) -> Optional[Task]:
+        return next((t for t in self.tasks if t.id == tid), None)
+
+    def add_acceptance(self, task: Task, text: str) -> None:
+        task.acceptance_criteria.append(text)
+
+    def add_dep(self, task: Task, dep_id: str) -> None:
+        if dep_id not in task.deps:
+            task.deps.append(dep_id)
+
+    def add_cover(self, task: Task, target_id: str) -> None:
+        if target_id not in task.covers:
+            task.covers.append(target_id)
+
+    def add_risk(self, text: str, kind: str, task_id: Optional[str] = None) -> PlanRisk:
+        if kind not in RISK_KINDS:
+            raise ValueError(f"unknown risk kind: {kind}")
+        r = PlanRisk(
+            id=self._next(self.risks, "r"),
+            text=text,
+            kind=kind,
+            task_id=task_id,
+        )
+        self.risks.append(r)
+        return r
+
+    def find_target(self, target_id: str) -> Optional[CoverageTarget]:
+        return next((tg for tg in self.targets if tg.id == target_id), None)
+
+    def set_status(self, task_id: str, status: str) -> bool:
+        task = self.find_task(task_id)
+        if task is not None:
+            task.status = status
+            return True
+        return False
+
+
+def targets_from_frame(frame: Frame) -> list[CoverageTarget]:
+    """Derive the coverage targets a plan must satisfy from a converged frame.
+
+    Targets are the frame's confirmed spec-affecting claims plus the confirmed
+    honesty conditions hanging off them — exactly the elements the spec asserts and
+    therefore the plan must build toward. Proposed/rejected claims and
+    ``open_question`` claims are excluded.
+    """
+    targets: list[CoverageTarget] = []
+    for claim in frame.claims:
+        if claim.status != "confirmed" or claim.kind not in SPEC_AFFECTING_KINDS:
+            continue
+        targets.append(CoverageTarget(id=claim.id, kind=claim.kind, text=claim.text))
+        for h in claim.honesty_conditions:
+            if h.status == "confirmed":
+                targets.append(CoverageTarget(id=h.id, kind="honesty", text=h.text))
+    return targets
+
+
+def to_dict(plan: Plan) -> dict:
+    return dataclasses.asdict(plan)
+
+
+def from_dict(d: dict) -> Plan:
+    tasks = [
+        Task(
+            id=t["id"],
+            summary=t["summary"],
+            origin=t.get("origin", "user"),
+            status=t.get("status", "confirmed"),
+            acceptance_criteria=list(t.get("acceptance_criteria", [])),
+            deps=list(t.get("deps", [])),
+            covers=list(t.get("covers", [])),
+        )
+        for t in d.get("tasks", [])
+    ]
+    targets = [CoverageTarget(**tg) for tg in d.get("targets", [])]
+    risks = [PlanRisk(**r) for r in d.get("risks", [])]
+    return Plan(
+        slug=d["slug"],
+        title=d["title"],
+        frame_slug=d["frame_slug"],
+        status=d.get("status", "drafting"),
+        created=d.get("created", ""),
+        updated=d.get("updated", ""),
+        targets=targets,
+        tasks=tasks,
+        risks=risks,
+    )

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -46,40 +46,51 @@ def _missing_resolution(plan: Plan) -> list[str]:
     ]
 
 
+_WHITE, _GRAY, _BLACK = 0, 1, 2
+
+
+def _walk_from(root: str, deps: dict[str, list[str]], color: dict[str, int]) -> Optional[list[str]]:
+    """DFS from ``root``; return the first back-edge cycle path, else None.
+
+    Iterative, with the stack holding ``[node, next-dep-index]`` and ``path`` the
+    current gray chain. Deps are visited in stored order, so the reported path is
+    deterministic.
+    """
+    stack: list[list] = [[root, 0]]
+    color[root] = _GRAY
+    path = [root]
+    while stack:
+        node, i = stack[-1]
+        if i >= len(deps[node]):
+            color[node] = _BLACK
+            stack.pop()
+            path.pop()
+            continue
+        stack[-1][1] += 1
+        nxt = deps[node][i]
+        if color[nxt] == _GRAY:
+            return path[path.index(nxt) :] + [nxt]
+        if color[nxt] == _WHITE:
+            color[nxt] = _GRAY
+            stack.append([nxt, 0])
+            path.append(nxt)
+    return None
+
+
 def _find_cycle(plan: Plan) -> Optional[list[str]]:
     """Return the first dependency cycle (as an id path) in stored order, else None.
 
-    Iterative DFS with white/gray/black colouring; tasks and their deps are visited in
-    stored order so the reported path is deterministic. Only deps that reference a real
-    task are followed (dangling deps are reported separately).
+    White/gray/black DFS over the dep graph. Only deps that reference a real task are
+    followed (dangling deps are reported separately).
     """
     ids = {t.id for t in plan.tasks}
     deps = {t.id: [d for d in t.deps if d in ids] for t in plan.tasks}
-    WHITE, GRAY, BLACK = 0, 1, 2
-    color = {t.id: WHITE for t in plan.tasks}
-
+    color = {t.id: _WHITE for t in plan.tasks}
     for root in (t.id for t in plan.tasks):
-        if color[root] != WHITE:
-            continue
-        # stack holds (node, index-into-its-deps); `path` is the current gray chain.
-        stack: list[list] = [[root, 0]]
-        color[root] = GRAY
-        path = [root]
-        while stack:
-            node, i = stack[-1]
-            if i < len(deps[node]):
-                stack[-1][1] += 1
-                nxt = deps[node][i]
-                if color[nxt] == GRAY:
-                    return path[path.index(nxt) :] + [nxt]
-                if color[nxt] == WHITE:
-                    color[nxt] = GRAY
-                    stack.append([nxt, 0])
-                    path.append(nxt)
-            else:
-                color[node] = BLACK
-                stack.pop()
-                path.pop()
+        if color[root] == _WHITE:
+            cycle = _walk_from(root, deps, color)
+            if cycle:
+                return cycle
     return None
 
 

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Optional
 
 from devague.convergence import ConvergenceResult
-from devague.plan import CoverageTarget, Plan
+from devague.plan import CoverageTarget, Plan, Task
 
 
 def _missing_tasks(plan: Plan) -> list[str]:
@@ -77,16 +77,17 @@ def _walk_from(root: str, deps: dict[str, list[str]], color: dict[str, int]) -> 
     return None
 
 
-def _find_cycle(plan: Plan) -> Optional[list[str]]:
+def _find_cycle(tasks: list[Task]) -> Optional[list[str]]:
     """Return the first dependency cycle (as an id path) in stored order, else None.
 
-    White/gray/black DFS over the dep graph. Only deps that reference a real task are
-    followed (dangling deps are reported separately).
+    White/gray/black DFS over ``tasks``. Only deps that reference a task *in this set*
+    are followed; deps pointing outside it (unknown or rejected) are reported
+    separately by :func:`_missing_dep_integrity`.
     """
-    ids = {t.id for t in plan.tasks}
-    deps = {t.id: [d for d in t.deps if d in ids] for t in plan.tasks}
-    color = {t.id: _WHITE for t in plan.tasks}
-    for root in (t.id for t in plan.tasks):
+    ids = {t.id for t in tasks}
+    deps = {t.id: [d for d in t.deps if d in ids] for t in tasks}
+    color = {t.id: _WHITE for t in tasks}
+    for root in (t.id for t in tasks):
         if color[root] == _WHITE:
             cycle = _walk_from(root, deps, color)
             if cycle:
@@ -95,14 +96,24 @@ def _find_cycle(plan: Plan) -> Optional[list[str]]:
 
 
 def _missing_dep_integrity(plan: Plan) -> list[str]:
-    ids = {t.id for t in plan.tasks}
-    missing = [
-        f"task {t.id} depends on unknown task {d}"
-        for t in plan.tasks
-        for d in t.deps
-        if d not in ids
-    ]
-    cycle = _find_cycle(plan)
+    """Dependency integrity over *active* (non-rejected) tasks.
+
+    Rejected tasks are omitted from the exported plan, so a dependency on one would
+    render a ``depends on:`` line whose target never appears — that is an integrity
+    failure, distinct from a dangling dep on a task that does not exist at all. Cycles
+    and dangling deps that live only among rejected tasks do not block convergence.
+    """
+    active = [t for t in plan.tasks if t.status != "rejected"]
+    active_ids = {t.id for t in active}
+    all_ids = {t.id for t in plan.tasks}
+    missing: list[str] = []
+    for t in active:
+        for d in t.deps:
+            if d not in all_ids:
+                missing.append(f"task {t.id} depends on unknown task {d}")
+            elif d not in active_ids:
+                missing.append(f"task {t.id} depends on rejected task {d}")
+    cycle = _find_cycle(active)
     if cycle:
         missing.append("dependency cycle: " + " -> ".join(cycle))
     return missing

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -1,0 +1,120 @@
+"""The plan convergence gate: is a plan solid enough to export a buildable plan?
+
+The peer of :mod:`devague.convergence`. A plan converges when every coverage target
+is covered by a confirmed task, every confirmed task carries acceptance criteria, the
+dependency graph is sound (no dangling refs, no cycles), nothing is left proposed, and
+no blocking risk remains. Reuses :class:`devague.convergence.ConvergenceResult` so both
+engines report the same ``{passed, missing}`` shape.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from devague.convergence import ConvergenceResult
+from devague.plan import CoverageTarget, Plan
+
+
+def _missing_tasks(plan: Plan) -> list[str]:
+    if not plan.tasks:
+        return ["no tasks yet (add at least one with 'plan task')"]
+    return []
+
+
+def _missing_coverage(plan: Plan, targets: list[CoverageTarget]) -> list[str]:
+    covered = {tid for t in plan.tasks if t.status == "confirmed" for tid in t.covers}
+    return [
+        f"coverage target {tg.id} ({tg.kind}) has no confirmed task"
+        for tg in targets
+        if tg.id not in covered
+    ]
+
+
+def _missing_acceptance(plan: Plan) -> list[str]:
+    return [
+        f"task {t.id} has no acceptance criteria"
+        for t in plan.tasks
+        if t.status == "confirmed" and not t.acceptance_criteria
+    ]
+
+
+def _missing_resolution(plan: Plan) -> list[str]:
+    return [
+        f"task {t.id} still proposed (confirm or reject it)"
+        for t in plan.tasks
+        if t.status == "proposed"
+    ]
+
+
+def _find_cycle(plan: Plan) -> Optional[list[str]]:
+    """Return the first dependency cycle (as an id path) in stored order, else None.
+
+    Iterative DFS with white/gray/black colouring; tasks and their deps are visited in
+    stored order so the reported path is deterministic. Only deps that reference a real
+    task are followed (dangling deps are reported separately).
+    """
+    ids = {t.id for t in plan.tasks}
+    deps = {t.id: [d for d in t.deps if d in ids] for t in plan.tasks}
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {t.id: WHITE for t in plan.tasks}
+
+    for root in (t.id for t in plan.tasks):
+        if color[root] != WHITE:
+            continue
+        # stack holds (node, index-into-its-deps); `path` is the current gray chain.
+        stack: list[list] = [[root, 0]]
+        color[root] = GRAY
+        path = [root]
+        while stack:
+            node, i = stack[-1]
+            if i < len(deps[node]):
+                stack[-1][1] += 1
+                nxt = deps[node][i]
+                if color[nxt] == GRAY:
+                    return path[path.index(nxt) :] + [nxt]
+                if color[nxt] == WHITE:
+                    color[nxt] = GRAY
+                    stack.append([nxt, 0])
+                    path.append(nxt)
+            else:
+                color[node] = BLACK
+                stack.pop()
+                path.pop()
+    return None
+
+
+def _missing_dep_integrity(plan: Plan) -> list[str]:
+    ids = {t.id for t in plan.tasks}
+    missing = [
+        f"task {t.id} depends on unknown task {d}"
+        for t in plan.tasks
+        for d in t.deps
+        if d not in ids
+    ]
+    cycle = _find_cycle(plan)
+    if cycle:
+        missing.append("dependency cycle: " + " -> ".join(cycle))
+    return missing
+
+
+def _missing_risks(plan: Plan) -> list[str]:
+    return [f"blocking risk {r.id} unresolved" for r in plan.risks if r.kind == "unknown_blocking"]
+
+
+def evaluate(plan: Plan, targets: Optional[list[CoverageTarget]] = None) -> ConvergenceResult:
+    """Evaluate the plan gate against ``targets`` (defaults to the plan's snapshot).
+
+    The CLI passes *live* targets re-derived from the current source frame so frame
+    drift is caught; unit tests may omit ``targets`` to gate against the stored
+    snapshot.
+    """
+    tgs = plan.targets if targets is None else targets
+    missing = (
+        _missing_tasks(plan)
+        + _missing_coverage(plan, tgs)
+        + _missing_acceptance(plan)
+        + _missing_resolution(plan)
+        + _missing_dep_integrity(plan)
+        + _missing_risks(plan)
+    )
+    return ConvergenceResult(passed=not missing, missing=missing)

--- a/devague/plan_store.py
+++ b/devague/plan_store.py
@@ -1,0 +1,60 @@
+"""Plan persistence: JSON under .devague/plans/, plus a current-plan pointer.
+
+The peer of :mod:`devague.store`. Paths are cwd-relative so plans live in the repo
+being specced, alongside the frames they derive from. A plan's slug is its source
+frame's slug verbatim (1:1 link); plans and frames live in separate directories, so
+the shared slug never collides.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from devague.plan import Plan, from_dict, to_dict
+from devague.store import validate_slug
+
+PLANS_DIR = Path(".devague/plans")
+CURRENT_PLAN = Path(".devague/current_plan")
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def path_for(slug: str) -> Path:
+    return PLANS_DIR / f"{validate_slug(slug)}.json"
+
+
+def save(plan: Plan) -> Path:
+    PLANS_DIR.mkdir(parents=True, exist_ok=True)
+    plan.updated = _now()
+    if not plan.created:
+        plan.created = plan.updated
+    p = path_for(plan.slug)
+    p.write_text(json.dumps(to_dict(plan), indent=2) + "\n", encoding="utf-8")
+    CURRENT_PLAN.write_text(plan.slug + "\n", encoding="utf-8")
+    return p
+
+
+def load(slug: str) -> Plan:
+    p = path_for(slug)
+    if not p.exists():
+        raise FileNotFoundError(slug)
+    plan = from_dict(json.loads(p.read_text(encoding="utf-8")))
+    validate_slug(plan.slug)  # reject a tampered file whose internal slug escapes
+    validate_slug(plan.frame_slug)  # the linked frame slug must be safe to load too
+    return plan
+
+
+def list_slugs() -> list[str]:
+    if not PLANS_DIR.exists():
+        return []
+    return sorted(p.stem for p in PLANS_DIR.glob("*.json"))
+
+
+def current_slug() -> str | None:
+    if CURRENT_PLAN.exists():
+        return CURRENT_PLAN.read_text(encoding="utf-8").strip() or None
+    return None

--- a/devague/render/plan_md.py
+++ b/devague/render/plan_md.py
@@ -1,0 +1,91 @@
+"""Renderer: the buildable plan as markdown, derived from a converged plan + frame.
+
+Unlike the frame renderers this is **not** registered in :mod:`devague.render` — that
+registry is ``Callable[[Frame], str]`` and a plan render needs both the plan and its
+source frame for context. The ``devague plan export`` command calls :func:`render_plan`
+directly, so ``render.formats()`` deliberately does not list ``plan-md``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from devague.frame import Frame
+from devague.plan import Plan, Task
+
+
+def _topo_order(tasks: list[Task]) -> list[Task]:
+    """Order tasks so each task's deps precede it; stable in stored order.
+
+    Independent tasks keep their stored order. Unknown deps are ignored (reported as
+    gaps by the gate). On a cycle the remaining tasks are appended in stored order so
+    rendering never fails — the gate is what blocks export, not the renderer.
+    """
+    by_id = {t.id: t for t in tasks}
+    emitted_ids: set[str] = set()
+    ordered: list[Task] = []
+    remaining = list(tasks)
+    progress = True
+    while remaining and progress:
+        progress = False
+        still: list[Task] = []
+        for t in remaining:
+            if all(d in emitted_ids or d not in by_id for d in t.deps):
+                ordered.append(t)
+                emitted_ids.add(t.id)
+                progress = True
+            else:
+                still.append(t)
+        remaining = still
+    ordered.extend(remaining)  # cycle leftover, stored order
+    return ordered
+
+
+def _announcement(frame: Optional[Frame]) -> Optional[str]:
+    if frame is None:
+        return None
+    for c in frame.claims:
+        if c.kind == "announcement" and c.status == "confirmed":
+            return c.text
+    return None
+
+
+def _task_lines(task: Task) -> list[str]:
+    mark = "" if task.status == "confirmed" else f" _({task.status})_"
+    lines = [f"### {task.id} — {task.summary}{mark}"]
+    if task.deps:
+        lines.append(f"- depends on: {', '.join(task.deps)}")
+    if task.covers:
+        lines.append(f"- covers: {', '.join(task.covers)}")
+    if task.acceptance_criteria:
+        lines.append("- acceptance:")
+        lines.extend(f"  - {a}" for a in task.acceptance_criteria)
+    lines.append("")
+    return lines
+
+
+def render_plan(plan: Plan, frame: Optional[Frame]) -> str:
+    out = [
+        f"# Build Plan — {plan.title}",
+        "",
+        f"_slug: {plan.slug} · status: {plan.status} · from frame: {plan.frame_slug}_",
+        "",
+    ]
+    ann = _announcement(frame)
+    if ann:
+        out += ["> " + ann, ""]
+
+    tasks = [t for t in plan.tasks if t.status != "rejected"]
+    if tasks:
+        out += ["## Tasks", ""]
+        for t in _topo_order(tasks):
+            out.extend(_task_lines(t))
+
+    if plan.risks:
+        out += ["## Risks"]
+        for r in plan.risks:
+            suffix = f" (task {r.task_id})" if r.task_id else ""
+            out.append(f"- [{r.kind}] {r.text}{suffix}")
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -27,14 +27,22 @@ rows.
 
 ## Origin skills (outbound)
 
-Not every skill here is inbound. The `devague` skill is **authored and
-maintained in this repo** — devague is its origin/upstream, not a downstream
-consumer. The devague agent dogfoods it to operate the devague CLI while
-improving the tool. The flow runs the *opposite* direction of the table above.
+Not every skill here is inbound. The `think` and `spec-to-plan` skills are
+**authored and maintained in this repo** — devague is their origin/upstream, not
+a downstream consumer. The devague agent dogfoods them to operate the devague CLI
+while improving the tool. The flow runs the *opposite* direction of the table
+above. (The skill names are `think` / `spec-to-plan`; the product/CLI they drive
+is `devague`. `think` was renamed from `devague` in 0.4.0 — when steward re-vendors,
+it must relearn the new name and pick up the new `spec-to-plan` sibling.)
 
 | Skill | Origin | Downstream | Notes |
 |-------|--------|------------|-------|
-| `devague` | **devague** (here: `.claude/skills/devague/`) | `steward`, then the AgentCulture mesh | Operator for the deterministic devague CLI: portable resolution + a `status` next-move helper over the convergence gate. When ready, `steward` re-vendors it from `../devague/.claude/skills/devague/` and broadcasts it to the mesh. `cite, don't import` still applies — downstream copies it, no symlink/dependency. Written portable-first so it passes steward's `portability-lint.sh`. |
+| `think` | **devague** (here: `.claude/skills/think/`) | `steward`, then the AgentCulture mesh | Operator for the **idea→spec** leg of the deterministic devague CLI: portable resolution + a `status` next-move helper over the frame convergence gate. Renamed from `devague` in 0.4.0. When ready, `steward` re-vendors it from `../devague/.claude/skills/think/` and broadcasts it to the mesh. |
+| `spec-to-plan` | **devague** (here: `.claude/skills/spec-to-plan/`) | `steward`, then the AgentCulture mesh | Operator for the **spec→plan** leg (`devague plan ...`): portable resolution + a `status` next-move helper over the plan convergence gate. New in 0.4.0. Re-vendor from `../devague/.claude/skills/spec-to-plan/`. |
+
+`cite, don't import` applies to both — downstream copies them, no
+symlink/dependency. Written portable-first so they pass steward's
+`portability-lint.sh`.
 
 ## Vendoring policy
 

--- a/docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md
+++ b/docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md
@@ -1,0 +1,198 @@
+# devague — spec→plan engine (`/think` + `/spec-to-plan`)
+
+**Date:** 2026-05-23
+**Status:** Approved (design) — implemented in 0.4.0
+**Design input:** user request to reframe the single `/devague` skill into a
+clearer two-skill pipeline and formalize the next leg (spec → plan).
+
+## Context
+
+devague's first engine — the **frame engine** (see
+`2026-05-23-devague-working-backwards-design.md`) — turns a vague idea into a
+buildable **spec** by working backwards, and deliberately stops at `export`,
+handing off to `superpowers:writing-plans`. This design adds the **forward** leg
+as a structural peer: a deterministic **plan engine** that turns a converged spec
+into a buildable **plan**, and reframes the operator skills so the pipeline reads
+clearly:
+
+```
+vague idea ──/think──▶ buildable spec ──/spec-to-plan──▶ buildable plan ──▶ build
+           (frame engine)               (plan engine, this design)
+```
+
+Locked decisions:
+
+- **Two skills, matched verbs.** `/devague` → `/think` (idea→spec); add
+  `/spec-to-plan` (spec→plan). The skill could **not** be named `/plan` — that
+  collides with the existing `plan` skill Claude Code and other agents use. The
+  product / CLI / repo stays **`devague`**; only the *skill* identity changes.
+  The CLI group is `devague plan <move>` (a subcommand, not a shared skill — no
+  collision).
+- **A real engine**, not a wrapper around `superpowers:writing-plans`.
+- **Seeded from a converged frame** (`devague plan new --frame <slug>`). External
+  markdown-spec ingestion is deferred.
+- **Hard rename** of the published skill (steward relearns the name downstream).
+
+## Goals / non-goals
+
+**Goals**
+- Turn a converged spec into a clear, covered, acyclic, buildable plan.
+- Make "no fabricated rigor" enforceable in code, exactly as the frame engine
+  does: LLM-proposed tasks stay `proposed` until the user confirms them.
+- Gate plan export on a convergence gate that *means something*.
+- Keep the plan engine a clean peer: deterministic, zero-runtime-dep, fully
+  unit-testable; reuse the existing CLI chassis, store conventions, and
+  `ConvergenceResult` shape.
+
+**Non-goals**
+- Not a project manager: no scheduling, estimation, or assignee tracking.
+- Not a spec parser (v1): the plan is seeded from the structured frame, not from
+  free-form markdown.
+- Do not reimplement superpowers; the exported plan-md can still feed it.
+
+## Architecture
+
+Mirror the frame engine 1:1. No LLM calls inside the CLI → fully unit-testable;
+the resident agent chooses moves.
+
+| Layer | Frame engine | Plan engine (this design) |
+|---|---|---|
+| Domain | `devague/frame.py` | `devague/plan.py` |
+| Gate | `devague/convergence.py` | `devague/plan_convergence.py` (reuses `ConvergenceResult`) |
+| Store | `devague/store.py` (`.devague/frames/`) | `devague/plan_store.py` (`.devague/plans/`) |
+| Render | `devague/render/spec_md.py` | `devague/render/plan_md.py` |
+| Resolver | `devague/cli/_frames.py` | `devague/cli/_plans.py` |
+| CLI | flat verbs | nested group `devague plan <move>` |
+
+### Domain model — the Plan
+
+One Plan per converged frame; **slug == frame slug** (1:1 link, separate
+directories so no collision). Source of truth: JSON at `.devague/plans/<slug>.json`.
+
+```
+Plan
+  meta: { slug, title, frame_slug, status: drafting|converged|exported, created, updated }
+  targets: [ CoverageTarget ]   # snapshot of what the plan must satisfy
+  tasks:   [ Task ]
+  risks:   [ PlanRisk ]
+
+CoverageTarget        # derived from the converged frame; id mirrors the frame id
+  id                  # c3 / h2 (claim id, or honesty-condition id)
+  kind                # a claim kind, or "honesty"
+  text
+
+Task
+  id                  # t1, t2
+  summary
+  origin              # user | llm
+  status              # proposed | confirmed | rejected   (user-only confirm)
+  acceptance_criteria: [ str ]
+  deps:               [ task-id ]   # tasks that must precede it
+  covers:             [ target-id ] # the c*/h* it satisfies
+
+PlanRisk              # first-class, task-level peer of the frame's open vagueness
+  id                  # r1
+  text
+  kind                # unknown_nonblocking | unknown_blocking | out_of_scope | follow_up
+  task_id?            # optional link to a task
+```
+
+`targets_from_frame(frame)` derives the targets: every **confirmed**
+spec-affecting claim plus the **confirmed** honesty conditions hanging off it.
+Confirmation rules match the frame engine: `origin=llm` tasks are born
+`proposed`; only an explicit user `confirm`/`reject` transitions them.
+
+### Moves → CLI verbs (nested group, all support `--json`)
+
+| Verb | Effect |
+|------|--------|
+| `devague plan new --frame <slug>` | Seed a plan from a **converged** frame; derive coverage targets. Refuses an unconverged frame; refuses to clobber an existing plan. |
+| `devague plan task "<summary>" [--accept … --dep … --covers … --origin]` | Add a task; inline acceptance criteria / deps / coverage. |
+| `devague plan accept <tN> "<crit>"` / `depend <tN> --on <tM>` / `cover <tN> --target <c*/h*>` | Incrementally enrich a task. |
+| `devague plan confirm <tN>` / `reject <tN>` | User-only status transitions. |
+| `devague plan risk "<text>" --kind <…> [--task <tN>]` | Record first-class plan risk. |
+| `devague plan converge` | Evaluate the gate against the **live** frame; report gaps. |
+| `devague plan export [--format plan-md]` | Emit the buildable plan — only if `converge` passes; writes `docs/plans/<slug>.md`. |
+| `devague plan show` / `list` | Render the plan / list plans. |
+| `devague plan learn` / `explain <move>` | Teach the method / a move. |
+
+Nested via `add_subparsers(parser_class=_DevagueArgumentParser)` so argparse
+errors still route through the structured `emit_error` path; bare `devague plan`
+prints group help (rc 0) via a `func` default.
+
+### Convergence gate (`plan_convergence.evaluate`)
+
+A plan converges when each failure names what's missing:
+
+- ≥1 task exists;
+- every coverage target is covered by ≥1 **confirmed** task;
+- every confirmed task has ≥1 acceptance criterion;
+- no task is still `proposed`;
+- every `dep` references a real task, and the dependency graph is **acyclic**
+  (cycle reported as a deterministic id path, e.g. `t1 -> t2 -> t1`);
+- no `unknown_blocking` risk remains.
+
+`export` refuses (with the gap list) until the gate passes.
+
+### Frame drift
+
+`converge`/`export` re-load the source frame and **re-derive** targets every
+time (the stored `targets` snapshot is a `show`-only cache). They refuse if the
+frame was deleted, has an invalid slug, or has **regressed below convergence** —
+the agent must re-converge the spec first. This is the one piece of machinery
+with no frame-engine analog; it has dedicated tests.
+
+### Output layer
+
+`plan-md` renders the buildable plan: tasks topologically ordered by deps (stable
+fallback on a cycle so rendering never crashes), each with acceptance criteria
+and the targets it covers, then a risks section. It is **not** registered in the
+`render` registry (which is `Callable[[Frame], str]`); the export command calls
+`render_plan(plan, frame)` directly.
+
+## Operator skills
+
+- `/think` (`.claude/skills/think/`, `scripts/think.sh`) — renamed from
+  `/devague`; drives the flat frame verbs; portable wrapper + `status` helper.
+- `/spec-to-plan` (`.claude/skills/spec-to-plan/`, `scripts/spec-to-plan.sh`) —
+  forwards every move to `devague plan <move>`; portable wrapper + `status`
+  helper over the plan gate.
+
+Both are first-party (origin = devague), dogfooded, and re-vendored by steward to
+the mesh — see `docs/skill-sources.md`.
+
+## Testing
+
+Deterministic throughout, mirroring `tests/`:
+- plan model: id allocation, transitions, dedup, `targets_from_frame` inclusion
+  rules, JSON round-trip;
+- gate: a case per `_missing_*` helper, incl. a deterministic cycle path;
+- store: round-trip + `current_plan`, tampered-slug rejection, frame coexistence;
+- renderer: topo order, acceptance/covers, risks, missing-frame degrade;
+- CLI: each move (text + `--json`), unconverged/missing/collision refusals, bare
+  group help, unknown sub-move, export gating, frame-drift guards, learn/explain;
+- both skill wrappers: bash validity, forwarding, `status`, install-hint.
+
+Coverage stays above `fail_under = 95`.
+
+## Acceptance criteria
+
+- `devague plan new --frame <converged>` → `task`/`accept`/`depend`/`cover`/
+  `risk` → user `confirm` → `converge` → `export` writes `docs/plans/<slug>.md`,
+  and `export` is refused (with the gap list) before convergence.
+- `plan new` refuses an unconverged frame; `converge`/`export` refuse a
+  deleted/regressed source frame.
+- LLM-origin tasks require explicit user confirmation.
+- All moves support `--json`; bare `devague plan` prints help.
+- `/devague` skill renamed to `/think`; `/spec-to-plan` added; both wrappers pass
+  `bash -n` and their smoke tests; `git grep skills/devague` finds only history.
+- Suite green (pytest-xdist), coverage ≥ 95%; flake8 / black / isort /
+  markdownlint clean.
+
+## Deferred
+
+- External markdown-spec ingestion (`plan new --spec <path>`): seam is the
+  `targets_from_frame` boundary; a markdown parser can produce targets later.
+- Effort/sequencing/assignee metadata on tasks.
+- Additional plan renderers (HTML, issue-tracker export) behind a future seam.
+- Auto-suggesting tasks/coverage from the spec (an agent affordance, not CLI).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "devague"
-version = "0.3.3"
-description = "devague — turns a vague feature idea into a buildable spec by working backwards."
+version = "0.4.0"
+description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"

--- a/tests/test_cli_plan.py
+++ b/tests/test_cli_plan.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devague import plan_store, store
+from devague.cli import main
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+# After a converged frame seeded below: claims c1..c6, honesty h1..h6 → 12 targets.
+_ALL_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame that passes the frame gate; return its slug."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the plan engine"])  # c1 announcement
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _converged_plan(monkeypatch, tmp_path, capsys) -> str:
+    """Seed + converge a plan covering every target; return the plan slug."""
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    args = ["plan", "task", "Build everything", "--accept", "all targets satisfied"]
+    for tid in _ALL_TARGETS:
+        args += ["--covers", tid]
+    main(args)
+    capsys.readouterr()
+    return slug
+
+
+# ── group plumbing ────────────────────────────────────────────────────────────
+def test_bare_plan_prints_help(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["plan"])
+    assert rc == 0
+    assert "plan" in capsys.readouterr().out
+
+
+def test_unknown_plan_move_errors(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        main(["plan", "frobnicate"])
+    assert exc.value.code == 1
+    assert "error:" in capsys.readouterr().err
+
+
+# ── new ─────────────────────────────────────────────────────────────────────
+def test_plan_new_refuses_unconverged_frame(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "just an idea"])
+    rc = main(["plan", "new", "--frame", store.current_slug()])
+    assert rc == 1
+    assert "has not converged" in capsys.readouterr().err
+
+
+def test_plan_new_missing_frame(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["plan", "new", "--frame", "ghost"])
+    assert rc == 1
+    assert "no such frame" in capsys.readouterr().err
+
+
+def test_plan_new_happy_and_collision(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["plan", "new", "--frame", slug, "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["slug"] == slug and payload["targets"] == 12
+    # second attempt refuses (1:1 link, no clobber)
+    rc = main(["plan", "new", "--frame", slug])
+    assert rc == 1
+    assert "already exists" in capsys.readouterr().err
+
+
+# ── task / accept / depend / cover ──────────────────────────────────────────
+def test_task_inline_flags_and_json(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(
+        ["plan", "task", "core", "--accept", "works", "--covers", "c1", "--dep", "t9", "--json"]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["id"] == "t1" and payload["covers"] == ["c1"] and payload["deps"] == ["t9"]
+
+
+def test_task_unknown_cover_target_errors(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(["plan", "task", "x", "--covers", "c99"])
+    assert rc == 1
+    assert "unknown coverage target" in capsys.readouterr().err
+
+
+def test_accept_depend_cover_moves(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "a"])
+    main(["plan", "task", "b"])
+    capsys.readouterr()
+    assert main(["plan", "accept", "t1", "criterion"]) == 0
+    assert main(["plan", "depend", "t2", "--on", "t1"]) == 0
+    capsys.readouterr()  # drain text output before the --json read
+    assert main(["plan", "cover", "t1", "--target", "c1", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["covers"] == ["c1"]
+
+
+def test_moves_on_unknown_task_error(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    for argv in (
+        ["plan", "accept", "tX", "c"],
+        ["plan", "depend", "tX", "--on", "t1"],
+        ["plan", "cover", "tX", "--target", "c1"],
+        ["plan", "confirm", "tX"],
+    ):
+        assert main(argv) == 1
+        assert "no such task" in capsys.readouterr().err
+
+
+def test_cover_unknown_target_errors(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "a"])
+    capsys.readouterr()
+    assert main(["plan", "cover", "t1", "--target", "zzz"]) == 1
+    assert "unknown coverage target" in capsys.readouterr().err
+
+
+# ── confirm / reject (user-only) ────────────────────────────────────────────
+def test_confirm_and_reject(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "speculative", "--origin", "llm"])  # proposed
+    capsys.readouterr()
+    assert main(["plan", "confirm", "t1", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "confirmed"
+    assert main(["plan", "reject", "t1"]) == 0
+    assert plan_store.load(slug).find_task("t1").status == "rejected"
+
+
+# ── risk ────────────────────────────────────────────────────────────────────
+def test_risk_recorded_and_unknown_task_errors(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(["plan", "risk", "scaling unknown", "--kind", "unknown_blocking", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["kind"] == "unknown_blocking"
+    assert main(["plan", "risk", "x", "--kind", "follow_up", "--task", "tX"]) == 1
+    assert "no such task" in capsys.readouterr().err
+
+
+# ── converge / export ───────────────────────────────────────────────────────
+def test_converge_reports_then_passes(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(["plan", "converge", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["passed"] is False  # no tasks yet
+
+    args = ["plan", "task", "all", "--accept", "ok"] + sum(
+        (["--covers", t] for t in _ALL_TARGETS), []
+    )
+    main(args)
+    capsys.readouterr()
+    rc = main(["plan", "converge", "--json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["passed"] is True
+    assert plan_store.load(slug).status == "converged"
+
+
+def test_export_blocked_until_converged(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(["plan", "export"])
+    assert rc == 1
+    assert "has not converged" in capsys.readouterr().err
+
+
+def test_export_writes_plan_md(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "export"])
+    assert rc == 0
+    out = Path("docs/plans") / f"{slug}.md"
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert text.startswith("# Build Plan — Ship the plan engine")
+    assert "status: exported" in text
+    assert plan_store.load(slug).status == "exported"
+
+
+def test_export_rejects_non_plan_format(tmp_path, monkeypatch, capsys) -> None:
+    _converged_plan(monkeypatch, tmp_path, capsys)
+    with pytest.raises(SystemExit) as exc:
+        main(["plan", "export", "--format", "spec-md"])
+    assert exc.value.code == 1
+
+
+# ── frame drift ───────────────────────────────────────────────────────────────
+def test_converge_errors_when_frame_deleted(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan(monkeypatch, tmp_path, capsys)
+    Path(".devague/frames").joinpath(f"{slug}.json").unlink()
+    rc = main(["plan", "converge"])
+    assert rc == 1
+    assert "no longer exists" in capsys.readouterr().err
+
+
+def test_converge_errors_when_frame_regressed(tmp_path, monkeypatch, capsys) -> None:
+    _converged_plan(monkeypatch, tmp_path, capsys)
+    # Regress the source frame below convergence.
+    main(["park", "scale?", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["plan", "converge"])
+    assert rc == 1
+    assert "regressed below convergence" in capsys.readouterr().err
+
+
+# ── show / list ───────────────────────────────────────────────────────────────
+def test_show_text_and_json(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan(monkeypatch, tmp_path, capsys)
+    assert main(["plan", "show"]) == 0
+    assert "# Build Plan" in capsys.readouterr().out
+    assert main(["plan", "show", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["slug"] == slug
+
+
+def test_show_degrades_without_frame(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan(monkeypatch, tmp_path, capsys)
+    Path(".devague/frames").joinpath(f"{slug}.json").unlink()
+    assert main(["plan", "show"]) == 0  # no announcement, but renders
+    assert "# Build Plan" in capsys.readouterr().out
+
+
+def test_list_empty_and_populated(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "list"]) == 0
+    assert "no plans yet" in capsys.readouterr().out
+    _converged_plan(monkeypatch, tmp_path, capsys)
+    assert main(["plan", "list", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["plans"]
+
+
+def test_resolve_plan_without_current(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["plan", "show"])
+    assert rc == 1
+    assert "no plan selected" in capsys.readouterr().err
+
+
+def test_resolve_plan_missing_slug(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["plan", "show", "--plan", "ghost"])
+    assert rc == 1
+    assert "no such plan" in capsys.readouterr().err
+
+
+def test_resolve_plan_invalid_slug(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["plan", "show", "--plan", "../evil"])
+    assert rc == 1
+    assert "invalid plan slug" in capsys.readouterr().err
+
+
+# ── learn / explain ───────────────────────────────────────────────────────────
+def test_learn_and_explain(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "learn"]) == 0
+    assert "spec into a buildable plan" in capsys.readouterr().out
+    assert main(["plan", "learn", "--json"]) == 0
+    assert "converge" in json.loads(capsys.readouterr().out)["moves"]
+    assert main(["plan", "explain", "task", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["move"] == "task"
+    assert main(["plan", "explain", "bogus"]) == 1
+    assert "unknown plan move" in capsys.readouterr().err

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from devague.frame import Frame
+from devague.plan import Plan, from_dict, targets_from_frame, to_dict
+
+
+def _plan() -> Plan:
+    return Plan(slug="demo", title="Demo", frame_slug="demo")
+
+
+def test_next_allocates_sequential_ids() -> None:
+    p = _plan()
+    t1 = p.add_task("first")
+    t2 = p.add_task("second")
+    assert (t1.id, t2.id) == ("t1", "t2")
+    r1 = p.add_risk("a risk", "unknown_nonblocking")
+    assert r1.id == "r1"
+
+
+def test_origin_drives_initial_status() -> None:
+    p = _plan()
+    assert p.add_task("user task").status == "confirmed"
+    assert p.add_task("llm task", origin="llm").status == "proposed"
+
+
+def test_find_task_and_target() -> None:
+    p = _plan()
+    t = p.add_task("x")
+    assert p.find_task("t1") is t
+    assert p.find_task("nope") is None
+    assert p.find_target("c1") is None
+
+
+def test_add_acceptance_dep_cover_dedup() -> None:
+    p = _plan()
+    t = p.add_task("x")
+    p.add_acceptance(t, "criterion one")
+    p.add_dep(t, "t2")
+    p.add_dep(t, "t2")  # dedup
+    p.add_cover(t, "c1")
+    p.add_cover(t, "c1")  # dedup
+    assert t.acceptance_criteria == ["criterion one"]
+    assert t.deps == ["t2"]
+    assert t.covers == ["c1"]
+
+
+def test_add_risk_rejects_unknown_kind() -> None:
+    p = _plan()
+    with pytest.raises(ValueError):
+        p.add_risk("bad", "not_a_kind")
+
+
+def test_set_status_transitions_and_reports_unknown() -> None:
+    p = _plan()
+    p.add_task("x")
+    assert p.set_status("t1", "rejected") is True
+    assert p.find_task("t1").status == "rejected"
+    assert p.set_status("tX", "confirmed") is False
+
+
+def test_roundtrip_preserves_nested_fields() -> None:
+    p = _plan()
+    t = p.add_task("core", origin="llm")
+    p.add_acceptance(t, "works")
+    p.add_dep(t, "t9")
+    p.add_cover(t, "h2")
+    p.add_risk("scope?", "unknown_blocking", task_id="t1")
+    p.targets.append(targets_from_frame(_seed_frame())[0])
+    restored = from_dict(to_dict(p))
+    assert restored == p
+
+
+def _seed_frame() -> Frame:
+    f = Frame(slug="demo", title="Demo")
+    # confirmed spec-affecting claim with a confirmed honesty condition
+    c = f.add_claim("announcement", "shipped X", origin="user")
+    f.add_honesty(c, "it is true", origin="user")
+    # a proposed claim and a rejected claim — neither should become a target
+    f.add_claim("audience", "maybe", origin="llm")  # proposed
+    rej = f.add_claim("boundary", "no", origin="user")
+    rej.status = "rejected"
+    # an open_question claim — excluded as non-spec-affecting
+    f.add_claim("open_question", "what about Y?", origin="user")
+    # a confirmed claim with a *proposed* honesty condition — claim is a target, honesty is not
+    c2 = f.add_claim("success_signal", "users adopt it", origin="user")
+    f.add_honesty(c2, "metric rises", origin="llm")  # proposed
+    return f
+
+
+def test_targets_from_frame_includes_only_confirmed_spec_elements() -> None:
+    targets = targets_from_frame(_seed_frame())
+    by_id = {t.id: t for t in targets}
+    assert "c1" in by_id and by_id["c1"].kind == "announcement"
+    assert "h1" in by_id and by_id["h1"].kind == "honesty"
+    assert "c5" in by_id  # success_signal claim is confirmed -> a target
+    # excluded: proposed claim (c2), rejected (c3), open_question (c4), proposed honesty (h2)
+    assert "c2" not in by_id
+    assert "c3" not in by_id
+    assert "c4" not in by_id
+    assert "h2" not in by_id

--- a/tests/test_plan_convergence.py
+++ b/tests/test_plan_convergence.py
@@ -70,6 +70,29 @@ def test_cycle_blocks_with_deterministic_path() -> None:
     assert "dependency cycle: t1 -> t2 -> t1" in res.missing
 
 
+def test_active_task_depending_on_rejected_task_blocks() -> None:
+    # A rejected task is omitted from the exported plan, so an active task depending
+    # on it would render a dangling `depends on:` line — the gate must catch it.
+    p = _converging()
+    rejected = p.add_task("dropped")  # t2
+    p.set_status(rejected.id, "rejected")
+    p.add_dep(p.find_task("t1"), "t2")
+    res = evaluate(p)
+    assert any("t1" in m and "depends on rejected task t2" in m for m in res.missing)
+
+
+def test_cycle_among_rejected_tasks_does_not_block() -> None:
+    # A cycle that lives entirely among rejected (non-exported) tasks is irrelevant.
+    p = _converging()
+    a = p.add_task("x")  # t2
+    b = p.add_task("y")  # t3
+    p.add_dep(a, "t3")
+    p.add_dep(b, "t2")
+    p.set_status("t2", "rejected")
+    p.set_status("t3", "rejected")
+    assert evaluate(p).passed is True
+
+
 def test_self_loop_cycle() -> None:
     p = _converging()
     p.add_dep(p.find_task("t1"), "t1")

--- a/tests/test_plan_convergence.py
+++ b/tests/test_plan_convergence.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from devague.convergence import ConvergenceResult
+from devague.plan import CoverageTarget, Plan
+from devague.plan_convergence import evaluate
+
+
+def _converging() -> Plan:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.targets = [
+        CoverageTarget(id="c1", kind="announcement", text="shipped"),
+        CoverageTarget(id="h1", kind="honesty", text="true"),
+    ]
+    t = p.add_task("do the thing")  # confirmed
+    p.add_acceptance(t, "it works")
+    p.add_cover(t, "c1")
+    p.add_cover(t, "h1")
+    return p
+
+
+def test_full_plan_converges() -> None:
+    res = evaluate(_converging())
+    assert isinstance(res, ConvergenceResult)
+    assert res.passed is True and res.missing == []
+
+
+def test_no_tasks_blocks() -> None:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    res = evaluate(p)
+    assert res.passed is False
+    assert any("no tasks" in m for m in res.missing)
+
+
+def test_uncovered_target_blocks() -> None:
+    p = _converging()
+    p.targets.append(CoverageTarget(id="c2", kind="audience", text="who"))
+    res = evaluate(p)
+    assert any("c2" in m and "no confirmed task" in m for m in res.missing)
+
+
+def test_confirmed_task_without_acceptance_blocks() -> None:
+    p = _converging()
+    extra = p.add_task("uncriteria'd")  # confirmed, no acceptance
+    extra  # noqa: B018 - referenced for clarity
+    res = evaluate(p)
+    assert any("t2" in m and "acceptance" in m for m in res.missing)
+
+
+def test_proposed_task_blocks() -> None:
+    p = _converging()
+    p.add_task("speculative", origin="llm")  # proposed
+    res = evaluate(p)
+    assert any("t2" in m and "still proposed" in m for m in res.missing)
+
+
+def test_dangling_dependency_blocks() -> None:
+    p = _converging()
+    p.add_dep(p.find_task("t1"), "t99")
+    res = evaluate(p)
+    assert any("unknown task t99" in m for m in res.missing)
+
+
+def test_cycle_blocks_with_deterministic_path() -> None:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    a = p.add_task("a")
+    b = p.add_task("b")
+    p.add_dep(a, "t2")
+    p.add_dep(b, "t1")
+    res = evaluate(p)
+    assert "dependency cycle: t1 -> t2 -> t1" in res.missing
+
+
+def test_self_loop_cycle() -> None:
+    p = _converging()
+    p.add_dep(p.find_task("t1"), "t1")
+    res = evaluate(p)
+    assert "dependency cycle: t1 -> t1" in res.missing
+
+
+def test_blocking_risk_blocks() -> None:
+    p = _converging()
+    p.add_risk("unknown scaling", "unknown_blocking")
+    res = evaluate(p)
+    assert any("blocking risk" in m for m in res.missing)
+
+
+def test_nonblocking_risk_does_not_block() -> None:
+    p = _converging()
+    p.add_risk("minor", "unknown_nonblocking")
+    assert evaluate(p).passed is True
+
+
+def test_live_targets_override_snapshot() -> None:
+    p = _converging()
+    # snapshot is satisfied, but a live extra target is not covered
+    live = p.targets + [CoverageTarget(id="c9", kind="boundary", text="non-goal")]
+    res = evaluate(p, targets=live)
+    assert any("c9" in m for m in res.missing)

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from devague import plan_store, store
+from devague.frame import Frame
+from devague.plan import Plan
+
+
+def _plan() -> Plan:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.add_task("first task")
+    return p
+
+
+def test_save_load_roundtrip_and_current(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    plan_store.save(_plan())
+    assert plan_store.current_slug() == "demo"
+    assert plan_store.list_slugs() == ["demo"]
+    loaded = plan_store.load("demo")
+    assert loaded.title == "Demo" and loaded.frame_slug == "demo"
+    assert loaded.created and loaded.updated
+
+
+def test_load_missing_raises(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        plan_store.load("nope")
+
+
+def test_list_slugs_empty_without_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert plan_store.list_slugs() == []
+    assert plan_store.current_slug() is None
+
+
+def test_path_for_rejects_unsafe_slug() -> None:
+    with pytest.raises(ValueError):
+        plan_store.path_for("../../escape")
+
+
+def test_load_rejects_tampered_internal_slug(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    plan_store.save(_plan())
+    p = plan_store.path_for("demo")
+    p.write_text(p.read_text().replace('"slug": "demo"', '"slug": "../../escape"', 1), "utf-8")
+    with pytest.raises(ValueError):
+        plan_store.load("demo")
+
+
+def test_load_rejects_tampered_frame_slug(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    plan_store.save(_plan())
+    p = plan_store.path_for("demo")
+    p.write_text(p.read_text().replace('"frame_slug": "demo"', '"frame_slug": "../x"', 1), "utf-8")
+    with pytest.raises(ValueError):
+        plan_store.load("demo")
+
+
+def test_plan_coexists_with_same_slug_frame(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.save(Frame(slug="demo", title="Demo"))
+    plan_store.save(_plan())
+    # Both persist independently in their own directories.
+    assert store.list_slugs() == ["demo"]
+    assert plan_store.list_slugs() == ["demo"]

--- a/tests/test_render_plan.py
+++ b/tests/test_render_plan.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from devague.frame import Frame
+from devague.plan import Plan
+from devague.render.plan_md import render_plan
+
+
+def _frame() -> Frame:
+    f = Frame(slug="demo", title="Demo")
+    f.add_claim("announcement", "We shipped the plan engine", origin="user")
+    return f
+
+
+def _plan() -> Plan:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    t1 = p.add_task("foundation")
+    p.add_acceptance(t1, "core lands")
+    p.add_cover(t1, "c1")
+    t2 = p.add_task("on top")
+    p.add_dep(t2, "t1")
+    p.add_cover(t2, "h1")
+    return p
+
+
+def test_topo_order_places_dep_before_dependent() -> None:
+    # t2 depends on t1; even if stored t1 first, dependents must follow deps.
+    out = render_plan(_plan(), _frame())
+    assert out.index("### t1") < out.index("### t2")
+
+
+def test_acceptance_and_covers_rendered() -> None:
+    out = render_plan(_plan(), _frame())
+    assert "- covers: c1" in out
+    assert "- acceptance:" in out and "  - core lands" in out
+    assert "- depends on: t1" in out
+
+
+def test_announcement_blockquote_from_frame() -> None:
+    out = render_plan(_plan(), _frame())
+    assert "> We shipped the plan engine" in out
+
+
+def test_renders_without_frame() -> None:
+    out = render_plan(_plan(), None)
+    assert out.startswith("# Build Plan — Demo")
+    assert ">" not in out.split("## Tasks")[0]
+
+
+def test_risks_section() -> None:
+    p = _plan()
+    p.add_risk("scaling unknown", "unknown_blocking", task_id="t1")
+    out = render_plan(p, _frame())
+    assert "## Risks" in out
+    assert "- [unknown_blocking] scaling unknown (task t1)" in out
+
+
+def test_rejected_task_omitted() -> None:
+    p = _plan()
+    p.set_status("t2", "rejected")
+    out = render_plan(p, _frame())
+    assert "### t2" not in out
+
+
+def test_cycle_still_renders() -> None:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    a = p.add_task("a")
+    b = p.add_task("b")
+    p.add_dep(a, "t2")
+    p.add_dep(b, "t1")
+    out = render_plan(p, None)  # cycle: must not raise, both tasks appear
+    assert "### t1" in out and "### t2" in out

--- a/tests/test_spec_to_plan_skill.py
+++ b/tests/test_spec_to_plan_skill.py
@@ -1,0 +1,124 @@
+"""Smoke tests for the first-party ``spec-to-plan`` skill wrapper.
+
+These drive ``.claude/skills/spec-to-plan/scripts/spec-to-plan.sh`` via subprocess
+in a sandboxed ``tmp_path`` cwd (so ``.devague/`` never touches the repo). The
+wrapper forwards every move to ``devague plan <move>`` verbatim and adds a
+``status`` helper that reads the plan convergence gate. Frames are seeded with the
+sibling ``think`` wrapper, since a plan must start from a converged frame. The
+skill is named ``spec-to-plan``; the CLI it drives is ``devague plan``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / ".claude" / "skills" / "spec-to-plan" / "scripts" / "spec-to-plan.sh"
+THINK = REPO_ROOT / ".claude" / "skills" / "think" / "scripts" / "think.sh"
+_ALL_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+def _run(script: Path, *args: str, cwd: Path, env: dict | None = None):
+    return subprocess.run(
+        ["bash", str(script), *args], cwd=str(cwd), env=env, capture_output=True, text=True
+    )
+
+
+def run(*args: str, cwd: Path, env: dict | None = None):
+    return _run(SCRIPT, *args, cwd=cwd, env=env)
+
+
+def _drive(cwd: Path, *args: str):
+    proc = run(*args, cwd=cwd)
+    assert proc.returncode == 0, f"{args} failed: {proc.stderr}"
+    return proc
+
+
+def _think(cwd: Path, *args: str):
+    proc = _run(THINK, *args, cwd=cwd)
+    assert proc.returncode == 0, f"think {args} failed: {proc.stderr}"
+    return proc
+
+
+def _converged_frame(cwd: Path) -> str:
+    out = _think(cwd, "new", "Ship the plan engine", "--json")
+    slug = json.loads(out.stdout)["slug"]
+    for kind in ("audience", "after_state", "before_state", "boundary", "success_signal"):
+        _think(cwd, "capture", "--kind", kind, f"{kind} text", "--origin", "user")
+    for cid in (f"c{i}" for i in range(1, 7)):
+        _think(cwd, "interrogate", cid, "--honesty", f"{cid} is testable", "--origin", "user")
+    return slug
+
+
+def test_script_is_executable_and_valid_bash() -> None:
+    assert SCRIPT.exists(), f"missing wrapper at {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), "wrapper should be executable"
+    assert subprocess.run(["bash", "-n", str(SCRIPT)]).returncode == 0
+
+
+def test_help_lists_moves(tmp_path: Path) -> None:
+    proc = _drive(tmp_path, "help")
+    assert "spec→plan engine" in proc.stdout
+    for move in ("new", "task", "cover", "converge", "export", "status"):
+        assert move in proc.stdout
+
+
+def test_status_reports_no_plans(tmp_path: Path) -> None:
+    proc = _drive(tmp_path, "status")
+    assert "no plans yet" in proc.stdout
+
+
+def test_forwards_learn_verbatim(tmp_path: Path) -> None:
+    proc = _drive(tmp_path, "learn")
+    assert "buildable plan" in proc.stdout
+
+
+def test_status_names_gaps_and_next_move(tmp_path: Path) -> None:
+    slug = _converged_frame(tmp_path)
+    _drive(tmp_path, "new", "--frame", slug)
+    proc = _drive(tmp_path, "status")
+    assert "NOT passed" in proc.stdout
+    assert "no tasks yet" in proc.stdout
+    assert "devague plan task" in proc.stdout  # first-gap suggestion
+
+
+def test_new_refuses_unconverged_frame(tmp_path: Path) -> None:
+    _think(tmp_path, "new", "just an idea")
+    proc = run("new", "--frame", "just-an-idea", cwd=tmp_path)
+    assert proc.returncode != 0
+    assert "has not converged" in proc.stderr
+
+
+def test_full_session_converges_and_exports(tmp_path: Path) -> None:
+    slug = _converged_frame(tmp_path)
+    _drive(tmp_path, "new", "--frame", slug)
+    args = ["task", "Build everything", "--accept", "all targets satisfied"]
+    for tid in _ALL_TARGETS:
+        args += ["--covers", tid]
+    _drive(tmp_path, *args)
+
+    status = _drive(tmp_path, "status")
+    assert "PASSED" in status.stdout
+    assert "devague plan export" in status.stdout
+
+    _drive(tmp_path, "converge")
+    exported = _drive(tmp_path, "export")
+    assert "exported plan" in exported.stdout
+    plans = list((tmp_path / "docs" / "plans").glob("*.md"))
+    assert plans, "export should write a plan file"
+
+
+def test_missing_cli_emits_install_hint(tmp_path: Path) -> None:
+    minimal_path = "/usr/bin:/bin"
+    env = {**os.environ, "PATH": minimal_path}
+    if shutil.which("devague", path=minimal_path) or shutil.which("uv", path=minimal_path):
+        pytest.skip("devague/uv resolvable under minimal PATH; cannot test hint path")
+    proc = run("show", cwd=tmp_path, env=env)
+    assert proc.returncode != 0
+    assert "devague CLI not found" in proc.stderr

--- a/tests/test_think_skill.py
+++ b/tests/test_think_skill.py
@@ -1,10 +1,11 @@
-"""Smoke tests for the first-party ``devague`` skill wrapper.
+"""Smoke tests for the first-party ``think`` skill wrapper.
 
-These drive ``.claude/skills/devague/scripts/devague.sh`` via subprocess in a
+These drive ``.claude/skills/think/scripts/think.sh`` via subprocess in a
 sandboxed ``tmp_path`` cwd (so ``.devague/`` never touches the repo). They pin
 the contract steward relies on when it pulls this skill into the mesh: the
 wrapper forwards moves verbatim, ``status`` reads the convergence gate and names
-the next move, and ``export`` stays blocked until the frame converges.
+the next move, and ``export`` stays blocked until the frame converges. The skill
+is named ``think``; the CLI it drives is still ``devague``.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCRIPT = REPO_ROOT / ".claude" / "skills" / "devague" / "scripts" / "devague.sh"
+SCRIPT = REPO_ROOT / ".claude" / "skills" / "think" / "scripts" / "think.sh"
 
 
 def run(*args: str, cwd: Path, env: dict | None = None) -> subprocess.CompletedProcess:
@@ -46,7 +47,7 @@ def test_script_is_executable_and_valid_bash() -> None:
 
 def test_help_lists_moves(tmp_path: Path) -> None:
     proc = _drive(tmp_path, "help")
-    assert "operate the devague" in proc.stdout
+    assert "drive devague" in proc.stdout
     for move in ("new", "capture", "interrogate", "converge", "export", "status"):
         assert move in proc.stdout
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Adds devague's second deterministic engine — the **spec→plan engine**, a
structural peer of the existing frame engine (idea→spec) — and reframes the
operator skills into a clear two-leg pipeline:

`vague idea → /think → buildable spec → /spec-to-plan → buildable plan → build`

## Plan engine (new, mirrors the frame engine 1:1)

- `devague/plan.py` — `Plan` / `Task` / `PlanRisk` / `CoverageTarget` domain; same `_next` id allocation and user-only confirm rule as `frame.py`. `targets_from_frame()` derives coverage targets from a converged frame's confirmed claims + honesty conditions.
- `devague/plan_convergence.py` — gate (reuses `ConvergenceResult`): every coverage target covered by a confirmed task, every confirmed task has acceptance criteria, no task left proposed, dependency graph acyclic (deterministic cycle path), no blocking risk.
- `devague/plan_store.py` — JSON under `.devague/plans/` (slug == frame slug, refuse-on-collision).
- `devague/render/plan_md.py` — topologically-ordered buildable plan-md (not in the `Frame`-typed render registry; called directly).
- `devague/cli/_commands/plan.py` + `_plans.py` — nested `devague plan <move>` group: `new`/`task`/`accept`/`depend`/`cover`/`confirm`/`reject`/`risk`/`converge`/`export`/`show`/`list`/`learn`/`explain`, all `--json`.
- `plan new` requires a **converged** frame; `converge`/`export` re-evaluate against the **live** frame and refuse on drift (source frame deleted or regressed below convergence).

## Skill reframe

- Renamed the published `/devague` skill → **`/think`** (idea→spec); "devague" stays a trigger keyword.
- Added **`/spec-to-plan`** (spec→plan), a portable wrapper over `devague plan` with a `status` next-move helper.
- Product / CLI / repo name stays `devague`. README reframed to make clear `devague` is a **CLI** (the PyPI-facing identity); the agent framing stays in `CLAUDE.md`.

## Tests / quality

- 147 tests pass; coverage **96.6%** (gate 95%). flake8 / black / isort / markdownlint / bandit clean.
- Version **0.3.3 → 0.4.0**.

## Downstream note (alignment delta)

Touches `CLAUDE.md`, `docs/skill-sources.md`, and `.claude/skills/`. The skill rename (`devague`→`think`) plus the new `spec-to-plan` sibling means **steward must relearn the skill names** when it re-vendors and broadcasts to the AgentCulture mesh — recorded in `docs/skill-sources.md`.

Design: `docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md`

- devague (Claude)
