### PR TITLE
spec+plan: 0.6.0 Human Review Loop (#17), via /think + /spec-to-plan

### DIFF
--- a/.devague/current_plan
+++ b/.devague/current_plan
@@ -1,1 +1,1 @@
-devague-now-ships-a-documented-spec-contract-every
+devague-0-6-0-ships-the-human-review-loop-devague

--- a/.devague/frames/devague-0-6-0-ships-the-human-review-loop-devague.json
+++ b/.devague/frames/devague-0-6-0-ships-the-human-review-loop-devague.json
@@ -1,0 +1,299 @@
+{
+  "slug": "devague-0-6-0-ships-the-human-review-loop-devague",
+  "title": "devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once \u2014 so honest human review scales to frames full of proposals without ever auto-confirming anything.",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-05-23T11:07:38Z",
+  "updated": "2026-05-23T11:24:24Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once \u2014 so honest human review scales to frames full of proposals without ever auto-confirming anything.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "At 0.6.0 release the announcement is literally true of the shipped CLI: 'devague review' exists, and a frame full of proposed items can be reviewed then bulk confirmed/rejected in one pass with no path that auto-confirms.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "The human operator driving devague who must review and confirm/reject LLM-proposed claims and honesty conditions, plus the assisting LLM agent that produces those proposals.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "Both audiences are served: the operator gets a single review + bulk-decide path, and the LLM agent's proposals stay visibly 'proposed' until the operator explicitly acts.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "In one pass the operator sees every unconfirmed proposal (proposed claims + proposed honesty conditions) without the frame needing to converge, then confirms or rejects many in a single command; pending design questions persist as durable .devague working state to decide later.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "On a non-converged frame, one 'review' shows every proposed item and one 'confirm'/'reject' call resolves a chosen set \u2014 demonstrable end-to-end in a test.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "Review was ad-hoc (hand-rolled from show / show --json) and confirmation was one id per command, so a frame with ~15 proposed conditions meant 15 sequential commands \u2014 pushing toward rubber-stamping instead of genuine review (surfaced dogfooding /think on #5).",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "The before-state pain is real and removed: the pre-0.6.0 flow needed N commands for N conditions with no review artifact; 0.6.0 replaces that with one review plus one bulk decision.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "The user-only confirmation step is devague's whole anti-fabrication guarantee; it must be ergonomic enough to do honestly at scale and support out-of-band review (read proposals somewhere comfortable like NotebookLM or a shared doc, then apply decisions), or it gets skipped or rubber-stamped.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h10",
+          "text": "The anti-fabrication guarantee is preserved exactly: ergonomics improve but no proposal becomes authoritative without an explicit user action, asserted by test.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c6",
+      "kind": "success_signal",
+      "text": "A frame with many proposed items is reviewed and resolved in a single 'devague review' plus one batched confirm/reject, and the test suite proves: review export works before convergence, multi-id confirm/reject works, and no review-flow command auto-confirms a proposal.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "The success signals are verified by the committed test suite, not asserted by hand.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c7",
+      "kind": "boundary",
+      "text": "Scope is the review/confirm UX layered over the existing proposed-vs-confirmed contract (#5/#16); it does not change the state model itself \u2014 proposals still only become authoritative by explicit user action.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "0.6.0 adds only review/confirm UX; the proposed-vs-confirmed state model and convergence gate from #5/#16 are unchanged \u2014 no new claim or condition states are introduced.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c8",
+      "kind": "non_goal",
+      "text": "Does not generate a polished buildable spec from unconfirmed review output \u2014 review output stays explicitly non-authoritative, distinct from what 'export' produces post-convergence.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c9",
+      "kind": "non_goal",
+      "text": "Does not auto-resolve questions and does not auto-confirm any LLM-proposed content anywhere in the review flow.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c10",
+      "kind": "non_goal",
+      "text": "The CLI does not call an LLM.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c11",
+      "kind": "non_goal",
+      "text": "Does not require GitHub, NotebookLM, or any external service.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "'devague review' (and 'devague review --json') emits all proposed claims and proposed honesty conditions, with their ids, without requiring or triggering convergence.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "Running 'devague review' on a frame that has NOT converged still exits 0 and lists every proposed claim and proposed honesty condition with ids; it never invokes the convergence gate nor mutates any claim/condition state.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "Review output is clearly labelled unconfirmed and non-authoritative, visually distinct from the buildable spec that 'export' produces only after convergence.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "The review artifact carries an explicit 'nothing confirmed yet \u2014 non-authoritative' banner and is written to a path under .devague/reviews/<slug>.md, distinct from docs/specs/, so it cannot be mistaken for the buildable spec.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c14",
+      "kind": "requirement",
+      "text": "'devague confirm' accepts multiple claim/honesty ids in one invocation, and 'devague reject' likewise.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "'devague confirm a b c' resolves every listed id in a single call (and 'reject a b c' likewise), and the handling of a batch containing an invalid/unknown id follows one defined, tested rule.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c15",
+      "kind": "requirement",
+      "text": "Open questions / pending user decisions can be written as durable .devague working state (e.g. .devague/questions/<slug>.md), treated as uncommitted working state by default unless the user intentionally promotes one into docs.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "A pending question the CLI writes persists across runs under .devague/questions/<slug>.md, is treated as uncommitted working state by default, and a documented path exists to apply a confirmed decision back into the frame.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c16",
+      "kind": "requirement",
+      "text": "No command in the review flow auto-confirms LLM-proposed content; every confirm/reject stays an explicit user action.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "An automated test asserts that no review-flow command (review, multi-id confirm/reject, any --json path) transitions an llm-origin proposed item to confirmed without an explicit user confirm naming that id.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c17",
+      "kind": "decision",
+      "text": "Batch confirm/reject is TRANSACTIONAL: validate all ids first; if any id is unknown/invalid, resolve none and exit non-zero with a hint \u2014 never a half-applied batch.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c18",
+      "kind": "decision",
+      "text": "'devague confirm --from-review <file>' IS in scope for 0.6.0: it parses a reviewed decision set (confirm/reject per id) from the review artifact and applies it, so the review artifact format must be documented and round-trippable.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c19",
+      "kind": "decision",
+      "text": "devague manages .gitignore: it ensures .devague/reviews/ and .devague/questions/ are git-ignored so review/question state is uncommitted working state by default; the user opts in to promote one into docs.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c20",
+      "kind": "decision",
+      "text": "Pending questions/decisions are produced by a CLI move that writes .devague/questions/<slug>.md and owns the format (first-class + unit-testable), not a hand-written skill artifact.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "'devague confirm --from-review <file>' applies a reviewed decision set parsed from the review artifact; the artifact 'devague review' emits is documented and round-trippable (review -> edit decisions -> apply).",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "A review artifact emitted by 'devague review' can be edited with confirm/reject decisions and fed to 'devague confirm --from-review <file>' to apply exactly those decisions \u2014 proven by a round-trip test \u2014 and applying it still auto-confirms nothing the file did not mark confirmed.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    }
+  ],
+  "open_vagueness": []
+}

--- a/.devague/plans/devague-0-6-0-ships-the-human-review-loop-devague.json
+++ b/.devague/plans/devague-0-6-0-ships-the-human-review-loop-devague.json
@@ -1,0 +1,288 @@
+{
+  "slug": "devague-0-6-0-ships-the-human-review-loop-devague",
+  "title": "devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once \u2014 so honest human review scales to frames full of proposals without ever auto-confirming anything.",
+  "frame_slug": "devague-0-6-0-ships-the-human-review-loop-devague",
+  "status": "exported",
+  "created": "2026-05-23T11:29:36Z",
+  "updated": "2026-05-23T11:32:13Z",
+  "targets": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once \u2014 so honest human review scales to frames full of proposals without ever auto-confirming anything."
+    },
+    {
+      "id": "h6",
+      "kind": "honesty",
+      "text": "At 0.6.0 release the announcement is literally true of the shipped CLI: 'devague review' exists, and a frame full of proposed items can be reviewed then bulk confirmed/rejected in one pass with no path that auto-confirms."
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "The human operator driving devague who must review and confirm/reject LLM-proposed claims and honesty conditions, plus the assisting LLM agent that produces those proposals."
+    },
+    {
+      "id": "h7",
+      "kind": "honesty",
+      "text": "Both audiences are served: the operator gets a single review + bulk-decide path, and the LLM agent's proposals stay visibly 'proposed' until the operator explicitly acts."
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "In one pass the operator sees every unconfirmed proposal (proposed claims + proposed honesty conditions) without the frame needing to converge, then confirms or rejects many in a single command; pending design questions persist as durable .devague working state to decide later."
+    },
+    {
+      "id": "h8",
+      "kind": "honesty",
+      "text": "On a non-converged frame, one 'review' shows every proposed item and one 'confirm'/'reject' call resolves a chosen set \u2014 demonstrable end-to-end in a test."
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "Review was ad-hoc (hand-rolled from show / show --json) and confirmation was one id per command, so a frame with ~15 proposed conditions meant 15 sequential commands \u2014 pushing toward rubber-stamping instead of genuine review (surfaced dogfooding /think on #5)."
+    },
+    {
+      "id": "h9",
+      "kind": "honesty",
+      "text": "The before-state pain is real and removed: the pre-0.6.0 flow needed N commands for N conditions with no review artifact; 0.6.0 replaces that with one review plus one bulk decision."
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "The user-only confirmation step is devague's whole anti-fabrication guarantee; it must be ergonomic enough to do honestly at scale and support out-of-band review (read proposals somewhere comfortable like NotebookLM or a shared doc, then apply decisions), or it gets skipped or rubber-stamped."
+    },
+    {
+      "id": "h10",
+      "kind": "honesty",
+      "text": "The anti-fabrication guarantee is preserved exactly: ergonomics improve but no proposal becomes authoritative without an explicit user action, asserted by test."
+    },
+    {
+      "id": "c6",
+      "kind": "success_signal",
+      "text": "A frame with many proposed items is reviewed and resolved in a single 'devague review' plus one batched confirm/reject, and the test suite proves: review export works before convergence, multi-id confirm/reject works, and no review-flow command auto-confirms a proposal."
+    },
+    {
+      "id": "h11",
+      "kind": "honesty",
+      "text": "The success signals are verified by the committed test suite, not asserted by hand."
+    },
+    {
+      "id": "c7",
+      "kind": "boundary",
+      "text": "Scope is the review/confirm UX layered over the existing proposed-vs-confirmed contract (#5/#16); it does not change the state model itself \u2014 proposals still only become authoritative by explicit user action."
+    },
+    {
+      "id": "h12",
+      "kind": "honesty",
+      "text": "0.6.0 adds only review/confirm UX; the proposed-vs-confirmed state model and convergence gate from #5/#16 are unchanged \u2014 no new claim or condition states are introduced."
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "'devague review' (and 'devague review --json') emits all proposed claims and proposed honesty conditions, with their ids, without requiring or triggering convergence."
+    },
+    {
+      "id": "h1",
+      "kind": "honesty",
+      "text": "Running 'devague review' on a frame that has NOT converged still exits 0 and lists every proposed claim and proposed honesty condition with ids; it never invokes the convergence gate nor mutates any claim/condition state."
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "Review output is clearly labelled unconfirmed and non-authoritative, visually distinct from the buildable spec that 'export' produces only after convergence."
+    },
+    {
+      "id": "h2",
+      "kind": "honesty",
+      "text": "The review artifact carries an explicit 'nothing confirmed yet \u2014 non-authoritative' banner and is written to a path under .devague/reviews/<slug>.md, distinct from docs/specs/, so it cannot be mistaken for the buildable spec."
+    },
+    {
+      "id": "c14",
+      "kind": "requirement",
+      "text": "'devague confirm' accepts multiple claim/honesty ids in one invocation, and 'devague reject' likewise."
+    },
+    {
+      "id": "h3",
+      "kind": "honesty",
+      "text": "'devague confirm a b c' resolves every listed id in a single call (and 'reject a b c' likewise), and the handling of a batch containing an invalid/unknown id follows one defined, tested rule."
+    },
+    {
+      "id": "c15",
+      "kind": "requirement",
+      "text": "Open questions / pending user decisions can be written as durable .devague working state (e.g. .devague/questions/<slug>.md), treated as uncommitted working state by default unless the user intentionally promotes one into docs."
+    },
+    {
+      "id": "h4",
+      "kind": "honesty",
+      "text": "A pending question the CLI writes persists across runs under .devague/questions/<slug>.md, is treated as uncommitted working state by default, and a documented path exists to apply a confirmed decision back into the frame."
+    },
+    {
+      "id": "c16",
+      "kind": "requirement",
+      "text": "No command in the review flow auto-confirms LLM-proposed content; every confirm/reject stays an explicit user action."
+    },
+    {
+      "id": "h5",
+      "kind": "honesty",
+      "text": "An automated test asserts that no review-flow command (review, multi-id confirm/reject, any --json path) transitions an llm-origin proposed item to confirmed without an explicit user confirm naming that id."
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "'devague confirm --from-review <file>' applies a reviewed decision set parsed from the review artifact; the artifact 'devague review' emits is documented and round-trippable (review -> edit decisions -> apply)."
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "A review artifact emitted by 'devague review' can be edited with confirm/reject decisions and fed to 'devague confirm --from-review <file>' to apply exactly those decisions \u2014 proven by a round-trip test \u2014 and applying it still auto-confirms nothing the file did not mark confirmed."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "Multi-id, transactional confirm/reject",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "confirm and reject accept multiple ids (nargs+) in a single invocation",
+        "batch is transactional: if any id is unknown/invalid, resolve none and exit non-zero with a hint (decision c17)",
+        "an all-valid batch resolves every listed id; existing single-id behaviour is unchanged"
+      ],
+      "deps": [],
+      "covers": [
+        "c14",
+        "h3"
+      ]
+    },
+    {
+      "id": "t2",
+      "summary": "'devague review' lists proposed items, un-gated, with no mutation (+ --json)",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "review lists every proposed claim and proposed honesty condition with their ids",
+        "review runs on a NON-converged frame, exits 0, and never invokes the convergence gate",
+        "review never mutates any claim/condition state; review --json emits the same set structured"
+      ],
+      "deps": [],
+      "covers": [
+        "c12",
+        "h1"
+      ]
+    },
+    {
+      "id": "t3",
+      "summary": "Non-authoritative review artifact at .devague/reviews/<slug>.md",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "review writes .devague/reviews/<slug>.md carrying an explicit 'nothing confirmed yet \u2014 non-authoritative' banner",
+        "the path is distinct from docs/specs/ so it cannot be mistaken for the buildable spec",
+        "devague ensures .devague/reviews/ is git-ignored so it is uncommitted working state by default (decision c19)"
+      ],
+      "deps": [
+        "t2"
+      ],
+      "covers": [
+        "c13",
+        "h2"
+      ]
+    },
+    {
+      "id": "t4",
+      "summary": "'confirm --from-review <file>' apply path + documented round-trippable format",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "the review artifact format is documented and round-trippable: review -> edit decisions -> apply",
+        "confirm --from-review parses confirm/reject decisions per id and applies them via the transactional path (t1)",
+        "applying a from-review file auto-confirms nothing the file did not mark confirmed; proven by a round-trip test"
+      ],
+      "deps": [
+        "t1",
+        "t2",
+        "t3"
+      ],
+      "covers": [
+        "c21",
+        "h13"
+      ]
+    },
+    {
+      "id": "t5",
+      "summary": "Pending questions as durable .devague/questions/<slug>.md working state",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "a CLI move writes .devague/questions/<slug>.md that persists across runs and owns the format (decision c20)",
+        "devague ensures .devague/questions/ is git-ignored \u2014 uncommitted working state by default (decision c19)",
+        "a documented path exists to apply a confirmed decision from the questions file back into the frame"
+      ],
+      "deps": [],
+      "covers": [
+        "c15",
+        "h4"
+      ]
+    },
+    {
+      "id": "t6",
+      "summary": "Verification test suite for the review loop",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "a test asserts NO review-flow command (review, multi-id confirm/reject, --from-review, any --json path) confirms an llm-origin proposed item without an explicit user confirm naming that id (c16/h5)",
+        "tests prove review export works before convergence, multi-id confirm/reject works, and the from-review round-trip applies exactly the file's decisions (c6/h11)",
+        "an end-to-end test demonstrates one 'review' + one batched confirm/reject resolving a chosen set on a non-converged frame (c3/h8), and that the anti-fabrication guarantee is preserved (c5/h10)"
+      ],
+      "deps": [
+        "t1",
+        "t2",
+        "t3",
+        "t4",
+        "t5"
+      ],
+      "covers": [
+        "c16",
+        "h5",
+        "c6",
+        "h11",
+        "c5",
+        "h10",
+        "c3",
+        "h8"
+      ]
+    },
+    {
+      "id": "t7",
+      "summary": "Docs, .gitignore/working-state guidance, version bump to 0.6.0 + CHANGELOG",
+      "origin": "user",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "docs explain which .devague/ files are local working state vs artifacts intentionally promoted to docs, and document the review-file format + apply-back path",
+        "an integration check confirms the shipped 0.6.0 CLI makes the announcement literally true: 'devague review' exists and a proposal-heavy frame is reviewed then bulk-resolved with no auto-confirm path (c1/h6, c2/h7, c4/h9)",
+        "verify ONLY review/confirm UX was added \u2014 no new claim/condition states and the #5/#16 convergence gate is unchanged (c7/h12); bump version to 0.6.0 and prepend a CHANGELOG entry"
+      ],
+      "deps": [
+        "t6"
+      ],
+      "covers": [
+        "c1",
+        "h6",
+        "c2",
+        "h7",
+        "c4",
+        "h9",
+        "c7",
+        "h12"
+      ]
+    }
+  ],
+  "risks": [
+    {
+      "id": "r1",
+      "text": "Exact review-file markers for the --from-review round-trip (e.g. checkbox vs CONFIRM/REJECT tokens, how ids are anchored) are unsettled \u2014 to be pinned during implementation of t4.",
+      "kind": "unknown_nonblocking",
+      "task_id": "t4"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-23
+
+### Added
+
+- Spec + plan for the 0.6.0 Human Review Loop milestone (#17, folding in #11 and #14), produced by dogfooding `/think` then `/spec-to-plan` on devague itself. `docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md` (converged frame: 13 confirmed claims, 13 confirmed honesty conditions) and `docs/plans/devague-0-6-0-ships-the-human-review-loop-devague.md` (7 topologically ordered tasks covering all 26 targets, one parked non-blocking risk).
+- Recorded design decisions in the frame: batch confirm/reject is transactional (abort-all on any invalid id); `confirm --from-review` is in scope for 0.6.0; devague manages `.gitignore` for `.devague/reviews/` and `.devague/questions/`; a CLI move (not a hand-written skill artifact) owns the pending-questions file.
+
+### Notes
+
+- Filed #21 — the `spec_md` renderer drops `non_goal` and `decision` claims (lossy export since the #5/#16 contract), surfaced while dogfooding this spec.
+
 ## [0.5.0] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Spec + plan for the 0.6.0 Human Review Loop milestone (#17, folding in #11 and #14), produced by dogfooding `/think` then `/spec-to-plan` on devague itself. `docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md` (converged frame: 13 confirmed claims, 13 confirmed honesty conditions) and `docs/plans/devague-0-6-0-ships-the-human-review-loop-devague.md` (7 topologically ordered tasks covering all 26 targets, one parked non-blocking risk).
 - Recorded design decisions in the frame: batch confirm/reject is transactional (abort-all on any invalid id); `confirm --from-review` is in scope for 0.6.0; devague manages `.gitignore` for `.devague/reviews/` and `.devague/questions/`; a CLI move (not a hand-written skill artifact) owns the pending-questions file.
 
-### Notes
+### Fixed
 
-- Filed #21 — the `spec_md` renderer drops `non_goal` and `decision` claims (lossy export since the #5/#16 contract), surfaced while dogfooding this spec.
+- Renderers were lossy since the #5/#16 contract: `spec_md` rendered "Non-goals" from `boundary` claims only and never emitted `non_goal` / `decision`; `frame_md`'s sections omitted `non_goal` / `requirement` / `assumption` / `decision`. Both now render every claim kind — `spec_md` gains Scope / boundaries, Non-goals, Assumptions, Decisions, and Open questions sections; `frame_md` covers all twelve kinds. Re-exported this spec so the committed md matches the authoritative frame. Closes #21 (also flagged by Qodo on PR #22).
 
 ## [0.5.0] - 2026-05-23
 

--- a/culture.yaml
+++ b/culture.yaml
@@ -1,3 +1,3 @@
 agents:
 - suffix: devague
-  backend: claude
+  backend: claude-code

--- a/devague/render/frame_md.py
+++ b/devague/render/frame_md.py
@@ -10,8 +10,12 @@ _SECTIONS = [
     ("after_state", "After-state experience"),
     ("why_it_matters", "Why it matters"),
     ("before_state", "Before-state pain"),
-    ("boundary", "Boundaries / non-goals"),
+    ("requirement", "Requirements"),
+    ("assumption", "Assumptions"),
     ("success_signal", "Success signals"),
+    ("boundary", "Boundaries"),
+    ("non_goal", "Non-goals"),
+    ("decision", "Decisions"),
     ("open_question", "Open questions"),
 ]
 

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -9,54 +9,53 @@ def _texts(frame: Frame, kind: str) -> list[str]:
     return [c.text for c in frame.claims if c.kind == kind and c.status == "confirmed"]
 
 
+def _section(heading: str, texts: list[str]) -> list[str]:
+    """A standard ``## heading`` + bullet-list block, or nothing when empty."""
+    if not texts:
+        return []
+    return [f"## {heading}", "", *[f"- {t}" for t in texts], ""]
+
+
+def _before_after(frame: Frame) -> list[str]:
+    befores = _texts(frame, "before_state")
+    afters = _texts(frame, "after_state")
+    if not (befores or afters):
+        return []
+    lines = ["## Before → After", ""]
+    lines += [f"- Before: {t}" for t in befores]
+    lines += [f"- After: {t}" for t in afters]
+    return lines + [""]
+
+
+def _confirmed_honesty(frame: Frame) -> list[str]:
+    return [h.text for c in frame.claims for h in c.honesty_conditions if h.status == "confirmed"]
+
+
+def _hard_questions(frame: Frame) -> list[str]:
+    hqs = [q for c in frame.claims for q in c.hard_questions]
+    bullets = [f"- {q.text}" + (" (blocking)" if q.blocking else "") for q in hqs]
+    return ["## Hard questions", "", *bullets, ""] if hqs else []
+
+
+def _follow_up(frame: Frame) -> list[str]:
+    return [v.text for v in frame.open_vagueness if v.kind in ("follow_up", "out_of_scope")]
+
+
 def render_spec(frame: Frame) -> str:
     out: list[str] = [f"# {frame.title}", ""]
     ann = _texts(frame, "announcement")
     if ann:
         out += ["> " + ann[0], ""]
-    aud = _texts(frame, "audience")
-    if aud:
-        out += ["## Audience", "", *[f"- {t}" for t in aud], ""]
-    befores = _texts(frame, "before_state")
-    afters = _texts(frame, "after_state")
-    if befores or afters:
-        out += ["## Before → After", ""]
-        out += [f"- Before: {t}" for t in befores]
-        out += [f"- After: {t}" for t in afters]
-        out.append("")
-    why = _texts(frame, "why_it_matters")
-    if why:
-        out += ["## Why it matters", "", *[f"- {t}" for t in why], ""]
-    reqs = [h.text for c in frame.claims for h in c.honesty_conditions if h.status == "confirmed"]
-    if reqs:
-        out += ["## Requirements / honesty conditions", "", *[f"- {t}" for t in reqs], ""]
-    succ = _texts(frame, "success_signal")
-    if succ:
-        out += ["## Success signals", "", *[f"- {t}" for t in succ], ""]
-    bnd = _texts(frame, "boundary")
-    if bnd:
-        out += ["## Scope / boundaries", "", *[f"- {t}" for t in bnd], ""]
-    nongoals = _texts(frame, "non_goal")
-    if nongoals:
-        out += ["## Non-goals", "", *[f"- {t}" for t in nongoals], ""]
-    assumptions = _texts(frame, "assumption")
-    if assumptions:
-        out += ["## Assumptions", "", *[f"- {t}" for t in assumptions], ""]
-    decisions = _texts(frame, "decision")
-    if decisions:
-        out += ["## Decisions", "", *[f"- {t}" for t in decisions], ""]
-    hqs = [q for c in frame.claims for q in c.hard_questions]
-    if hqs:
-        out += [
-            "## Hard questions",
-            "",
-            *[f"- {q.text}" + (" (blocking)" if q.blocking else "") for q in hqs],
-            "",
-        ]
-    oqs = _texts(frame, "open_question")
-    if oqs:
-        out += ["## Open questions", "", *[f"- {t}" for t in oqs], ""]
-    follow = [v.text for v in frame.open_vagueness if v.kind in ("follow_up", "out_of_scope")]
-    if follow:
-        out += ["## Open / follow-up", "", *[f"- {t}" for t in follow], ""]
+    out += _section("Audience", _texts(frame, "audience"))
+    out += _before_after(frame)
+    out += _section("Why it matters", _texts(frame, "why_it_matters"))
+    out += _section("Requirements / honesty conditions", _confirmed_honesty(frame))
+    out += _section("Success signals", _texts(frame, "success_signal"))
+    out += _section("Scope / boundaries", _texts(frame, "boundary"))
+    out += _section("Non-goals", _texts(frame, "non_goal"))
+    out += _section("Assumptions", _texts(frame, "assumption"))
+    out += _section("Decisions", _texts(frame, "decision"))
+    out += _hard_questions(frame)
+    out += _section("Open questions", _texts(frame, "open_question"))
+    out += _section("Open / follow-up", _follow_up(frame))
     return "\n".join(out).rstrip() + "\n"

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -35,7 +35,16 @@ def render_spec(frame: Frame) -> str:
         out += ["## Success signals", "", *[f"- {t}" for t in succ], ""]
     bnd = _texts(frame, "boundary")
     if bnd:
-        out += ["## Non-goals", "", *[f"- {t}" for t in bnd], ""]
+        out += ["## Scope / boundaries", "", *[f"- {t}" for t in bnd], ""]
+    nongoals = _texts(frame, "non_goal")
+    if nongoals:
+        out += ["## Non-goals", "", *[f"- {t}" for t in nongoals], ""]
+    assumptions = _texts(frame, "assumption")
+    if assumptions:
+        out += ["## Assumptions", "", *[f"- {t}" for t in assumptions], ""]
+    decisions = _texts(frame, "decision")
+    if decisions:
+        out += ["## Decisions", "", *[f"- {t}" for t in decisions], ""]
     hqs = [q for c in frame.claims for q in c.hard_questions]
     if hqs:
         out += [
@@ -44,6 +53,9 @@ def render_spec(frame: Frame) -> str:
             *[f"- {q.text}" + (" (blocking)" if q.blocking else "") for q in hqs],
             "",
         ]
+    oqs = _texts(frame, "open_question")
+    if oqs:
+        out += ["## Open questions", "", *[f"- {t}" for t in oqs], ""]
     follow = [v.text for v in frame.open_vagueness if v.kind in ("follow_up", "out_of_scope")]
     if follow:
         out += ["## Open / follow-up", "", *[f"- {t}" for t in follow], ""]

--- a/docs/plans/devague-0-6-0-ships-the-human-review-loop-devague.md
+++ b/docs/plans/devague-0-6-0-ships-the-human-review-loop-devague.md
@@ -1,0 +1,71 @@
+# Build Plan — devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once — so honest human review scales to frames full of proposals without ever auto-confirming anything
+
+slug: `devague-0-6-0-ships-the-human-review-loop-devague` · status: `exported` · from frame: `devague-0-6-0-ships-the-human-review-loop-devague`
+
+> devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once — so honest human review scales to frames full of proposals without ever auto-confirming anything.
+
+## Tasks
+
+### t1 — Multi-id, transactional confirm/reject
+
+- covers: c14, h3
+- acceptance:
+  - confirm and reject accept multiple ids (nargs+) in a single invocation
+  - batch is transactional: if any id is unknown/invalid, resolve none and exit non-zero with a hint (decision c17)
+  - an all-valid batch resolves every listed id; existing single-id behaviour is unchanged
+
+### t2 — 'devague review' lists proposed items, un-gated, with no mutation (+ --json)
+
+- covers: c12, h1
+- acceptance:
+  - review lists every proposed claim and proposed honesty condition with their ids
+  - review runs on a NON-converged frame, exits 0, and never invokes the convergence gate
+  - review never mutates any claim/condition state; review --json emits the same set structured
+
+### t3 — Non-authoritative review artifact at `.devague/reviews/<slug>.md`
+
+- depends on: t2
+- covers: c13, h2
+- acceptance:
+  - review writes `.devague/reviews/<slug>.md` carrying an explicit 'nothing confirmed yet — non-authoritative' banner
+  - the path is distinct from docs/specs/ so it cannot be mistaken for the buildable spec
+  - devague ensures .devague/reviews/ is git-ignored so it is uncommitted working state by default (decision c19)
+
+### t4 — `confirm --from-review <file>` apply path + documented round-trippable format
+
+- depends on: t1, t2, t3
+- covers: c21, h13
+- acceptance:
+  - the review artifact format is documented and round-trippable: review -> edit decisions -> apply
+  - confirm --from-review parses confirm/reject decisions per id and applies them via the transactional path (t1)
+  - applying a from-review file auto-confirms nothing the file did not mark confirmed; proven by a round-trip test
+
+### t5 — Pending questions as durable `.devague/questions/<slug>.md` working state
+
+- covers: c15, h4
+- acceptance:
+  - a CLI move writes `.devague/questions/<slug>.md` that persists across runs and owns the format (decision c20)
+  - devague ensures .devague/questions/ is git-ignored — uncommitted working state by default (decision c19)
+  - a documented path exists to apply a confirmed decision from the questions file back into the frame
+
+### t6 — Verification test suite for the review loop
+
+- depends on: t1, t2, t3, t4, t5
+- covers: c16, h5, c6, h11, c5, h10, c3, h8
+- acceptance:
+  - a test asserts NO review-flow command (review, multi-id confirm/reject, --from-review, any --json path) confirms an llm-origin proposed item without an explicit user confirm naming that id (c16/h5)
+  - tests prove review export works before convergence, multi-id confirm/reject works, and the from-review round-trip applies exactly the file's decisions (c6/h11)
+  - an end-to-end test demonstrates one 'review' + one batched confirm/reject resolving a chosen set on a non-converged frame (c3/h8), and that the anti-fabrication guarantee is preserved (c5/h10)
+
+### t7 — Docs, .gitignore/working-state guidance, version bump to 0.6.0 + CHANGELOG
+
+- depends on: t6
+- covers: c1, h6, c2, h7, c4, h9, c7, h12
+- acceptance:
+  - docs explain which .devague/ files are local working state vs artifacts intentionally promoted to docs, and document the review-file format + apply-back path
+  - an integration check confirms the shipped 0.6.0 CLI makes the announcement literally true: 'devague review' exists and a proposal-heavy frame is reviewed then bulk-resolved with no auto-confirm path (c1/h6, c2/h7, c4/h9)
+  - verify ONLY review/confirm UX was added — no new claim/condition states and the #5/#16 convergence gate is unchanged (c7/h12); bump version to 0.6.0 and prepend a CHANGELOG entry
+
+## Risks
+
+- [unknown_nonblocking] Exact review-file markers for the --from-review round-trip (e.g. checkbox vs CONFIRM/REJECT tokens, how ids are anchored) are unsettled — to be pinned during implementation of t4. (task t4)

--- a/docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md
+++ b/docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md
@@ -1,0 +1,40 @@
+# devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once — so honest human review scales to frames full of proposals without ever auto-confirming anything
+
+> devague 0.6.0 ships the Human Review Loop: 'devague review' surfaces every unconfirmed LLM proposal in one pass, and confirm/reject now take many ids at once — so honest human review scales to frames full of proposals without ever auto-confirming anything.
+
+## Audience
+
+- The human operator driving devague who must review and confirm/reject LLM-proposed claims and honesty conditions, plus the assisting LLM agent that produces those proposals.
+
+## Before → After
+
+- Before: Review was ad-hoc (hand-rolled from show / show --json) and confirmation was one id per command, so a frame with ~15 proposed conditions meant 15 sequential commands — pushing toward rubber-stamping instead of genuine review (surfaced dogfooding /think on #5).
+- After: In one pass the operator sees every unconfirmed proposal (proposed claims + proposed honesty conditions) without the frame needing to converge, then confirms or rejects many in a single command; pending design questions persist as durable .devague working state to decide later.
+
+## Why it matters
+
+- The user-only confirmation step is devague's whole anti-fabrication guarantee; it must be ergonomic enough to do honestly at scale and support out-of-band review (read proposals somewhere comfortable like NotebookLM or a shared doc, then apply decisions), or it gets skipped or rubber-stamped.
+
+## Requirements / honesty conditions
+
+- At 0.6.0 release the announcement is literally true of the shipped CLI: 'devague review' exists, and a frame full of proposed items can be reviewed then bulk confirmed/rejected in one pass with no path that auto-confirms.
+- Both audiences are served: the operator gets a single review + bulk-decide path, and the LLM agent's proposals stay visibly 'proposed' until the operator explicitly acts.
+- On a non-converged frame, one 'review' shows every proposed item and one 'confirm'/'reject' call resolves a chosen set — demonstrable end-to-end in a test.
+- The before-state pain is real and removed: the pre-0.6.0 flow needed N commands for N conditions with no review artifact; 0.6.0 replaces that with one review plus one bulk decision.
+- The anti-fabrication guarantee is preserved exactly: ergonomics improve but no proposal becomes authoritative without an explicit user action, asserted by test.
+- The success signals are verified by the committed test suite, not asserted by hand.
+- 0.6.0 adds only review/confirm UX; the proposed-vs-confirmed state model and convergence gate from #5/#16 are unchanged — no new claim or condition states are introduced.
+- Running 'devague review' on a frame that has NOT converged still exits 0 and lists every proposed claim and proposed honesty condition with ids; it never invokes the convergence gate nor mutates any claim/condition state.
+- The review artifact carries an explicit 'nothing confirmed yet — non-authoritative' banner and is written to a path under `.devague/reviews/<slug>.md`, distinct from docs/specs/, so it cannot be mistaken for the buildable spec.
+- 'devague confirm a b c' resolves every listed id in a single call (and 'reject a b c' likewise), and the handling of a batch containing an invalid/unknown id follows one defined, tested rule.
+- A pending question the CLI writes persists across runs under `.devague/questions/<slug>.md`, is treated as uncommitted working state by default, and a documented path exists to apply a confirmed decision back into the frame.
+- An automated test asserts that no review-flow command (review, multi-id confirm/reject, any --json path) transitions an llm-origin proposed item to confirmed without an explicit user confirm naming that id.
+- A review artifact emitted by 'devague review' can be edited with confirm/reject decisions and fed to `devague confirm --from-review <file>` to apply exactly those decisions — proven by a round-trip test — and applying it still auto-confirms nothing the file did not mark confirmed.
+
+## Success signals
+
+- A frame with many proposed items is reviewed and resolved in a single 'devague review' plus one batched confirm/reject, and the test suite proves: review export works before convergence, multi-id confirm/reject works, and no review-flow command auto-confirms a proposal.
+
+## Non-goals
+
+- Scope is the review/confirm UX layered over the existing proposed-vs-confirmed contract (#5/#16); it does not change the state model itself — proposals still only become authoritative by explicit user action.

--- a/docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md
+++ b/docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md
@@ -35,6 +35,20 @@
 
 - A frame with many proposed items is reviewed and resolved in a single 'devague review' plus one batched confirm/reject, and the test suite proves: review export works before convergence, multi-id confirm/reject works, and no review-flow command auto-confirms a proposal.
 
-## Non-goals
+## Scope / boundaries
 
 - Scope is the review/confirm UX layered over the existing proposed-vs-confirmed contract (#5/#16); it does not change the state model itself — proposals still only become authoritative by explicit user action.
+
+## Non-goals
+
+- Does not generate a polished buildable spec from unconfirmed review output — review output stays explicitly non-authoritative, distinct from what 'export' produces post-convergence.
+- Does not auto-resolve questions and does not auto-confirm any LLM-proposed content anywhere in the review flow.
+- The CLI does not call an LLM.
+- Does not require GitHub, NotebookLM, or any external service.
+
+## Decisions
+
+- Batch confirm/reject is TRANSACTIONAL: validate all ids first; if any id is unknown/invalid, resolve none and exit non-zero with a hint — never a half-applied batch.
+- `devague confirm --from-review <file>` IS in scope for 0.6.0: it parses a reviewed decision set (confirm/reject per id) from the review artifact and applies it, so the review artifact format must be documented and round-trippable.
+- devague manages .gitignore: it ensures .devague/reviews/ and .devague/questions/ are git-ignored so review/question state is uncommitted working state by default; the user opts in to promote one into docs.
+- Pending questions/decisions are produced by a CLI move that writes `.devague/questions/<slug>.md` and owns the format (first-class + unit-testable), not a hand-written skill artifact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.5.0"
+version = "0.5.1"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -76,6 +76,50 @@ def test_spec_md_omits_empty_before_after_section() -> None:
     assert "## Before → After" not in out
 
 
+def _rich_frame() -> Frame:
+    """A frame exercising the kinds added by the #5/#16 contract."""
+    f = Frame(slug="r", title="Rich Feature")
+    f.add_claim("announcement", "Shipped", origin="user")
+    f.add_claim("boundary", "scope is X only", origin="user")
+    f.add_claim("non_goal", "does not call an LLM", origin="user")
+    f.add_claim("non_goal", "no external services", origin="user")
+    f.add_claim("assumption", "frames fit in memory", origin="user")
+    f.add_claim("decision", "batch is transactional", origin="user")
+    req = f.add_claim("requirement", "review lists proposed items", origin="user")
+    f.add_honesty(req, "review never mutates state", origin="user")
+    return f
+
+
+def test_spec_md_renders_non_goal_and_decision() -> None:
+    # Regression for #21 / Qodo: spec-md must not silently drop non_goal + decision.
+    out = render.render(_rich_frame(), "spec-md")
+    assert "## Non-goals" in out
+    assert "does not call an LLM" in out
+    assert "no external services" in out
+    assert "## Decisions" in out
+    assert "batch is transactional" in out
+    assert "## Assumptions" in out
+    assert "frames fit in memory" in out
+    # boundary keeps its own section, distinct from non-goals
+    assert "## Scope / boundaries" in out
+    assert "scope is X only" in out
+    assert_markdownlint_clean(out)
+
+
+def test_frame_md_renders_non_goal_and_decision() -> None:
+    out = render.render(_rich_frame(), "frame-md")
+    for needle in (
+        "## Non-goals",
+        "does not call an LLM",
+        "## Decisions",
+        "batch is transactional",
+        "## Requirements",
+        "## Assumptions",
+    ):
+        assert needle in out, needle
+    assert_markdownlint_clean(out)
+
+
 def test_unknown_format_raises() -> None:
     with pytest.raises(DevagueError):
         render.render(_frame(), "nope")


### PR DESCRIPTION
## What

Dogfoods devague on itself to **spec and plan the 0.6.0 Human Review Loop** (#17),
folding in **#11** (review-export + batch confirm/reject) and **#14** (pending
questions as durable `.devague/` working state). Produced with `/think` then
`/spec-to-plan` — no hand-authored spec.

This PR adds **planning artifacts only** (no 0.6.0 feature code yet) plus a patch
version bump.

## Artifacts

- `docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md` — converged
  frame: 13 confirmed claims, each pressure-tested with a confirmed honesty
  condition (13 total).
- `docs/plans/devague-0-6-0-ships-the-human-review-loop-devague.md` — 7
  topologically ordered tasks covering all **26** coverage targets, each with
  acceptance criteria; one parked non-blocking risk (the `--from-review`
  review-file markers).
- Frame + plan state under `.devague/`, `CHANGELOG.md`, version `0.5.0 → 0.5.1`.

## Decisions captured during `/think`

Surfaced as genuine forks and decided by the user (the #14 spirit — pending
decisions belong to the human):

| Fork | Decision |
|------|----------|
| Batch confirm/reject atomicity | **Transactional** — validate all ids first; any invalid id ⇒ resolve none, exit non-zero |
| `confirm --from-review <file>` | **In scope for 0.6.0** — documented, round-trippable artifact format |
| `.devague/` working state | **devague manages `.gitignore`** for `reviews/` and `questions/` (uncommitted by default) |
| Pending-questions producer | **A CLI move owns it** (writes `.devague/questions/<slug>.md`), not a hand-written skill artifact |

## The plan, briefly

`t1` multi-id transactional confirm/reject → `t2` `devague review` (un-gated, no
mutation) → `t3` non-authoritative review artifact → `t4` `--from-review` apply
path → `t5` pending-questions working state → `t6` verification suite
(no-auto-confirm invariant, review-before-convergence, round-trip) → `t7` docs +
`.gitignore` guidance + version bump.

## Side finding

Filed **#21** — the `spec_md` renderer silently drops `non_goal` and `decision`
claims (lossy export since the #5/#16 contract), discovered while exporting this
very spec. The frame JSON is complete; only the rendered view is missing kinds.

## Notes for review

- The session itself demonstrated the problem #17 fixes: confirming 13 honesty
  conditions required **13 separate `confirm` commands** because `confirm`
  rejects multiple ids today.
- The exported md was hand-tweaked **only** for markdownlint compliance
  (trailing-period H1; `<slug>`/`<file>` placeholders wrapped in backticks); the
  `.devague/*.json` state is authoritative.

Closes #17 (spec+plan phase). Advances #11 and #14.

- devague (Claude)
