### PR TITLE
Implement the Devague spec contract (#5): enriched model, schema_version, structured converge

### DIFF
--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -108,7 +108,6 @@ cmd_status() {
         python3 - <<'PY'
 import json
 import os
-import re
 import sys
 
 
@@ -154,52 +153,25 @@ if conv is None:
     print("next move: devague plan show     # inspect the plan")
     sys.exit(0)
 
-if conv.get("passed"):
+if conv.get("ready_for_plan"):
     print("convergence: PASSED ✓")
+    for w in conv.get("warnings") or []:
+        print(f"  ⚠ {w}")
     print("next move: devague plan export   # write the buildable plan")
     sys.exit(0)
 
-missing = conv.get("missing") or []
-print(f"convergence: NOT passed — {len(missing)} gap(s):")
-for gap in missing:
-    print(f"  - {gap}")
+blockers = conv.get("blockers") or []
+print(f"convergence: NOT passed — {len(blockers)} gap(s):")
+for b in blockers:
+    print(f"  - {b}")
+for w in conv.get("warnings") or []:
+    print(f"  ⚠ {w}")
 
-
-def suggest(gap):
-    if "no tasks yet" in gap:
-        return 'devague plan task "<summary>" --covers <c*/h*> --accept "<criterion>"'
-    m = re.search(r"coverage target (\w+) ", gap)
-    if m:
-        tid = m.group(1)
-        return (
-            f'cover {tid}: devague plan task "<summary>" --covers {tid} --accept "<...>"'
-            f"   (or: devague plan cover <tN> --target {tid})"
-        )
-    m = re.search(r"task (t\d+) has no acceptance", gap)
-    if m:
-        return f'devague plan accept {m.group(1)} "<acceptance criterion>"'
-    m = re.search(r"task (t\d+) still proposed", gap)
-    if m:
-        tid = m.group(1)
-        return (
-            f"this is an LLM proposal — the USER decides:"
-            f" devague plan confirm {tid}   (or: devague plan reject {tid})"
-        )
-    m = re.search(r"task (t\d+) depends on unknown task (t\d+)", gap)
-    if m:
-        return f"fix {m.group(1)}'s dependency on missing {m.group(2)} (add it, or drop the dep)"
-    if "dependency cycle" in gap:
-        return "break the dependency cycle: re-point one task's --dep so the graph is acyclic"
-    m = re.search(r"blocking risk (r\d+)", gap)
-    if m:
-        return f"resolve {m.group(1)}: cover it with a task, or re-record it as non-blocking"
-    return "devague plan show     # inspect and decide"
-
-
-if missing:
+moves = conv.get("required_next_moves") or []
+if moves:
     print()
     print("recommended next move (first gap):")
-    print(f"  {suggest(missing[0])}")
+    print(f"  {moves[0]}")
 PY
 }
 

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -66,27 +66,31 @@ portable resolution and the `status` helper.
 | `learn` / `explain <move>` | Teach the method / explain one move. |
 
 Claim kinds: `announcement`, `audience`, `after_state`, `before_state`,
-`why_it_matters`, `boundary`, `success_signal`, `open_question`. Vagueness kinds:
-`unknown_nonblocking`, `unknown_blocking`, `out_of_scope`, `follow_up`.
+`why_it_matters`, `boundary`, `success_signal`, `open_question`, `non_goal`,
+`requirement`, `assumption`, `decision`. Vagueness kinds: `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
 
 These are exactly the kinds the **shipped CLI enforces** (`CLAIM_KINDS` /
 `VAGUENESS_KINDS` in `devague/frame.py`) — the skill documents the surface as
-built, so every command here passes the CLI's `choices=` validation. A fuller
-proposed type/state set, plus the formal per-move input/output/transition
-contract, is tracked on the CLI side in
-[#5](https://github.com/agentculture/devague/issues/5); for the authoritative
+built, so every command here passes the CLI's `choices=` validation. `requirement`
+is spec-affecting (needs a confirmed honesty condition); `non_goal` / `decision`
+are descriptive; an unconfirmed `assumption` is a convergence *warning*, not a
+blocker. The formal entity model, the `(state × origin)` vocabulary, and the
+per-move input/output/transition/error contract are documented in
+[`docs/spec-contract.md`](../../../docs/spec-contract.md) (issue
+[#5](https://github.com/agentculture/devague/issues/5)); for the authoritative
 live shape of any move, run it with `--json` (or `devague learn --json` /
-`devague explain <move>`). When the CLI's contract grows, re-sync this list.
+`devague explain <move>`).
 
 ### `status` — the next-move helper
 
 `status` is a wrapper-only verb (the CLI has no `status`). It reads
 `converge --json` + `list --json` and prints where the current frame stands, the
-remaining gaps, and the recommended next move derived from the first gap.
-`converge --json` currently emits `{passed, missing}`, which is what the helper
-consumes; if [#5](https://github.com/agentculture/devague/issues/5) enriches that
-payload (e.g. structured `blockers` / `warnings` / `required_next_moves`),
-`status` will surface the richer fields then.
+remaining gaps, and the recommended next move. `converge --json` emits the
+structured result `{ready_for_spec, blockers, warnings, parked_items,
+required_next_moves}` (issue [#5](https://github.com/agentculture/devague/issues/5));
+the helper reads `ready_for_spec`, lists the `blockers` and `warnings`, and shows
+`required_next_moves[0]` as the recommended move — no longer deriving it itself.
 
 ```text
 frame: my-feature    (1 frame total)

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -114,7 +114,6 @@ cmd_status() {
         python3 - <<'PY'
 import json
 import os
-import re
 import sys
 
 
@@ -161,58 +160,25 @@ if conv is None:
     print("next move: devague show     # inspect the frame")
     sys.exit(0)
 
-if conv.get("passed"):
+if conv.get("ready_for_spec"):
     print("convergence: PASSED ✓")
+    for w in conv.get("warnings") or []:
+        print(f"  ⚠ {w}")
     print("next move: devague export   # write the buildable spec")
     sys.exit(0)
 
-missing = conv.get("missing") or []
-print(f"convergence: NOT passed — {len(missing)} gap(s):")
-for gap in missing:
-    print(f"  - {gap}")
+blockers = conv.get("blockers") or []
+print(f"convergence: NOT passed — {len(blockers)} gap(s):")
+for b in blockers:
+    print(f"  - {b}")
+for w in conv.get("warnings") or []:
+    print(f"  ⚠ {w}")
 
-
-def suggest(gap):
-    # Confirmation is a USER-only transition; a plain (user-origin) capture
-    # is already confirmed, so never imply the agent should confirm its own
-    # work. Spell out who confirms wherever a confirm is in play.
-    m = re.search(r"missing confirmed '([a-z_]+)' claim", gap)
-    if m:
-        kind = m.group(1)
-        return (f'devague capture --kind {kind} "<text>"'
-                f'   (a user capture auto-confirms; an --origin llm capture'
-                f' then needs the USER to confirm it)')
-    if "before_state" in gap and "why_it_matters" in gap:
-        return 'devague capture --kind why_it_matters "<text>"'
-    if "boundary" in gap:
-        return 'devague capture --kind boundary "<text>"'
-    if "success_signal" in gap:
-        return 'devague capture --kind success_signal "<text>"'
-    m = re.search(r"claim (c\d+) still proposed", gap)
-    if m:
-        cid = m.group(1)
-        return (f'this is an LLM proposal — the USER decides:'
-                f' devague confirm {cid}   (or: devague reject {cid})')
-    m = re.search(r"claim (c\d+) has no confirmed honesty condition", gap)
-    if m:
-        cid = m.group(1)
-        return (f'devague interrogate {cid} --honesty "<what must be true>"'
-                f'   then the USER runs: devague confirm <hN>')
-    m = re.search(r"blocking vagueness (v\d+)", gap)
-    if m:
-        return (f"resolve {m.group(1)}: capture+confirm the answer, "
-                f"or re-park it as non-blocking")
-    m = re.search(r"blocking hard question (q\d+) on (c\d+)", gap)
-    if m:
-        return (f"resolve {m.group(1)} on {m.group(2)}: answer it, then "
-                f"capture/confirm the resulting claim")
-    return "devague show     # inspect and decide"
-
-
-if missing:
+moves = conv.get("required_next_moves") or []
+if moves:
     print()
     print("recommended next move (first gap):")
-    print(f"  {suggest(missing[0])}")
+    print(f"  {moves[0]}")
 PY
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-23
+
+### Added
+
+- Spec contract (#5): claim kinds non_goal / requirement / assumption / decision, each with a documented convergence-gate role (requirement is spec-affecting; non_goal/decision are descriptive; an unconfirmed assumption is a warning, not a blocker).
+- Every frame carries a fail-closed schema_version: written on save, validated on load (a newer/unknown version is rejected with an actionable error); existing 0.4.0 frames still load.
+- docs/spec-contract.md — the documented source of truth for the entity model, the (state x origin) vocabulary, the structured convergence result, and the per-move input/output/transition/validation-error contract — plus a test-verified worked example at docs/examples/contract-example.json.
+- Contract test suite: claim provenance, honesty-condition confirmation, parking vagueness, structured convergence failure, lossless round-trip, schema versioning, and an offline-operation guarantee (no networking imports; a full session runs with sockets stubbed).
+
+### Changed
+
+- BREAKING: converge --json now emits the structured result {ready_for_spec, blockers, warnings, parked_items, required_next_moves} (plans: ready_for_plan) instead of {passed, missing}. The /think and /spec-to-plan status helpers were updated in the same change; required_next_moves is now derived by the CLI. capture --json now includes origin.
+- Frame loading raises distinct, actionable DevagueErrors (newer schema -> upgrade; malformed/hand-edited frame -> fix hint) instead of a generic 'invalid slug'.
+
 ## [0.4.1] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
+**Spec contract landed (#5).** The entity model is documented in
+`docs/spec-contract.md` (the source of truth for kinds, the `(state × origin)`
+vocabulary, the structured convergence result, and the per-move I/O contract).
+Claim kinds now include `non_goal` / `requirement` / `assumption` / `decision`;
+every frame carries a fail-closed `schema_version`; and `converge --json` emits
+the structured `{ready_for_spec, blockers, warnings, parked_items,
+required_next_moves}` (plans: `ready_for_plan`) — a hard break from the old
+`{passed, missing}`.
+
 **Spec→plan engine landed (v0.4.0).** Both deterministic engines now ship.
 The **frame engine** (idea→spec) — Frame domain model, JSON store, convergence
 gate, renderer registry, and the flat moves `new` / `capture` / `interrogate` /

--- a/devague/cli/_commands/capture.py
+++ b/devague/cli/_commands/capture.py
@@ -15,7 +15,15 @@ def cmd_capture(args: argparse.Namespace) -> int:
     claim = frame.add_claim(args.kind, args.text, origin=args.origin)
     store.save(frame)
     if getattr(args, "json", False):
-        emit_result({"id": claim.id, "kind": claim.kind, "status": claim.status}, json_mode=True)
+        emit_result(
+            {
+                "id": claim.id,
+                "kind": claim.kind,
+                "origin": claim.origin,
+                "status": claim.status,
+            },
+            json_mode=True,
+        )
     else:
         emit_result(f"captured {claim.id} ({claim.kind}, {claim.status})", json_mode=False)
     return 0

--- a/devague/cli/_commands/converge.py
+++ b/devague/cli/_commands/converge.py
@@ -13,20 +13,31 @@ from devague.convergence import evaluate
 def cmd_converge(args: argparse.Namespace) -> int:
     frame = resolve(args.frame)
     result = evaluate(frame)
-    if result.passed and frame.status == "drafting":
+    if result.ready and frame.status == "drafting":
         frame.status = "converged"
         store.save(frame)
-    elif not result.passed and frame.status == "converged":
+    elif not result.ready and frame.status == "converged":
         frame.status = "drafting"
         store.save(frame)
     if getattr(args, "json", False):
-        emit_result({"passed": result.passed, "missing": result.missing}, json_mode=True)
-    elif result.passed:
-        emit_result("converged ✓", json_mode=False)
-    else:
         emit_result(
-            "not converged:\n" + "\n".join(f"  - {m}" for m in result.missing), json_mode=False
+            {
+                "ready_for_spec": result.ready,
+                "blockers": result.blockers,
+                "warnings": result.warnings,
+                "parked_items": result.parked_items,
+                "required_next_moves": result.required_next_moves,
+            },
+            json_mode=True,
         )
+    elif result.ready:
+        msg = "converged ✓"
+        if result.warnings:
+            msg += "\nwarnings:\n" + "\n".join(f"  - {w}" for w in result.warnings)
+        emit_result(msg, json_mode=False)
+    else:
+        lines = "\n".join(f"  - {b}" for b in result.blockers)
+        emit_result("not converged:\n" + lines, json_mode=False)
     return 0
 
 

--- a/devague/cli/_commands/export.py
+++ b/devague/cli/_commands/export.py
@@ -17,11 +17,11 @@ SPECS_DIR = Path("docs/specs")
 def cmd_export(args: argparse.Namespace) -> int:
     frame = resolve(args.frame)
     result = evaluate(frame)
-    if not result.passed:
+    if not result.ready:
         raise DevagueError(
             EXIT_USER_ERROR,
             "frame has not converged; cannot export",
-            "resolve: " + "; ".join(result.missing),
+            "resolve: " + "; ".join(result.blockers),
         )
     text = render.render(frame, args.format)
     SPECS_DIR.mkdir(parents=True, exist_ok=True)

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -69,7 +69,7 @@ def _live(plan: Plan):
     """Re-load the source frame and re-derive targets; guard against frame drift."""
     frame = _load_source_frame(plan.frame_slug)
     fres = evaluate_frame(frame)
-    if not fres.passed:
+    if not fres.ready:
         raise DevagueError(
             EXIT_USER_ERROR,
             f"source frame '{frame.slug}' has regressed below convergence",
@@ -98,11 +98,11 @@ def _require_target(plan: Plan, target_id: str) -> None:
 def cmd_plan_new(args: argparse.Namespace) -> int:
     frame = resolve_frame(args.frame)
     result = evaluate_frame(frame)
-    if not result.passed:
+    if not result.ready:
         raise DevagueError(
             EXIT_USER_ERROR,
             f"frame '{frame.slug}' has not converged; cannot start a plan",
-            "resolve: " + "; ".join(result.missing),
+            "resolve: " + "; ".join(result.blockers),
         )
     if plan_store.path_for(frame.slug).exists():
         raise DevagueError(
@@ -234,19 +234,27 @@ def cmd_plan_converge(args: argparse.Namespace) -> int:
     _frame, targets = _live(plan)
     plan.targets = targets  # refresh the snapshot from the live frame
     result = evaluate_plan(plan, targets=targets)
-    if result.passed and plan.status == "drafting":
+    if result.ready and plan.status == "drafting":
         plan.status = "converged"
-    elif not result.passed and plan.status == "converged":
+    elif not result.ready and plan.status == "converged":
         plan.status = "drafting"
     plan_store.save(plan)
     if getattr(args, "json", False):
-        emit_result({"passed": result.passed, "missing": result.missing}, json_mode=True)
-    elif result.passed:
+        emit_result(
+            {
+                "ready_for_plan": result.ready,
+                "blockers": result.blockers,
+                "warnings": result.warnings,
+                "parked_items": result.parked_items,
+                "required_next_moves": result.required_next_moves,
+            },
+            json_mode=True,
+        )
+    elif result.ready:
         emit_result("converged ✓", json_mode=False)
     else:
-        emit_result(
-            "not converged:\n" + "\n".join(f"  - {m}" for m in result.missing), json_mode=False
-        )
+        lines = "\n".join(f"  - {b}" for b in result.blockers)
+        emit_result("not converged:\n" + lines, json_mode=False)
     return 0
 
 
@@ -255,11 +263,11 @@ def cmd_plan_export(args: argparse.Namespace) -> int:
     frame, targets = _live(plan)
     plan.targets = targets
     result = evaluate_plan(plan, targets=targets)
-    if not result.passed:
+    if not result.ready:
         raise DevagueError(
             EXIT_USER_ERROR,
             "plan has not converged; cannot export",
-            "resolve: " + "; ".join(result.missing),
+            "resolve: " + "; ".join(result.blockers),
         )
     plan.status = "exported"
     text = plan_md.render_plan(plan, frame)

--- a/devague/cli/_frames.py
+++ b/devague/cli/_frames.py
@@ -16,14 +16,29 @@ def resolve(slug: str | None) -> Frame:
             "run 'devague new \"<announcement>\"' or pass --frame <slug>",
         )
     try:
-        return store.load(slug)
+        store.validate_slug(slug)
     except ValueError as exc:
         raise DevagueError(
             EXIT_USER_ERROR,
             f"invalid frame slug: {slug!r}",
             "slugs are lowercase letters, digits, and hyphens — no path separators",
         ) from exc
+    try:
+        return store.load(slug)
+    except store.IncompatibleSchemaError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            str(exc),
+            "this frame was written by a newer devague — upgrade: 'uv tool install -U devague'",
+        ) from exc
     except FileNotFoundError:
         raise DevagueError(
             EXIT_USER_ERROR, f"no such frame: {slug}", "run 'devague list' to see frames"
         ) from None
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"frame {slug!r} is malformed: {exc}",
+            "the frame file was hand-edited or corrupted — "
+            "fix .devague/frames/<slug>.json or recreate the frame",
+        ) from exc

--- a/devague/convergence.py
+++ b/devague/convergence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 
 from devague.frame import SPEC_AFFECTING_KINDS, Frame
@@ -9,8 +10,20 @@ from devague.frame import SPEC_AFFECTING_KINDS, Frame
 
 @dataclass
 class ConvergenceResult:
-    passed: bool
-    missing: list[str] = field(default_factory=list)
+    """Structured convergence verdict, shared by the frame and plan engines.
+
+    ``ready`` is the gate (no blockers). The CLI serializes it under an
+    engine-specific key (``ready_for_spec`` for frames, ``ready_for_plan`` for
+    plans). ``blockers`` hold convergence back; ``warnings`` do not;
+    ``parked_items`` are tracked-but-non-blocking unknowns; ``required_next_moves``
+    are derived from the blockers so an operator knows what to do next.
+    """
+
+    ready: bool
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    parked_items: list[str] = field(default_factory=list)
+    required_next_moves: list[str] = field(default_factory=list)
 
 
 def _missing_required_kinds(confirmed_kinds: set[str]) -> list[str]:
@@ -61,12 +74,76 @@ def _missing_open_uncertainty(frame: Frame) -> list[str]:
     return missing
 
 
+def _assumption_warnings(frame: Frame) -> list[str]:
+    """Unconfirmed assumptions are soft: a warning, never a blocker (#5, h14)."""
+    return [
+        f"assumption {c.id} is unconfirmed — confirm it or it ships as a stated assumption"
+        for c in frame.claims
+        if c.kind == "assumption" and c.status != "confirmed"
+    ]
+
+
+def _parked_items(frame: Frame) -> list[str]:
+    """Tracked, non-blocking open vagueness (everything but unknown_blocking)."""
+    return [f"[{v.kind}] {v.text}" for v in frame.open_vagueness if v.kind != "unknown_blocking"]
+
+
+def suggest_move(blocker: str) -> str:
+    """Map a single blocker to the recommended next devague move.
+
+    Confirmation is a USER-only transition, so any confirm-related move spells
+    out who confirms — the agent must never imply it should confirm its own work.
+    """
+    m = re.search(r"missing confirmed '([a-z_]+)' claim", blocker)
+    if m:
+        kind = m.group(1)
+        return (
+            f'devague capture --kind {kind} "<text>"   (a user capture '
+            f"auto-confirms; an --origin llm capture then needs the USER to confirm it)"
+        )
+    if "before_state" in blocker and "why_it_matters" in blocker:
+        return 'devague capture --kind why_it_matters "<text>"'
+    if "boundary" in blocker:
+        return 'devague capture --kind boundary "<text>"'
+    if "success_signal" in blocker:
+        return 'devague capture --kind success_signal "<text>"'
+    m = re.search(r"claim (c\d+) still proposed", blocker)
+    if m:
+        cid = m.group(1)
+        return (
+            f"this is an LLM proposal — the USER decides: devague confirm {cid} (or reject {cid})"
+        )
+    m = re.search(r"claim (c\d+) has no confirmed honesty condition", blocker)
+    if m:
+        cid = m.group(1)
+        return (
+            f'devague interrogate {cid} --honesty "<what must be true>"'
+            f"   then USER: devague confirm <hN>"
+        )
+    m = re.search(r"blocking vagueness (v\d+)", blocker)
+    if m:
+        return f"resolve {m.group(1)}: capture+confirm the answer, or re-park it as non-blocking"
+    m = re.search(r"blocking hard question (q\d+) on (c\d+)", blocker)
+    if m:
+        return (
+            f"resolve {m.group(1)} on {m.group(2)}: answer it, then "
+            f"capture/confirm the resulting claim"
+        )
+    return "devague show     # inspect and decide"
+
+
 def evaluate(frame: Frame) -> ConvergenceResult:
     confirmed = [c for c in frame.claims if c.status == "confirmed"]
     confirmed_kinds = {c.kind for c in confirmed}
-    missing = (
+    blockers = (
         _missing_required_kinds(confirmed_kinds)
         + _missing_claim_resolution(frame, confirmed)
         + _missing_open_uncertainty(frame)
     )
-    return ConvergenceResult(passed=not missing, missing=missing)
+    return ConvergenceResult(
+        ready=not blockers,
+        blockers=blockers,
+        warnings=_assumption_warnings(frame),
+        parked_items=_parked_items(frame),
+        required_next_moves=[suggest_move(b) for b in blockers],
+    )

--- a/devague/frame.py
+++ b/devague/frame.py
@@ -9,6 +9,10 @@ import dataclasses
 from dataclasses import dataclass, field
 from typing import Optional
 
+# Bump when the persisted shape changes incompatibly. `store.load` fails closed
+# on a frame whose schema_version is newer/unknown (see #5, honesty condition h15).
+SCHEMA_VERSION = 1
+
 CLAIM_KINDS = (
     "announcement",
     "audience",
@@ -18,8 +22,27 @@ CLAIM_KINDS = (
     "boundary",
     "success_signal",
     "open_question",
+    # Added for the documented spec contract (#5).
+    "non_goal",
+    "requirement",
+    "assumption",
+    "decision",
 )
-SPEC_AFFECTING_KINDS = tuple(k for k in CLAIM_KINDS if k != "open_question")
+# Spec-affecting claims must be confirmed and carry a confirmed honesty condition
+# to converge. `requirement` joins the original set; `non_goal`/`decision`/
+# `open_question` are descriptive, and `assumption` is soft (an unconfirmed one is
+# a convergence *warning*, not a blocker — see convergence.py).
+SPEC_AFFECTING_KINDS = (
+    "announcement",
+    "audience",
+    "after_state",
+    "before_state",
+    "why_it_matters",
+    "boundary",
+    "success_signal",
+    "requirement",
+)
+DESCRIPTIVE_KINDS = ("open_question", "non_goal", "decision")
 VAGUENESS_KINDS = (
     "unknown_nonblocking",
     "unknown_blocking",
@@ -27,6 +50,8 @@ VAGUENESS_KINDS = (
     "follow_up",
 )
 CLAIM_STATUSES = ("proposed", "confirmed", "rejected")
+HONESTY_STATUSES = ("proposed", "confirmed", "rejected")
+ORIGINS = ("user", "llm")
 
 
 @dataclass
@@ -34,6 +59,10 @@ class HonestyCondition:
     id: str
     text: str
     status: str = "proposed"  # proposed | confirmed | rejected
+
+    def __post_init__(self) -> None:
+        if self.status not in HONESTY_STATUSES:
+            raise ValueError(f"unknown honesty status: {self.status!r}")
 
 
 @dataclass
@@ -55,6 +84,14 @@ class Claim:
     hard_questions: list[HardQuestion] = field(default_factory=list)
     links: list[str] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        if self.kind not in CLAIM_KINDS:
+            raise ValueError(f"unknown claim kind: {self.kind!r}")
+        if self.origin not in ORIGINS:
+            raise ValueError(f"unknown claim origin: {self.origin!r}")
+        if self.status not in CLAIM_STATUSES:
+            raise ValueError(f"unknown claim status: {self.status!r}")
+
 
 @dataclass
 class Vagueness:
@@ -63,11 +100,16 @@ class Vagueness:
     kind: str
     claim_id: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        if self.kind not in VAGUENESS_KINDS:
+            raise ValueError(f"unknown vagueness kind: {self.kind!r}")
+
 
 @dataclass
 class Frame:
     slug: str
     title: str
+    schema_version: int = SCHEMA_VERSION
     status: str = "drafting"  # drafting | converged | exported
     created: str = ""
     updated: str = ""
@@ -176,6 +218,8 @@ def from_dict(d: dict) -> Frame:
     return Frame(
         slug=d["slug"],
         title=d["title"],
+        # A 0.4.0 frame predates the field; treat it as the current schema.
+        schema_version=int(d.get("schema_version", SCHEMA_VERSION)),
         status=d.get("status", "drafting"),
         created=d.get("created", ""),
         updated=d.get("updated", ""),

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -4,11 +4,13 @@ The peer of :mod:`devague.convergence`. A plan converges when every coverage tar
 is covered by a confirmed task, every confirmed task carries acceptance criteria, the
 dependency graph is sound (no dangling refs, no cycles), nothing is left proposed, and
 no blocking risk remains. Reuses :class:`devague.convergence.ConvergenceResult` so both
-engines report the same ``{passed, missing}`` shape.
+engines report the same structured ``{ready, blockers, warnings, parked_items,
+required_next_moves}`` shape (the CLI serializes ``ready`` as ``ready_for_plan``).
 """
 
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 from devague.convergence import ConvergenceResult
@@ -123,6 +125,43 @@ def _missing_risks(plan: Plan) -> list[str]:
     return [f"blocking risk {r.id} unresolved" for r in plan.risks if r.kind == "unknown_blocking"]
 
 
+def _parked_items(plan: Plan) -> list[str]:
+    """Tracked, non-blocking risks (everything but unknown_blocking)."""
+    return [f"[{r.kind}] {r.text}" for r in plan.risks if r.kind != "unknown_blocking"]
+
+
+def suggest_move(blocker: str) -> str:
+    """Map a single plan blocker to the recommended next ``devague plan`` move."""
+    if "no tasks yet" in blocker:
+        return 'devague plan task "<summary>" --covers <c*/h*> --accept "<criterion>"'
+    m = re.search(r"coverage target (\w+) ", blocker)
+    if m:
+        tid = m.group(1)
+        return (
+            f'cover {tid}: devague plan task "<summary>" --covers {tid} --accept "<...>"'
+            f"   (or: devague plan cover <tN> --target {tid})"
+        )
+    m = re.search(r"task (t\d+) has no acceptance", blocker)
+    if m:
+        return f'devague plan accept {m.group(1)} "<acceptance criterion>"'
+    m = re.search(r"task (t\d+) still proposed", blocker)
+    if m:
+        tid = m.group(1)
+        return (
+            f"this is an LLM proposal — the USER decides: "
+            f"devague plan confirm {tid} (or reject {tid})"
+        )
+    m = re.search(r"task (t\d+) depends on (?:unknown|rejected) task (t\d+)", blocker)
+    if m:
+        return f"fix {m.group(1)}'s dependency on {m.group(2)} (add it, or drop the dep)"
+    if "dependency cycle" in blocker:
+        return "break the dependency cycle: re-point one task's --dep so the graph is acyclic"
+    m = re.search(r"blocking risk (r\d+)", blocker)
+    if m:
+        return f"resolve {m.group(1)}: cover it with a task, or re-record it as non-blocking"
+    return "devague plan show     # inspect and decide"
+
+
 def evaluate(plan: Plan, targets: Optional[list[CoverageTarget]] = None) -> ConvergenceResult:
     """Evaluate the plan gate against ``targets`` (defaults to the plan's snapshot).
 
@@ -131,7 +170,7 @@ def evaluate(plan: Plan, targets: Optional[list[CoverageTarget]] = None) -> Conv
     snapshot.
     """
     tgs = plan.targets if targets is None else targets
-    missing = (
+    blockers = (
         _missing_tasks(plan)
         + _missing_coverage(plan, tgs)
         + _missing_acceptance(plan)
@@ -139,4 +178,9 @@ def evaluate(plan: Plan, targets: Optional[list[CoverageTarget]] = None) -> Conv
         + _missing_dep_integrity(plan)
         + _missing_risks(plan)
     )
-    return ConvergenceResult(passed=not missing, missing=missing)
+    return ConvergenceResult(
+        ready=not blockers,
+        blockers=blockers,
+        parked_items=_parked_items(plan),
+        required_next_moves=[suggest_move(b) for b in blockers],
+    )

--- a/devague/store.py
+++ b/devague/store.py
@@ -10,10 +10,14 @@ import re
 import time
 from pathlib import Path
 
-from devague.frame import Frame, from_dict, to_dict
+from devague.frame import SCHEMA_VERSION, Frame, from_dict, to_dict
 
 FRAMES_DIR = Path(".devague/frames")
 CURRENT = Path(".devague/current")
+
+
+class IncompatibleSchemaError(ValueError):
+    """A persisted frame declares a schema_version this devague cannot read."""
 
 # A safe slug is a bounded, lowercase, hyphen-separated token with no path
 # separators or `.` segments — so it can never escape FRAMES_DIR / SPECS_DIR.
@@ -73,6 +77,11 @@ def load(slug: str) -> Frame:
         raise FileNotFoundError(slug)
     frame = from_dict(json.loads(p.read_text(encoding="utf-8")))
     validate_slug(frame.slug)  # reject a tampered file whose internal slug escapes
+    if frame.schema_version > SCHEMA_VERSION:
+        raise IncompatibleSchemaError(
+            f"frame {slug!r} uses schema_version {frame.schema_version}, but this "
+            f"devague supports up to {SCHEMA_VERSION}; upgrade devague to read it"
+        )
     return frame
 
 

--- a/devague/store.py
+++ b/devague/store.py
@@ -19,6 +19,7 @@ CURRENT = Path(".devague/current")
 class IncompatibleSchemaError(ValueError):
     """A persisted frame declares a schema_version this devague cannot read."""
 
+
 # A safe slug is a bounded, lowercase, hyphen-separated token with no path
 # separators or `.` segments — so it can never escape FRAMES_DIR / SPECS_DIR.
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,79}$")

--- a/docs/examples/contract-example.json
+++ b/docs/examples/contract-example.json
@@ -1,0 +1,160 @@
+{
+  "slug": "devague-ships-a-documented-spec-contract",
+  "title": "Devague ships a documented spec contract",
+  "schema_version": 1,
+  "status": "converged",
+  "created": "2026-05-23T09:47:05Z",
+  "updated": "2026-05-23T09:47:19Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "Devague ships a documented spec contract",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "c1 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "devague and the assisting LLM",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "c2 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "a vague idea becomes a buildable, validated spec",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "c3 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "framing state was implicit and undocumented",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "c4 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c5",
+      "kind": "success_signal",
+      "text": "a frame exports only after the gate passes",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "c5 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "every frame round-trips losslessly",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "c6 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c7",
+      "kind": "non_goal",
+      "text": "not a full PRD generator",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c8",
+      "kind": "decision",
+      "text": "keep the shipped state x origin vocabulary",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c9",
+      "kind": "assumption",
+      "text": "frames stay small enough to hold in memory",
+      "origin": "llm",
+      "status": "proposed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c10",
+      "kind": "boundary",
+      "text": "no fixed wizard; the move-driven model stays",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "c10 is verifiable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    }
+  ],
+  "open_vagueness": [
+    {
+      "id": "v1",
+      "text": "ship a formal JSON Schema file?",
+      "kind": "follow_up",
+      "claim_id": null
+    }
+  ]
+}

--- a/docs/spec-contract.md
+++ b/docs/spec-contract.md
@@ -1,0 +1,180 @@
+# The Devague spec contract
+
+The durable, reloadable artifact model that turns a vague idea into a
+claim-based, pressure-tested, buildable spec — and the moves that operate on it.
+This document is the **source of truth** for the entity model, the vocabulary,
+the convergence verdict, and the per-move I/O contract (issue #5).
+
+The CLI is deterministic and move-driven: the assisting LLM chooses moves, the
+CLI tracks state. Every move accepts and emits JSON (`--json`), with a strict
+`stdout` (results) / `stderr` (diagnostics) split, so an LLM can drive devague
+without guessing internal state. All operations run fully offline against local
+`.devague/` state.
+
+## Versioning
+
+Every frame carries an integer `schema_version` (currently `1`). It is written
+on save and checked on load: a frame whose `schema_version` is newer than this
+devague supports is rejected, fail-closed, with an actionable error. A 0.4.0
+frame predates the field and loads as the current schema, so existing frames
+keep working.
+
+> **Migration note.** Before this contract, devague (0.4.0) shipped no committed
+> contract document and `converge --json` emitted `{passed, missing}`. This
+> contract supersedes that with the structured convergence result below; the old
+> keys are gone (a deliberate hard break).
+
+## Entities
+
+### Frame
+
+A feature-framing workspace.
+
+- `slug` — filesystem-safe id (lowercase, digits, hyphens).
+- `title` — the announcement headline.
+- `schema_version` — integer; see Versioning.
+- `status` — `drafting` | `converged` | `exported`.
+- `created`, `updated` — ISO-8601 UTC timestamps, stamped on save.
+- `claims` — list of Claim.
+- `open_vagueness` — list of Vagueness.
+
+### Claim
+
+A discrete statement that may become part of the spec.
+
+- `id` — `c1`, `c2`, …
+- `kind` — see Claim kinds.
+- `text` — the statement.
+- `origin` — `user` | `llm` (who proposed it).
+- `status` — `proposed` | `confirmed` | `rejected`.
+- `honesty_conditions` — list of HonestyCondition.
+- `hard_questions` — list of HardQuestion.
+- `links` — related claim ids.
+
+### HonestyCondition
+
+What must be true for a claim to be honest.
+
+- `id` — `h1`, `h2`, …
+- `text` — the condition.
+- `status` — `proposed` | `confirmed` | `rejected`.
+
+### HardQuestion
+
+An unresolved question against a claim.
+
+- `id` — `q1`, `q2`, …
+- `text` — the question.
+- `resolved` — boolean.
+- `blocking` — boolean; a blocking, unresolved question holds back convergence.
+
+### Vagueness
+
+First-class open vagueness — parked uncertainty, not a markdown afterthought.
+
+- `id` — `v1`, `v2`, …
+- `text` — the unknown.
+- `kind` — see Vagueness kinds.
+- `claim_id` — optional owning claim.
+
+## Vocabulary
+
+### Claim kinds
+
+`announcement`, `audience`, `after_state`, `before_state`, `why_it_matters`,
+`boundary`, `success_signal`, `open_question`, `non_goal`, `requirement`,
+`assumption`, `decision`.
+
+Their gate roles:
+
+- **Spec-affecting** (must be confirmed and carry a confirmed honesty condition
+  to converge): `announcement`, `audience`, `after_state`, `before_state`,
+  `why_it_matters`, `boundary`, `success_signal`, `requirement`.
+- **Descriptive** (no honesty condition required, never blocking):
+  `open_question`, `non_goal`, `decision`.
+- **Soft**: an unconfirmed `assumption` is a convergence *warning*, never a
+  blocker.
+
+### Claim states and provenance
+
+State and provenance are orthogonal: `status ∈ {proposed, confirmed, rejected}`
+× `origin ∈ {user, llm}`. The issue's proposed names map onto this model — no
+information is lost and no rename is needed:
+
+| Issue name | This contract |
+|---|---|
+| `user_provided` | a user capture → `(status=confirmed, origin=user)` |
+| `llm_proposed` | `(status=proposed, origin=llm)` |
+| `user_confirmed` | `(status=confirmed)` after an explicit user `confirm` |
+| `rejected` | `status=rejected` |
+| `parked` | a Vagueness entry (not a claim status) |
+
+### Vagueness kinds
+
+`unknown_nonblocking`, `unknown_blocking`, `out_of_scope`, `follow_up`. The
+issue's `unknown_non_blocking` is `unknown_nonblocking`; `intentionally_out_of_scope`
+is `out_of_scope`. Only `unknown_blocking` holds back convergence.
+
+## Convergence result
+
+`converge` returns a structured verdict (not prose-only advice). The frame CLI
+serializes it under `ready_for_spec`; the plan CLI under `ready_for_plan`.
+
+- `ready_for_spec` (bool) — the gate: true when there are no blockers.
+- `blockers` (list) — what holds convergence back.
+- `warnings` (list) — surfaced but non-blocking (e.g. an unconfirmed assumption).
+- `parked_items` (list) — tracked, non-blocking open vagueness.
+- `required_next_moves` (list) — the recommended move per blocker.
+
+A frame converges when there are confirmed `announcement` / `audience` /
+`after_state` claims, a `before_state` or `why_it_matters`, a `boundary`, a
+`success_signal`, a confirmed honesty condition on every spec-affecting claim,
+and no unresolved blocking vagueness or blocking hard question. `export` is gated
+on `ready_for_spec`.
+
+## Moves
+
+All moves take `--json` and `--frame <slug>` (default: the current frame).
+Mutating moves persist immediately and echo the changed entity. On user error
+the exit code is non-zero and `stderr` carries a `hint:` line.
+
+| Move | Input | Output (JSON) | Transition |
+|---|---|---|---|
+| `new "<text>"` | announcement text | frame slug | creates a frame; seeds a confirmed `announcement` claim |
+| `capture --kind K "<text>" [--origin]` | kind, text, origin | `{id, kind, origin, status}` | adds a claim (`llm` → `proposed`, else `confirmed`) |
+| `interrogate <cN> [--honesty/--hard-question/--risk/--contradicts]` | claim id + attachment | `{added: [...]}` | attaches a honesty condition / question (`llm` honesty → `proposed`) |
+| `confirm <id>` / `reject <id>` | claim or honesty id | `{id, status}` | the **only** path to `confirmed` / `rejected` — user-only |
+| `park "<text>" --kind K` | text, vagueness kind | `{id, kind}` | adds first-class open vagueness |
+| `converge` | — | the convergence result | promotes/demotes frame `status` |
+| `export [--format spec-md]` | — | `{path, format}` | writes the spec; requires `ready_for_spec` |
+| `show` / `list` | — | frame dict / slug list | none |
+| `learn` / `explain <move>` | — | method / move help | none |
+
+**Validation errors** (all raise a clean `DevagueError`, exit code 1): unknown
+claim kind / origin / status or vagueness kind (rejected at construction);
+unknown claim or honesty id on `confirm`/`reject`; an invalid `--frame` slug; a
+missing frame; a malformed or hand-edited frame file; a frame whose
+`schema_version` is too new.
+
+## Anti-fabrication guarantee
+
+LLM-proposed claims and honesty conditions persist as `proposed` and require an
+explicit user `confirm` before they affect convergence. Nothing auto-confirms,
+`converge` never mutates a claim's status, and no fixed prompt sequence is
+imposed — the CLI stays a move-driven state tracker.
+
+## Worked example
+
+`docs/examples/contract-example.json` is a real, converged frame exercising the
+full vocabulary (including `requirement`, `non_goal`, `decision`, and an
+unconfirmed `assumption` that surfaces as a warning), plus a parked `follow_up`.
+`tests/test_contract.py::test_contract_example_round_trips_and_converges` proves
+it round-trips losslessly and converges, so this document's model stays honest.
+
+## The plan peer
+
+The plan engine (`devague plan …`) is the structural peer: a Plan holds coverage
+targets derived from a converged frame, Tasks (`origin`/`status` like claims,
+plus `deps`, `covers`, `acceptance_criteria`), and PlanRisks. It reuses the same
+structured convergence result, serialized under `ready_for_plan`. See
+`docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.4.1"
+version = "0.5.0"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_converge_export.py
+++ b/tests/test_cli_converge_export.py
@@ -29,14 +29,14 @@ def test_converge_reports_gaps_then_passes(tmp_path, monkeypatch, capsys) -> Non
     rc = main(["converge", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["passed"] is False and payload["missing"]
+    assert payload["ready_for_spec"] is False and payload["blockers"]
 
     _converged(monkeypatch, tmp_path)
     capsys.readouterr()  # drain _converged output
     rc = main(["converge", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["passed"] is True
+    assert payload["ready_for_spec"] is True
 
 
 def test_export_blocked_until_converged(tmp_path, monkeypatch, capsys) -> None:
@@ -65,7 +65,7 @@ def test_converge_demotes_converged_frame_when_gate_fails(tmp_path, monkeypatch,
     rc = main(["converge", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["passed"] is True
+    assert payload["ready_for_spec"] is True
     assert store.load(store.current_slug()).status == "converged"
     # Add a blocking vagueness item — gate now fails.
     main(["park", "scale?", "--kind", "unknown_blocking"])
@@ -74,7 +74,7 @@ def test_converge_demotes_converged_frame_when_gate_fails(tmp_path, monkeypatch,
     rc = main(["converge", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["passed"] is False
+    assert payload["ready_for_spec"] is False
     assert store.load(store.current_slug()).status == "drafting"
 
 
@@ -106,8 +106,8 @@ def test_converge_llm_honesty_blocks_until_confirmed(tmp_path, monkeypatch, caps
     rc = main(["converge", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["passed"] is False
-    assert any("c2" in m and "honesty" in m for m in payload["missing"])
+    assert payload["ready_for_spec"] is False
+    assert any("c2" in m and "honesty" in m for m in payload["blockers"])
 
     # Discover the honesty id via show --json.
     main(["show", "--json"])
@@ -123,4 +123,4 @@ def test_converge_llm_honesty_blocks_until_confirmed(tmp_path, monkeypatch, caps
     rc = main(["converge", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["passed"] is True
+    assert payload["ready_for_spec"] is True

--- a/tests/test_cli_moves.py
+++ b/tests/test_cli_moves.py
@@ -44,6 +44,31 @@ def test_frame_flag_unknown_slug_errors(tmp_path, monkeypatch, capsys) -> None:
     assert "no such frame" in capsys.readouterr().err.lower()
 
 
+def test_load_malformed_frame_errors_cleanly(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Shipped instant specs"])
+    capsys.readouterr()
+    # Corrupt the persisted frame with an unknown claim kind.
+    p = store.path_for("shipped-instant-specs")
+    p.write_text(p.read_text().replace('"announcement"', '"bogus_kind"', 1), encoding="utf-8")
+    rc = main(["show"])
+    assert rc == 1
+    err = capsys.readouterr().err.lower()
+    assert "malformed" in err and "traceback" not in err
+
+
+def test_load_newer_schema_errors_cleanly(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Shipped instant specs"])
+    capsys.readouterr()
+    p = store.path_for("shipped-instant-specs")
+    p.write_text(p.read_text().replace('"schema_version": 1', '"schema_version": 99'), encoding="utf-8")
+    rc = main(["show"])
+    assert rc == 1
+    err = capsys.readouterr().err.lower()
+    assert "schema_version" in err and "upgrade" in err
+
+
 def test_capture_adds_classified_claim(tmp_path, monkeypatch, capsys) -> None:
     monkeypatch.chdir(tmp_path)
     main(["new", "Shipped instant specs"])

--- a/tests/test_cli_moves.py
+++ b/tests/test_cli_moves.py
@@ -62,7 +62,9 @@ def test_load_newer_schema_errors_cleanly(tmp_path, monkeypatch, capsys) -> None
     main(["new", "Shipped instant specs"])
     capsys.readouterr()
     p = store.path_for("shipped-instant-specs")
-    p.write_text(p.read_text().replace('"schema_version": 1', '"schema_version": 99'), encoding="utf-8")
+    p.write_text(
+        p.read_text().replace('"schema_version": 1', '"schema_version": 99'), encoding="utf-8"
+    )
     rc = main(["show"])
     assert rc == 1
     err = capsys.readouterr().err.lower()

--- a/tests/test_cli_plan.py
+++ b/tests/test_cli_plan.py
@@ -172,7 +172,7 @@ def test_converge_reports_then_passes(tmp_path, monkeypatch, capsys) -> None:
     capsys.readouterr()
     rc = main(["plan", "converge", "--json"])
     assert rc == 0
-    assert json.loads(capsys.readouterr().out)["passed"] is False  # no tasks yet
+    assert json.loads(capsys.readouterr().out)["ready_for_plan"] is False  # no tasks yet
 
     args = ["plan", "task", "all", "--accept", "ok"] + sum(
         (["--covers", t] for t in _ALL_TARGETS), []
@@ -181,7 +181,7 @@ def test_converge_reports_then_passes(tmp_path, monkeypatch, capsys) -> None:
     capsys.readouterr()
     rc = main(["plan", "converge", "--json"])
     assert rc == 0
-    assert json.loads(capsys.readouterr().out)["passed"] is True
+    assert json.loads(capsys.readouterr().out)["ready_for_plan"] is True
     assert plan_store.load(slug).status == "converged"
 
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 
 from devague import store
 from devague.cli import _build_parser, main
 from devague.convergence import evaluate
-from devague.frame import Frame
+from devague.frame import Frame, from_dict, to_dict
+
+CONTRACT_EXAMPLE = (
+    Path(__file__).resolve().parent.parent / "docs" / "examples" / "contract-example.json"
+)
 
 
 def _leaf_parsers(parser: argparse.ArgumentParser, prefix: str = "") -> dict:
@@ -106,3 +111,19 @@ def test_area_convergence_failure_is_structured(tmp_path, monkeypatch) -> None:
     assert res.ready is False
     assert res.blockers  # structured blockers, not prose-only advice
     assert res.required_next_moves  # with a derived next move per blocker
+
+
+# --- t10: the documented contract's worked example round-trips + converges ---
+
+
+def test_contract_example_round_trips_and_converges() -> None:
+    raw = json.loads(CONTRACT_EXAMPLE.read_text(encoding="utf-8"))
+    frame = from_dict(raw)
+    # Lossless round-trip through the dataclasses.
+    assert to_dict(from_dict(to_dict(frame))) == to_dict(frame)
+    # The worked example is a *converged* frame (an unconfirmed assumption is
+    # only a warning, so it does not block).
+    result = evaluate(frame)
+    assert result.ready is True
+    assert any(c.kind == "requirement" for c in frame.claims)  # exercises a new kind
+    assert result.warnings  # the stated-assumption warning is surfaced

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,108 @@
+"""Cross-cutting contract tests for the documented devague spec contract (#5).
+
+Pins the guarantees that span the whole surface: every move speaks JSON (t7),
+LLM proposals never auto-confirm (t9), and the four acceptance areas — claim
+provenance, honesty-condition confirmation, parking vagueness, and convergence
+failure (t11) — each have an explicit test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from devague import store
+from devague.cli import _build_parser, main
+from devague.convergence import evaluate
+from devague.frame import Frame
+
+
+def _leaf_parsers(parser: argparse.ArgumentParser, prefix: str = "") -> dict:
+    out: dict = {}
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for name, sub in action.choices.items():
+                nested = _leaf_parsers(sub, f"{prefix}{name} ")
+                out.update(nested or {f"{prefix}{name}".strip(): sub})
+    return out
+
+
+def _has_json(parser: argparse.ArgumentParser) -> bool:
+    return any("--json" in (a.option_strings or []) for a in parser._actions)
+
+
+# --- t7: every move speaks JSON (c2, h2) -------------------------------------
+
+
+def test_every_move_supports_json() -> None:
+    leaves = _leaf_parsers(_build_parser())
+    missing = sorted(name for name, p in leaves.items() if not _has_json(p))
+    assert missing == [], f"moves missing --json: {missing}"
+    assert len(leaves) >= 24  # the full frame + plan surface is present
+
+
+# --- t9: anti-fabrication — LLM proposals stay proposed (c8, h8) --------------
+
+
+def test_llm_claim_and_honesty_stay_proposed() -> None:
+    f = Frame(slug="s", title="t")
+    c = f.add_claim("requirement", "must round-trip", origin="llm")
+    h = f.add_honesty(c, "is testable", origin="llm")
+    assert c.status == "proposed" and h.status == "proposed"
+
+
+def test_evaluating_never_confirms_a_proposal(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Shipped X"])
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2 proposed
+    capsys.readouterr()
+    evaluate(store.load(store.current_slug()))  # evaluating must not mutate
+    assert store.load(store.current_slug()).find_claim("c2").status == "proposed"
+    main(["confirm", "c2"])  # only an explicit user confirm flips it
+    assert store.load(store.current_slug()).find_claim("c2").status == "confirmed"
+
+
+# --- t11: the four named acceptance areas (c12, h12) -------------------------
+
+
+def _seed(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Shipped X"])  # c1 announcement (confirmed, user origin)
+
+
+def test_area_claim_provenance(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["origin"] == "llm" and payload["status"] == "proposed"
+
+
+def test_area_honesty_confirmation(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["interrogate", "c1", "--honesty", "announcement is true", "--origin", "llm"])
+    capsys.readouterr()
+    f = store.load(store.current_slug())
+    hid = f.claims[0].honesty_conditions[0].id
+    assert f.claims[0].honesty_conditions[0].status == "proposed"
+    main(["confirm", hid])
+    f2 = store.load(store.current_slug())
+    assert f2.claims[0].honesty_conditions[0].status == "confirmed"
+
+
+def test_area_parking_vagueness(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    main(["park", "scale?", "--kind", "unknown_blocking", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "unknown_blocking"
+    res = evaluate(store.load(store.current_slug()))
+    assert res.ready is False and any("blocking vagueness" in b for b in res.blockers)
+
+
+def test_area_convergence_failure_is_structured(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    res = evaluate(store.load(store.current_slug()))
+    assert res.ready is False
+    assert res.blockers  # structured blockers, not prose-only advice
+    assert res.required_next_moves  # with a derived next move per blocker

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -23,40 +23,75 @@ def _full_frame() -> Frame:
 
 def test_full_frame_converges() -> None:
     res = evaluate(_full_frame())
-    assert res.passed is True and res.missing == []
+    assert res.ready is True and res.blockers == []
 
 
 def test_missing_required_kinds_reported() -> None:
     f = Frame(slug="s", title="t")
     f.add_claim("announcement", "x", origin="user")
     res = evaluate(f)
-    assert res.passed is False
-    assert any("audience" in m for m in res.missing)
-    assert any("after_state" in m for m in res.missing)
+    assert res.ready is False
+    assert any("audience" in m for m in res.blockers)
+    assert any("after_state" in m for m in res.blockers)
 
 
 def test_proposed_claim_blocks() -> None:
     f = _full_frame()
     f.add_claim("boundary", "maybe not this", origin="llm")  # proposed
     res = evaluate(f)
-    assert res.passed is False
-    assert any("still proposed" in m for m in res.missing)
+    assert res.ready is False
+    assert any("still proposed" in m for m in res.blockers)
 
 
 def test_confirmed_claim_without_honesty_blocks() -> None:
     f = _full_frame()
     c = f.add_claim("success_signal", "extra signal", origin="user")  # confirmed, no honesty
     res = evaluate(f)
-    assert res.passed is False
-    assert any(c.id in m and "honesty" in m for m in res.missing)
+    assert res.ready is False
+    assert any(c.id in m and "honesty" in m for m in res.blockers)
 
 
 def test_blocking_vagueness_and_hard_question_block() -> None:
     f = _full_frame()
     f.add_vagueness("scale?", "unknown_blocking")
     res = evaluate(f)
-    assert any("blocking vagueness" in m for m in res.missing)
+    assert any("blocking vagueness" in m for m in res.blockers)
     f2 = _full_frame()
     f2.add_hard_question(f2.claims[0], "what if zero?", blocking=True)
     res2 = evaluate(f2)
-    assert any("blocking hard question" in m for m in res2.missing)
+    assert any("blocking hard question" in m for m in res2.blockers)
+
+
+# --- #5 spec contract: gate semantics for the new claim kinds (t4/t5) ---------
+
+
+def test_unconfirmed_assumption_is_warning_not_blocker() -> None:
+    f = _full_frame()
+    f.add_claim("assumption", "frames stay small", origin="llm")  # proposed
+    res = evaluate(f)
+    assert res.ready is True  # an assumption never blocks
+    assert any("assumption" in w for w in res.warnings)
+
+
+def test_requirement_is_spec_affecting() -> None:
+    f = _full_frame()
+    r = f.add_claim("requirement", "must round-trip", origin="user")  # confirmed, no honesty
+    res = evaluate(f)
+    assert res.ready is False
+    assert any(r.id in b and "honesty" in b for b in res.blockers)
+
+
+def test_descriptive_kinds_do_not_block() -> None:
+    f = _full_frame()
+    f.add_claim("non_goal", "not a PRD generator", origin="user")
+    f.add_claim("decision", "keep the shipped vocabulary", origin="user")
+    assert evaluate(f).ready is True  # neither needs a honesty condition
+
+
+def test_structured_result_lists_parked_items() -> None:
+    f = _full_frame()
+    f.add_vagueness("ship a JSON Schema file?", "follow_up")
+    res = evaluate(f)
+    assert res.ready is True
+    assert any("follow_up" in p for p in res.parked_items)
+    assert res.required_next_moves == []  # nothing left to do

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
-from devague.frame import Frame, from_dict, to_dict
+import pytest
+
+from devague.frame import (
+    CLAIM_KINDS,
+    SCHEMA_VERSION,
+    SPEC_AFFECTING_KINDS,
+    Claim,
+    Frame,
+    HonestyCondition,
+    Vagueness,
+    from_dict,
+    to_dict,
+)
 
 
 def test_add_claim_user_is_confirmed_llm_is_proposed() -> None:
@@ -40,3 +52,60 @@ def test_roundtrip_to_from_dict() -> None:
     f2 = from_dict(to_dict(f))
     assert to_dict(f2) == to_dict(f)
     assert f2.claims[0].honesty_conditions[0].text == "cond"
+
+
+# --- #5 spec contract: enriched entity model ----------------------------------
+
+
+def test_new_claim_kinds_present() -> None:
+    for kind in ("non_goal", "requirement", "assumption", "decision"):
+        assert kind in CLAIM_KINDS
+
+
+def test_requirement_is_spec_affecting_descriptive_kinds_are_not() -> None:
+    assert "requirement" in SPEC_AFFECTING_KINDS
+    # Descriptive kinds (and the soft assumption kind) must not demand a honesty
+    # condition / block convergence by being proposed.
+    for kind in ("non_goal", "decision", "open_question", "assumption"):
+        assert kind not in SPEC_AFFECTING_KINDS
+
+
+def test_can_add_new_kind_claims() -> None:
+    f = Frame(slug="s", title="t")
+    r = f.add_claim("requirement", "must persist losslessly", origin="user")
+    n = f.add_claim("non_goal", "not a PRD generator", origin="user")
+    a = f.add_claim("assumption", "frames are small", origin="llm")
+    d = f.add_claim("decision", "keep shipped vocabulary", origin="user")
+    assert (r.kind, n.kind, a.kind, d.kind) == (
+        "requirement",
+        "non_goal",
+        "assumption",
+        "decision",
+    )
+    assert a.status == "proposed"  # llm origin still lands proposed
+
+
+def test_frame_carries_schema_version() -> None:
+    f = Frame(slug="s", title="t")
+    assert f.schema_version == SCHEMA_VERSION
+    assert to_dict(f)["schema_version"] == SCHEMA_VERSION
+    assert from_dict(to_dict(f)).schema_version == SCHEMA_VERSION
+
+
+def test_legacy_frame_without_schema_version_loads() -> None:
+    # A 0.4.0 frame has no schema_version key — it must still load.
+    f = from_dict({"slug": "s", "title": "t", "claims": [], "open_vagueness": []})
+    assert f.schema_version == SCHEMA_VERSION
+
+
+def test_dataclasses_validate_enums() -> None:
+    with pytest.raises(ValueError):
+        Claim(id="c1", kind="bogus", text="x")
+    with pytest.raises(ValueError):
+        Claim(id="c1", kind="audience", text="x", origin="alien")
+    with pytest.raises(ValueError):
+        Claim(id="c1", kind="audience", text="x", status="weird")
+    with pytest.raises(ValueError):
+        Vagueness(id="v1", text="x", kind="nope")
+    with pytest.raises(ValueError):
+        HonestyCondition(id="h1", text="x", status="weird")

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1,0 +1,58 @@
+"""t8: every contract operation runs fully offline — zero network access (c7, h7).
+
+Two guarantees: devague's own source imports no networking library, and a full
+frame -> spec -> plan session runs to completion with ``socket`` access stubbed
+to raise. If any operation reached the network, the session would fail.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+from pathlib import Path
+
+import pytest
+
+from devague import store
+from devague.cli import main
+
+_NET_IMPORT = re.compile(
+    r"^\s*(?:import|from)\s+(socket|ssl|urllib|http|ftplib|requests|httpx|aiohttp)\b",
+    re.MULTILINE,
+)
+
+
+def test_source_imports_no_networking_library() -> None:
+    offenders = [
+        str(py)
+        for py in Path("devague").rglob("*.py")
+        if _NET_IMPORT.search(py.read_text(encoding="utf-8"))
+    ]
+    assert offenders == [], f"networking import found in: {offenders}"
+
+
+@pytest.fixture
+def block_network(monkeypatch):
+    def _boom(*_a, **_k):
+        raise AssertionError("network access attempted during an offline operation")
+
+    monkeypatch.setattr(socket, "socket", _boom)
+    monkeypatch.setattr(socket, "create_connection", _boom)
+
+
+def test_full_session_runs_offline(block_network, tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["new", "Specs in minutes"]) == 0
+    for kind in ("audience", "after_state", "before_state", "boundary", "success_signal"):
+        assert main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"]) == 0
+    # confirm a honesty condition on every confirmed spec-affecting claim
+    for c in store.load(store.current_slug()).claims:
+        assert main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"]) == 0
+    assert main(["converge"]) == 0
+    assert main(["export"]) == 0
+
+    slug = store.current_slug()
+    assert main(["plan", "new", "--frame", slug]) == 0
+    assert main(["plan", "task", "do it", "--accept", "done", "--origin", "user"]) == 0
+    assert main(["show"]) == 0
+    assert main(["list"]) == 0

--- a/tests/test_plan_convergence.py
+++ b/tests/test_plan_convergence.py
@@ -21,21 +21,21 @@ def _converging() -> Plan:
 def test_full_plan_converges() -> None:
     res = evaluate(_converging())
     assert isinstance(res, ConvergenceResult)
-    assert res.passed is True and res.missing == []
+    assert res.ready is True and res.blockers == []
 
 
 def test_no_tasks_blocks() -> None:
     p = Plan(slug="demo", title="Demo", frame_slug="demo")
     res = evaluate(p)
-    assert res.passed is False
-    assert any("no tasks" in m for m in res.missing)
+    assert res.ready is False
+    assert any("no tasks" in m for m in res.blockers)
 
 
 def test_uncovered_target_blocks() -> None:
     p = _converging()
     p.targets.append(CoverageTarget(id="c2", kind="audience", text="who"))
     res = evaluate(p)
-    assert any("c2" in m and "no confirmed task" in m for m in res.missing)
+    assert any("c2" in m and "no confirmed task" in m for m in res.blockers)
 
 
 def test_confirmed_task_without_acceptance_blocks() -> None:
@@ -43,21 +43,21 @@ def test_confirmed_task_without_acceptance_blocks() -> None:
     extra = p.add_task("uncriteria'd")  # confirmed, no acceptance
     extra  # noqa: B018 - referenced for clarity
     res = evaluate(p)
-    assert any("t2" in m and "acceptance" in m for m in res.missing)
+    assert any("t2" in m and "acceptance" in m for m in res.blockers)
 
 
 def test_proposed_task_blocks() -> None:
     p = _converging()
     p.add_task("speculative", origin="llm")  # proposed
     res = evaluate(p)
-    assert any("t2" in m and "still proposed" in m for m in res.missing)
+    assert any("t2" in m and "still proposed" in m for m in res.blockers)
 
 
 def test_dangling_dependency_blocks() -> None:
     p = _converging()
     p.add_dep(p.find_task("t1"), "t99")
     res = evaluate(p)
-    assert any("unknown task t99" in m for m in res.missing)
+    assert any("unknown task t99" in m for m in res.blockers)
 
 
 def test_cycle_blocks_with_deterministic_path() -> None:
@@ -67,7 +67,7 @@ def test_cycle_blocks_with_deterministic_path() -> None:
     p.add_dep(a, "t2")
     p.add_dep(b, "t1")
     res = evaluate(p)
-    assert "dependency cycle: t1 -> t2 -> t1" in res.missing
+    assert "dependency cycle: t1 -> t2 -> t1" in res.blockers
 
 
 def test_active_task_depending_on_rejected_task_blocks() -> None:
@@ -78,7 +78,7 @@ def test_active_task_depending_on_rejected_task_blocks() -> None:
     p.set_status(rejected.id, "rejected")
     p.add_dep(p.find_task("t1"), "t2")
     res = evaluate(p)
-    assert any("t1" in m and "depends on rejected task t2" in m for m in res.missing)
+    assert any("t1" in m and "depends on rejected task t2" in m for m in res.blockers)
 
 
 def test_cycle_among_rejected_tasks_does_not_block() -> None:
@@ -90,27 +90,27 @@ def test_cycle_among_rejected_tasks_does_not_block() -> None:
     p.add_dep(b, "t2")
     p.set_status("t2", "rejected")
     p.set_status("t3", "rejected")
-    assert evaluate(p).passed is True
+    assert evaluate(p).ready is True
 
 
 def test_self_loop_cycle() -> None:
     p = _converging()
     p.add_dep(p.find_task("t1"), "t1")
     res = evaluate(p)
-    assert "dependency cycle: t1 -> t1" in res.missing
+    assert "dependency cycle: t1 -> t1" in res.blockers
 
 
 def test_blocking_risk_blocks() -> None:
     p = _converging()
     p.add_risk("unknown scaling", "unknown_blocking")
     res = evaluate(p)
-    assert any("blocking risk" in m for m in res.missing)
+    assert any("blocking risk" in m for m in res.blockers)
 
 
 def test_nonblocking_risk_does_not_block() -> None:
     p = _converging()
     p.add_risk("minor", "unknown_nonblocking")
-    assert evaluate(p).passed is True
+    assert evaluate(p).ready is True
 
 
 def test_live_targets_override_snapshot() -> None:
@@ -118,4 +118,4 @@ def test_live_targets_override_snapshot() -> None:
     # snapshot is satisfied, but a live extra target is not covered
     live = p.targets + [CoverageTarget(id="c9", kind="boundary", text="non-goal")]
     res = evaluate(p, targets=live)
-    assert any("c9" in m for m in res.missing)
+    assert any("c9" in m for m in res.blockers)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from devague import store
-from devague.frame import Frame
+from devague.frame import SCHEMA_VERSION, Frame, to_dict
 
 
 def test_slugify_caps_and_sanitises() -> None:
@@ -64,3 +66,43 @@ def test_unique_slug_avoids_collision(tmp_path, monkeypatch) -> None:
     assert store.unique_slug("demo") == "demo-2"
     store.save(Frame(slug="demo-2", title="Demo"))
     assert store.unique_slug("demo") == "demo-3"
+
+
+# --- #5 spec contract: schema_version persistence -----------------------------
+
+
+def test_save_writes_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.save(Frame(slug="demo", title="Demo"))
+    raw = json.loads(store.path_for("demo").read_text(encoding="utf-8"))
+    assert raw["schema_version"] == SCHEMA_VERSION
+    assert store.load("demo").schema_version == SCHEMA_VERSION
+
+
+def test_lossless_roundtrip_with_new_kinds(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = Frame(slug="demo", title="Demo")
+    f.add_claim("announcement", "shipped X", origin="user")
+    f.add_claim("requirement", "must round-trip", origin="user")
+    f.add_claim("assumption", "frames stay small", origin="llm")
+    store.save(f)
+    assert to_dict(store.load("demo")) == to_dict(f)
+
+
+def test_load_rejects_newer_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.save(Frame(slug="demo", title="Demo"))
+    p = store.path_for("demo")
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["schema_version"] = SCHEMA_VERSION + 99
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        store.load("demo")
+
+
+def test_load_legacy_frame_without_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.FRAMES_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {"slug": "demo", "title": "Demo", "claims": [], "open_vagueness": []}
+    store.path_for("demo").write_text(json.dumps(legacy), encoding="utf-8")
+    assert store.load("demo").schema_version == SCHEMA_VERSION

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Implements **#5 — Define the Devague spec contract**: the durable, reloadable
artifact model is now enriched, validated, documented, and pressure-tested. Built
from the converged plan in #15 (the `/spec-to-plan` output), task by task, TDD.

Closes #5.

## The 11 plan tasks (one logical commit each)

| Task | What landed |
|---|---|
| t1 | Entity model: claim kinds `non_goal`/`requirement`/`assumption`/`decision`; explicit `SPEC_AFFECTING_KINDS`; `schema_version` field; dataclass enum validation |
| t2 | `schema_version` written on save, **fail-closed** on load (newer → rejected); 0.4.0 frames still load; lossless round-trip |
| t3 | Distinct, actionable load errors (newer-schema → upgrade; malformed → fix hint) — no traceback leaks |
| t4/t5 | **Structured convergence result** `{ready_for_spec, blockers, warnings, parked_items, required_next_moves}` + gate semantics for the new kinds |
| t6 | `/think` + `/spec-to-plan` status helpers consume the new payload (`required_next_moves` now CLI-derived) |
| t7 | Every one of the 26 moves speaks `--json`; `capture` payload now carries `origin` |
| t8 | Offline guarantee: no networking imports; full session runs with sockets stubbed |
| t9 | Anti-fabrication: LLM proposals stay `proposed`; only an explicit user `confirm` flips status; `converge` never mutates |
| t10 | `docs/spec-contract.md` (source of truth) + a test-verified worked example |
| t11 | Contract test suite: the four acceptance areas + round-trip + versioning |

## ⚠ Breaking change

`converge --json` no longer emits `{passed, missing}` — it emits the structured
result above (plans: `ready_for_plan`). This is a deliberate hard break (issue
#5); the only consumers — the two skill status helpers — are updated in the same
PR, so nothing is left dangling.

## Issue #5 acceptance criteria

- [x] A documented spec contract exists in the repo (`docs/spec-contract.md`)
- [x] Contract example for at least one feature frame (`docs/examples/contract-example.json`, test-verified)
- [x] The CLI can create, load, mutate, and display a frame locally
- [x] Core entities are validated (construction + load)
- [x] `converge` returns a structured result with blockers, not prose-only advice
- [x] Tests cover provenance, honesty-condition confirmation, parking vagueness, and convergence failure

## Test plan

- `uv run pytest -n auto` → **179 passing**; coverage **96.75%** (gate 95%).
- `flake8` / `black --check` / `isort --check` clean; `bandit` clean; `pylint` 10.00/10.
- `markdownlint-cli2` clean on all committed markdown.
- Version bumped 0.4.1 → 0.5.0 with a Keep-a-Changelog entry (BREAKING noted).

## Not included (tracked separately)

#13 (parallel-subagent implementation convention) and #14 (review/confirm
questions as `.devague` working state) remain open follow-ups; this PR was built
sequentially, TDD, as agreed.

- devague (Claude)
