### PR TITLE
feat: implement the 0.6.0 Human Review Loop (#17)

### DIFF
--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -58,7 +58,9 @@ portable resolution and the `status` helper.
 | `new "<announcement>"` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. |
 | `capture --kind <kind> "<text>"` | Record + classify a claim. `--origin llm` lands it as `proposed`. |
 | `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. |
-| `confirm <id>` / `reject <id>` | Resolve a claim (`c*`) or honesty condition (`h*`). **User-only decision.** |
+| `confirm <id> [<id>…]` / `reject <id> [<id>…]` | Resolve one or more claims (`c*`) / honesty conditions (`h*`) in one **transactional** call. **User-only decision.** Also `confirm --from-review <file>` to apply an edited review artifact. |
+| `review` | List every **proposed** (unconfirmed) claim + honesty condition with ids (`--json` too); writes a non-authoritative artifact to `.devague/reviews/<slug>.md`. Un-gated; never mutates. |
+| `question "<text>"` | Record / list / `--resolve` a pending user decision as durable working state in `.devague/questions/<slug>.md`. |
 | `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
 | `converge` | Evaluate the gate; list remaining gaps. |
 | `export` | Write the buildable spec to `docs/specs/` — only after `converge` passes. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-23
+
+### Added
+
+- **Human Review Loop (#17).** Makes the user-only confirmation step ergonomic at scale, preserving the anti-fabrication guarantee.
+  - `devague review` (+ `--json`) lists every proposed (unconfirmed) claim and honesty condition with ids — un-gated by convergence and without mutating state — and persists a non-authoritative artifact to `.devague/reviews/<slug>.md`.
+  - `confirm` / `reject` now accept multiple ids in one transactional call (any unknown id ⇒ nothing changes).
+  - `confirm --from-review <file>` applies a reviewed decision set: each item is emitted with a `pending` marker the human edits to `confirm`/`reject`; `pending` lines are never auto-confirmed (round-trippable artifact).
+  - `devague question` records / lists / resolves pending user decisions as durable working state in `.devague/questions/<slug>.md`.
+  - devague manages `.gitignore` so `.devague/reviews/` and `.devague/questions/` stay uncommitted working state by default.
+
+### Changed
+
+- `confirm --json` now emits `{confirmed, rejected}` (lists) instead of `{id, status}`, reflecting the multi-id, transactional batch.
+
 ## [0.5.1] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
+**Human Review Loop landed (0.6.0, #17).** `devague review` (+ `--json`) lists
+every proposed claim + honesty condition with ids — un-gated by convergence,
+never mutating state — and writes a non-authoritative artifact to
+`.devague/reviews/<slug>.md`. `confirm` / `reject` now take multiple ids in one
+**transactional** call; `confirm --from-review <file>` applies an edited review
+artifact (`pending` lines are never auto-confirmed). `devague question` records
+pending decisions in `.devague/questions/<slug>.md`. devague manages
+`.gitignore` so `reviews/` and `questions/` stay uncommitted working state.
+
 **Spec contract landed (#5).** The entity model is documented in
 `docs/spec-contract.md` (the source of truth for kinds, the `(state × origin)`
 vocabulary, the structured convergence result, and the per-move I/O contract).
@@ -16,8 +25,9 @@ required_next_moves}` (plans: `ready_for_plan`) — a hard break from the old
 **Spec→plan engine landed (v0.4.0).** Both deterministic engines now ship.
 The **frame engine** (idea→spec) — Frame domain model, JSON store, convergence
 gate, renderer registry, and the flat moves `new` / `capture` / `interrogate` /
-`confirm` / `reject` / `park` / `converge` / `export` / `show` / `list` /
-`learn` / `explain`. The **plan engine** (spec→plan) is its structural peer:
+`confirm` / `reject` / `review` / `question` / `park` / `converge` / `export` /
+`show` / `list` / `learn` / `explain`. The **plan engine** (spec→plan) is its
+structural peer:
 `devague/plan.py`, `plan_convergence.py`, `plan_store.py`, `render/plan_md.py`,
 and the nested group `devague plan <move>` (`new` / `task` / `accept` / `depend`
 / `cover` / `confirm` / `reject` / `risk` / `converge` / `export` / `show` /

--- a/README.md
+++ b/README.md
@@ -32,6 +32,50 @@ devague --version
 Run `devague learn` (or `devague plan learn`) to learn the method, and `devague
 explain <move>` for any single move.
 
+## Human Review Loop
+
+LLM-proposed claims and honesty conditions stay `proposed` until **you**
+confirm them — that anti-fabrication rule is the point of the method. The review
+loop makes that human step ergonomic at scale:
+
+```bash
+devague review                 # list every proposed (unconfirmed) item, with ids
+devague review --json          # same, structured
+devague confirm c2 h1 h3       # confirm many ids in one transactional call
+devague reject c4 c5           # reject many ids in one call
+devague confirm --from-review .devague/reviews/<slug>.md   # apply an edited review file
+```
+
+`review` is **not** gated on convergence and never mutates state. It writes a
+durable, explicitly non-authoritative artifact you can review out of band, then
+apply: each item is emitted with a `pending` marker — change it to `confirm` or
+`reject` and feed the file back with `confirm --from-review`. `pending` lines are
+never auto-confirmed; a batch is transactional (one bad id ⇒ nothing changes).
+
+Open questions / pending decisions live as durable working state too:
+
+```bash
+devague question "should batch confirm be transactional?"   # record a pending decision
+devague question --list                                     # review them
+devague question --resolve q1 --decision "yes, transactional"
+```
+
+Applying a resolved decision into the frame stays an explicit move (e.g.
+`devague capture --kind decision "…"` then `devague confirm`).
+
+### `.devague/` — what's committed vs working state
+
+| Path | Committed? |
+|------|-----------|
+| `.devague/frames/`, `.devague/plans/` | yes — the converged frame/plan state |
+| `.devague/reviews/<slug>.md` | no — local review working state |
+| `.devague/questions/<slug>.md` | no — local pending-decision working state |
+| `.devague/current`, `.devague/current_plan` | no — local pointers |
+
+devague keeps `reviews/` and `questions/` out of git for you (it manages
+`.gitignore`). Promote one into `docs/` only if you intentionally want it
+committed.
+
 ## Driving it from an agent
 
 Inside AgentCulture, an assistant drives this CLI through two operator skills —

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -66,6 +66,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import park as _park_cmd
     from devague.cli._commands import plan as _plan_cmd
     from devague.cli._commands import reject as _reject_cmd
+    from devague.cli._commands import review as _review_cmd
     from devague.cli._commands import show as _show_cmd
 
     _learn_cmd.register(sub)
@@ -75,6 +76,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _interrogate_cmd.register(sub)
     _confirm_cmd.register(sub)
     _reject_cmd.register(sub)
+    _review_cmd.register(sub)
     _park_cmd.register(sub)
     _converge_cmd.register(sub)
     _export_cmd.register(sub)

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -65,6 +65,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import new as _new_cmd
     from devague.cli._commands import park as _park_cmd
     from devague.cli._commands import plan as _plan_cmd
+    from devague.cli._commands import question as _question_cmd
     from devague.cli._commands import reject as _reject_cmd
     from devague.cli._commands import review as _review_cmd
     from devague.cli._commands import show as _show_cmd
@@ -77,6 +78,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _confirm_cmd.register(sub)
     _reject_cmd.register(sub)
     _review_cmd.register(sub)
+    _question_cmd.register(sub)
     _park_cmd.register(sub)
     _converge_cmd.register(sub)
     _export_cmd.register(sub)

--- a/devague/cli/_commands/confirm.py
+++ b/devague/cli/_commands/confirm.py
@@ -1,4 +1,9 @@
-"""``devague confirm`` — confirm a claim or honesty condition (user-only transition)."""
+"""``devague confirm`` — confirm claims/honesty conditions (user-only transition).
+
+Accepts one or more ids in a single call. The batch is **transactional**: every
+id is validated first, and if any is unknown nothing is changed (no half-applied
+batch). Confirmation stays a user-only action — see issue #17.
+"""
 
 from __future__ import annotations
 
@@ -10,19 +15,27 @@ from devague.cli._frames import resolve
 from devague.cli._output import emit_result
 
 
+def _exists(frame, item_id: str) -> bool:
+    return frame.find_claim(item_id) is not None or frame.find_honesty(item_id) is not None
+
+
 def _transition(args: argparse.Namespace, status: str) -> int:
     frame = resolve(args.frame)
-    if not frame.set_status(args.id, status):
+    ids: list[str] = args.ids
+    unknown = [i for i in ids if not _exists(frame, i)]
+    if unknown:
         raise DevagueError(
             EXIT_USER_ERROR,
-            f"no such claim or honesty condition: {args.id}",
-            "run 'devague show'",
+            f"no such claim or honesty condition: {', '.join(unknown)}",
+            "run 'devague show'; the batch is transactional — nothing was changed",
         )
+    for item_id in ids:
+        frame.set_status(item_id, status)
     store.save(frame)
     if getattr(args, "json", False):
-        emit_result({"id": args.id, "status": status}, json_mode=True)
+        emit_result({"ids": ids, "status": status}, json_mode=True)
     else:
-        emit_result(f"{args.id} -> {status}", json_mode=False)
+        emit_result("\n".join(f"{i} -> {status}" for i in ids), json_mode=False)
     return 0
 
 
@@ -31,8 +44,8 @@ def cmd_confirm(args: argparse.Namespace) -> int:
 
 
 def register(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("confirm", help="Confirm a claim or honesty condition.")
-    p.add_argument("id", help="Claim id (c*) or honesty id (h*).")
+    p = sub.add_parser("confirm", help="Confirm one or more claims / honesty conditions.")
+    p.add_argument("ids", nargs="+", help="One or more claim ids (c*) or honesty ids (h*).")
     p.add_argument("--frame", help="Frame slug (default: current).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_confirm)

--- a/devague/cli/_commands/confirm.py
+++ b/devague/cli/_commands/confirm.py
@@ -1,51 +1,96 @@
 """``devague confirm`` — confirm claims/honesty conditions (user-only transition).
 
-Accepts one or more ids in a single call. The batch is **transactional**: every
-id is validated first, and if any is unknown nothing is changed (no half-applied
-batch). Confirmation stays a user-only action — see issue #17.
+Accepts one or more ids in a single call, or a reviewed decision set via
+``--from-review <file>`` (apply the confirm/reject markers a human edited into a
+``devague review`` artifact). Either way the batch is **transactional**: every
+id is validated first, and if any is unknown nothing is changed. Confirmation
+stays a user-only action, and ``--from-review`` applies only what the file
+explicitly marks — ``pending`` lines are never auto-confirmed. See issue #17.
 """
 
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from devague import store
 from devague.cli._errors import EXIT_USER_ERROR, DevagueError
 from devague.cli._frames import resolve
 from devague.cli._output import emit_result
+from devague.render.review_md import parse_decisions
 
 
 def _exists(frame, item_id: str) -> bool:
     return frame.find_claim(item_id) is not None or frame.find_honesty(item_id) is not None
 
 
-def _transition(args: argparse.Namespace, status: str) -> int:
+def _run(args: argparse.Namespace, confirm_ids: list[str], reject_ids: list[str]) -> int:
     frame = resolve(args.frame)
-    ids: list[str] = args.ids
-    unknown = [i for i in ids if not _exists(frame, i)]
+    all_ids = confirm_ids + reject_ids
+    if not all_ids:
+        raise DevagueError(EXIT_USER_ERROR, "no ids to resolve", "pass at least one id")
+    unknown = [i for i in all_ids if not _exists(frame, i)]
     if unknown:
         raise DevagueError(
             EXIT_USER_ERROR,
             f"no such claim or honesty condition: {', '.join(unknown)}",
             "run 'devague show'; the batch is transactional — nothing was changed",
         )
-    for item_id in ids:
-        frame.set_status(item_id, status)
+    for item_id in confirm_ids:
+        frame.set_status(item_id, "confirmed")
+    for item_id in reject_ids:
+        frame.set_status(item_id, "rejected")
     store.save(frame)
     if getattr(args, "json", False):
-        emit_result({"ids": ids, "status": status}, json_mode=True)
+        emit_result({"confirmed": confirm_ids, "rejected": reject_ids}, json_mode=True)
     else:
-        emit_result("\n".join(f"{i} -> {status}" for i in ids), json_mode=False)
+        lines = [f"{i} -> confirmed" for i in confirm_ids]
+        lines += [f"{i} -> rejected" for i in reject_ids]
+        emit_result("\n".join(lines), json_mode=False)
     return 0
 
 
+def _from_review(path: str) -> tuple[list[str], list[str]]:
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as err:
+        raise DevagueError(EXIT_USER_ERROR, f"cannot read review file: {path}", str(err))
+    try:
+        decisions = parse_decisions(text)
+    except ValueError as err:
+        raise DevagueError(EXIT_USER_ERROR, str(err), "fix the conflicting decision and retry")
+    confirm_ids = [i for i, d in decisions.items() if d == "confirm"]
+    reject_ids = [i for i, d in decisions.items() if d == "reject"]
+    if not confirm_ids and not reject_ids:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "no decisions found in review file",
+            "change a line's 'pending' to 'confirm' or 'reject' first",
+        )
+    return confirm_ids, reject_ids
+
+
 def cmd_confirm(args: argparse.Namespace) -> int:
-    return _transition(args, "confirmed")
+    if args.from_review:
+        if args.ids:
+            raise DevagueError(
+                EXIT_USER_ERROR,
+                "pass ids or --from-review, not both",
+                "drop the positional ids when applying a review file",
+            )
+        confirm_ids, reject_ids = _from_review(args.from_review)
+        return _run(args, confirm_ids, reject_ids)
+    return _run(args, list(args.ids), [])
+
+
+def cmd_reject(args: argparse.Namespace) -> int:
+    return _run(args, [], list(args.ids))
 
 
 def register(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("confirm", help="Confirm one or more claims / honesty conditions.")
-    p.add_argument("ids", nargs="+", help="One or more claim ids (c*) or honesty ids (h*).")
+    p = sub.add_parser("confirm", help="Confirm claims/honesty conditions, or apply a review file.")
+    p.add_argument("ids", nargs="*", help="One or more claim ids (c*) or honesty ids (h*).")
+    p.add_argument("--from-review", help="Apply confirm/reject decisions from a review file.")
     p.add_argument("--frame", help="Frame slug (default: current).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_confirm)

--- a/devague/cli/_commands/question.py
+++ b/devague/cli/_commands/question.py
@@ -21,44 +21,51 @@ def _load(slug: str) -> list[dict]:
     return questions_io.parse(path.read_text(encoding="utf-8")) if path.exists() else []
 
 
-def cmd_question(args: argparse.Namespace) -> int:
-    frame = resolve(args.frame)  # validates the frame exists; never mutates it
-    slug = frame.slug
-    items = _load(slug)
+def _resolve_question(args: argparse.Namespace, slug: str, items: list[dict]) -> None:
+    target = next((i for i in items if i["id"] == args.resolve), None)
+    if target is None:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"no such question: {args.resolve}",
+            "run 'devague question --list'",
+        )
+    target["resolved"] = True
+    target["decision"] = args.decision
+    store.write_questions(slug, questions_io.render(slug, items))
+    if args.json:
+        emit_result({"id": args.resolve, "resolved": True}, json_mode=True)
+    else:
+        emit_result(f"{args.resolve} -> resolved", json_mode=False)
 
-    if args.resolve:
-        target = next((i for i in items if i["id"] == args.resolve), None)
-        if target is None:
-            raise DevagueError(
-                EXIT_USER_ERROR,
-                f"no such question: {args.resolve}",
-                "run 'devague question --list'",
-            )
-        target["resolved"] = True
-        target["decision"] = args.decision
-        store.write_questions(slug, questions_io.render(slug, items))
-        if args.json:
-            emit_result({"id": args.resolve, "resolved": True}, json_mode=True)
-        else:
-            emit_result(f"{args.resolve} -> resolved", json_mode=False)
-        return 0
 
-    if args.text:
-        new_id = questions_io.next_id(items)
-        items.append({"id": new_id, "text": args.text, "resolved": False, "decision": None})
-        path = store.write_questions(slug, questions_io.render(slug, items))
-        if args.json:
-            emit_result({"id": new_id, "text": args.text, "path": str(path)}, json_mode=True)
-        else:
-            emit_result(f"recorded {new_id}", json_mode=False)
-            emit_diagnostic(f"wrote pending decision to {path} (uncommitted working state)")
-        return 0
+def _add_question(args: argparse.Namespace, slug: str, items: list[dict]) -> None:
+    new_id = questions_io.next_id(items)
+    items.append({"id": new_id, "text": args.text, "resolved": False, "decision": None})
+    path = store.write_questions(slug, questions_io.render(slug, items))
+    if args.json:
+        emit_result({"id": new_id, "text": args.text, "path": str(path)}, json_mode=True)
+    else:
+        emit_result(f"recorded {new_id}", json_mode=False)
+        emit_diagnostic(f"wrote pending decision to {path} (uncommitted working state)")
 
-    # default / --list: show the pending-decisions state
+
+def _list_questions(args: argparse.Namespace, slug: str, items: list[dict]) -> None:
     if args.json:
         emit_result({"slug": slug, "questions": items}, json_mode=True)
     else:
         emit_result(questions_io.render(slug, items), json_mode=False)
+
+
+def cmd_question(args: argparse.Namespace) -> int:
+    frame = resolve(args.frame)  # validates the frame exists; never mutates it
+    slug = frame.slug
+    items = _load(slug)
+    if args.resolve:
+        _resolve_question(args, slug, items)
+    elif args.text:
+        _add_question(args, slug, items)
+    else:  # default / --list: show the pending-decisions state
+        _list_questions(args, slug, items)
     return 0
 
 

--- a/devague/cli/_commands/question.py
+++ b/devague/cli/_commands/question.py
@@ -1,0 +1,73 @@
+"""``devague question`` — record/list/resolve pending user decisions.
+
+Durable, uncommitted working state under .devague/questions/<slug>.md. The CLI
+owns the format (decision c20). Nothing here auto-resolves: ``--resolve`` only
+records a decision a human made; applying it into the frame is a separate,
+explicit move (see the file header). Issue #14/#17.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from devague import questions_io, store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
+from devague.cli._frames import resolve
+from devague.cli._output import emit_diagnostic, emit_result
+
+
+def _load(slug: str) -> list[dict]:
+    path = store.questions_path(slug)
+    return questions_io.parse(path.read_text(encoding="utf-8")) if path.exists() else []
+
+
+def cmd_question(args: argparse.Namespace) -> int:
+    frame = resolve(args.frame)  # validates the frame exists; never mutates it
+    slug = frame.slug
+    items = _load(slug)
+
+    if args.resolve:
+        target = next((i for i in items if i["id"] == args.resolve), None)
+        if target is None:
+            raise DevagueError(
+                EXIT_USER_ERROR,
+                f"no such question: {args.resolve}",
+                "run 'devague question --list'",
+            )
+        target["resolved"] = True
+        target["decision"] = args.decision
+        store.write_questions(slug, questions_io.render(slug, items))
+        if args.json:
+            emit_result({"id": args.resolve, "resolved": True}, json_mode=True)
+        else:
+            emit_result(f"{args.resolve} -> resolved", json_mode=False)
+        return 0
+
+    if args.text:
+        new_id = questions_io.next_id(items)
+        items.append({"id": new_id, "text": args.text, "resolved": False, "decision": None})
+        path = store.write_questions(slug, questions_io.render(slug, items))
+        if args.json:
+            emit_result({"id": new_id, "text": args.text, "path": str(path)}, json_mode=True)
+        else:
+            emit_result(f"recorded {new_id}", json_mode=False)
+            emit_diagnostic(f"wrote pending decision to {path} (uncommitted working state)")
+        return 0
+
+    # default / --list: show the pending-decisions state
+    if args.json:
+        emit_result({"slug": slug, "questions": items}, json_mode=True)
+    else:
+        emit_result(questions_io.render(slug, items), json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("question", help="Record / list / resolve pending user decisions.")
+    p.add_argument("text", nargs="?", help="Question text to record (omit to list).")
+    p.add_argument("--resolve", metavar="QID", help="Mark a question id resolved.")
+    p.add_argument("--decision", help="The decision note recorded with --resolve.")
+    p.add_argument("--list", action="store_true", help="List pending decisions (default).")
+    p.add_argument("--frame", help="Frame slug (default: current).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_question)

--- a/devague/cli/_commands/reject.py
+++ b/devague/cli/_commands/reject.py
@@ -1,14 +1,10 @@
-"""``devague reject`` — reject a claim or honesty condition."""
+"""``devague reject`` — reject one or more claims / honesty conditions."""
 
 from __future__ import annotations
 
 import argparse
 
-from devague.cli._commands.confirm import _transition
-
-
-def cmd_reject(args: argparse.Namespace) -> int:
-    return _transition(args, "rejected")
+from devague.cli._commands.confirm import cmd_reject
 
 
 def register(sub: argparse._SubParsersAction) -> None:

--- a/devague/cli/_commands/reject.py
+++ b/devague/cli/_commands/reject.py
@@ -12,8 +12,8 @@ def cmd_reject(args: argparse.Namespace) -> int:
 
 
 def register(sub: argparse._SubParsersAction) -> None:
-    p = sub.add_parser("reject", help="Reject a claim or honesty condition.")
-    p.add_argument("id", help="Claim id (c*) or honesty id (h*).")
+    p = sub.add_parser("reject", help="Reject one or more claims / honesty conditions.")
+    p.add_argument("ids", nargs="+", help="One or more claim ids (c*) or honesty ids (h*).")
     p.add_argument("--frame", help="Frame slug (default: current).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_reject)

--- a/devague/cli/_commands/review.py
+++ b/devague/cli/_commands/review.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import argparse
 
-from devague import render
+from devague import render, store
 from devague.cli._frames import resolve
-from devague.cli._output import emit_result
+from devague.cli._output import emit_diagnostic, emit_result
 from devague.render.review_md import proposed_claims, proposed_honesty
 
 
@@ -30,11 +30,21 @@ def _json_payload(frame) -> dict:
 
 
 def cmd_review(args: argparse.Namespace) -> int:
-    frame = resolve(args.frame)  # read-only: never saved, never converged
+    frame = resolve(args.frame)  # read-only: the frame is never saved/converged
+    artifact = render.render(frame, "review-md")
+    path = None
+    if not getattr(args, "no_write", False):
+        # Persist a durable, NON-authoritative artifact to uncommitted working
+        # state (.devague/reviews/<slug>.md) — distinct from docs/specs/.
+        path = store.write_review(frame.slug, artifact)
     if getattr(args, "json", False):
-        emit_result(_json_payload(frame), json_mode=True)
+        payload = _json_payload(frame)
+        payload["path"] = str(path) if path else None
+        emit_result(payload, json_mode=True)
     else:
-        emit_result(render.render(frame, "review-md"), json_mode=False)
+        emit_result(artifact, json_mode=False)
+        if path:
+            emit_diagnostic(f"wrote review artifact to {path} (unconfirmed, not authoritative)")
     return 0
 
 
@@ -45,4 +55,9 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p.add_argument("--frame", help="Frame slug (default: current).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Print only; do not persist .devague/reviews/<slug>.md.",
+    )
     p.set_defaults(func=cmd_review)

--- a/devague/cli/_commands/review.py
+++ b/devague/cli/_commands/review.py
@@ -1,0 +1,48 @@
+"""``devague review`` — surface every *proposed* (unconfirmed) item for human review.
+
+Lists proposed claims and proposed honesty conditions with their ids. It is
+deliberately NOT gated on convergence and never mutates state — it is a
+read-only view of what is awaiting a user decision (issue #17). Confirm/reject
+the listed ids with ``devague confirm`` / ``devague reject``.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from devague import render
+from devague.cli._frames import resolve
+from devague.cli._output import emit_result
+from devague.render.review_md import proposed_claims, proposed_honesty
+
+
+def _json_payload(frame) -> dict:
+    return {
+        "slug": frame.slug,
+        "proposed_claims": [
+            {"id": c.id, "kind": c.kind, "text": c.text} for c in proposed_claims(frame)
+        ],
+        "proposed_honesty": [
+            {"id": h.id, "claim_id": c.id, "claim_kind": c.kind, "text": h.text}
+            for c, h in proposed_honesty(frame)
+        ],
+    }
+
+
+def cmd_review(args: argparse.Namespace) -> int:
+    frame = resolve(args.frame)  # read-only: never saved, never converged
+    if getattr(args, "json", False):
+        emit_result(_json_payload(frame), json_mode=True)
+    else:
+        emit_result(render.render(frame, "review-md"), json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "review",
+        help="List proposed (unconfirmed) claims + honesty conditions for human review.",
+    )
+    p.add_argument("--frame", help="Frame slug (default: current).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_review)

--- a/devague/questions_io.py
+++ b/devague/questions_io.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import re
 
-_LINE = re.compile(r"^- \[(?P<mark>[ x])\]\s+`(?P<id>q\d+)`:\s+(?P<rest>.*)$")
+# Bounded whitespace only (single literal spaces, rest stripped in parse) so the
+# pattern is linear — no \s+…\s+…\.* shape that trips ReDoS heuristics.
+_LINE = re.compile(r"^- \[(?P<mark>[ x])\] `(?P<id>q\d+)`:(?P<rest>.*)$")
 _DECIDED = " — decided: "
 
 _BANNER = (

--- a/devague/questions_io.py
+++ b/devague/questions_io.py
@@ -1,0 +1,60 @@
+"""Pending-decision working state: ``.devague/questions/<slug>.md`` (CLI-owned).
+
+A durable, **uncommitted** list of open questions / pending user decisions raised
+while working a frame (issue #14/#17, decision c20). The CLI owns the markdown
+format so it round-trips (``parse`` ⇄ ``render``). A resolved decision is applied
+back into the frame with the normal moves (e.g. ``devague capture --kind decision
+"<the decision>"`` then ``devague confirm``); resolving here only records it.
+"""
+
+from __future__ import annotations
+
+import re
+
+_LINE = re.compile(r"^- \[(?P<mark>[ x])\]\s+`(?P<id>q\d+)`:\s+(?P<rest>.*)$")
+_DECIDED = " — decided: "
+
+_BANNER = (
+    "> **Working state — not committed by default.** Open questions / pending "
+    "decisions for this frame. Apply a decision into the frame with the normal "
+    'moves (e.g. `devague capture --kind decision "…"` then `devague confirm`), '
+    "then mark it resolved here with `devague question --resolve <id>`."
+)
+
+
+def parse(text: str) -> list[dict]:
+    items: list[dict] = []
+    for line in text.splitlines():
+        m = _LINE.match(line.strip())
+        if not m:
+            continue
+        rest = m.group("rest")
+        resolved = m.group("mark") == "x"
+        decision = None
+        if resolved and _DECIDED in rest:
+            rest, decision = rest.split(_DECIDED, 1)
+        items.append(
+            {"id": m.group("id"), "text": rest.strip(), "resolved": resolved, "decision": decision}
+        )
+    return items
+
+
+def next_id(items: list[dict]) -> str:
+    nums = [int(i["id"][1:]) for i in items if i["id"][1:].isdigit()]
+    return f"q{(max(nums) + 1) if nums else 1}"
+
+
+def render(slug: str, items: list[dict]) -> str:
+    out = [f"# Pending decisions — {slug}", "", _BANNER, ""]
+    open_items = [i for i in items if not i["resolved"]]
+    done_items = [i for i in items if i["resolved"]]
+    out += ["## Open", ""]
+    out += [f"- [ ] `{i['id']}`: {i['text']}" for i in open_items] or ["None."]
+    out += [""]
+    if done_items:
+        out += ["## Resolved", ""]
+        for i in done_items:
+            tail = f"{_DECIDED}{i['decision']}" if i["decision"] else ""
+            out.append(f"- [x] `{i['id']}`: {i['text']}{tail}")
+        out += [""]
+    return "\n".join(out).rstrip() + "\n"

--- a/devague/questions_io.py
+++ b/devague/questions_io.py
@@ -34,7 +34,9 @@ def parse(text: str) -> list[dict]:
         resolved = m.group("mark") == "x"
         decision = None
         if resolved and _DECIDED in rest:
-            rest, decision = rest.split(_DECIDED, 1)
+            # render() appends the decided tail last, so split from the right —
+            # otherwise a question whose *text* contains the delimiter corrupts.
+            rest, decision = rest.rsplit(_DECIDED, 1)
         items.append(
             {"id": m.group("id"), "text": rest.strip(), "resolved": resolved, "decision": decision}
         )

--- a/devague/render/__init__.py
+++ b/devague/render/__init__.py
@@ -33,7 +33,9 @@ def render(frame: Frame, fmt: str) -> str:
 
 # Register the built-in renderers (import-time side effect).
 from devague.render import frame_md as _frame_md  # noqa: E402
+from devague.render import review_md as _review_md  # noqa: E402
 from devague.render import spec_md as _spec_md  # noqa: E402
 
 register("frame-md", _frame_md.render_frame)
 register("spec-md", _spec_md.render_spec)
+register("review-md", _review_md.render_review)

--- a/devague/render/review_md.py
+++ b/devague/render/review_md.py
@@ -1,18 +1,30 @@
-"""Renderer: the human-review artifact — every *proposed* (unconfirmed) item.
+"""Renderer + parser for the human-review artifact — every *proposed* item.
 
 Explicitly NON-authoritative and distinct from spec-md: it exists so a human can
 review LLM proposals (in-terminal or out of band) before confirming any. Nothing
 here is authoritative until the user runs ``devague confirm``. See issue #17.
+
+The artifact is **round-trippable**: each proposed item is emitted with a leading
+``pending`` marker. Edit a line's marker to ``confirm`` or ``reject``, then feed
+the file to ``devague confirm --from-review <file>`` to apply exactly those
+decisions (``render_review`` ⇄ :func:`parse_decisions`).
 """
 
 from __future__ import annotations
 
+import re
+
 from devague.frame import Frame
+
+# A decision line: "- <marker> `<id>` ...". The marker is the only editable part.
+_DECISIONS = ("pending", "confirm", "reject")
+_LINE = re.compile(r"^- (?P<decision>pending|confirm|reject)\s+`(?P<id>[ch]\d+)`")
 
 _BANNER = (
     "> **Review artifact — nothing confirmed yet.** These are unconfirmed, "
     "LLM-proposed items; they are NOT authoritative and NOT a buildable spec. "
-    "Confirm or reject each with `devague confirm <id>` / `devague reject <id>`."
+    "To apply, change a line's `pending` to `confirm` or `reject`, then run "
+    "`devague confirm --from-review <file>` (or `devague confirm <id> ...`)."
 )
 
 
@@ -33,10 +45,32 @@ def render_review(frame: Frame) -> str:
         return "\n".join(out).rstrip() + "\n"
     if claims:
         out += ["## Proposed claims", ""]
-        out += [f"- `{c.id}` ({c.kind}): {c.text}" for c in claims]
+        out += [f"- pending `{c.id}` ({c.kind}): {c.text}" for c in claims]
         out += [""]
     if pairs:
         out += ["## Proposed honesty conditions", ""]
-        out += [f"- `{h.id}` (on `{c.id}` {c.kind}): {h.text}" for c, h in pairs]
+        out += [f"- pending `{h.id}` (on `{c.id}` {c.kind}): {h.text}" for c, h in pairs]
         out += [""]
     return "\n".join(out).rstrip() + "\n"
+
+
+def parse_decisions(text: str) -> dict[str, str]:
+    """Parse a (possibly edited) review artifact into ``{id: "confirm"|"reject"}``.
+
+    ``pending`` lines carry no decision and are skipped — applying a review file
+    therefore touches only what the human explicitly marked (no auto-confirm).
+    Raises ``ValueError`` on a duplicate, conflicting decision for one id.
+    """
+    decisions: dict[str, str] = {}
+    for line in text.splitlines():
+        m = _LINE.match(line.strip())
+        if not m:
+            continue
+        decision, item_id = m.group("decision"), m.group("id")
+        if decision == "pending":
+            continue
+        if item_id in decisions and decisions[item_id] != decision:
+            prior = decisions[item_id]
+            raise ValueError(f"conflicting decisions for {item_id}: {prior} vs {decision}")
+        decisions[item_id] = decision
+    return decisions

--- a/devague/render/review_md.py
+++ b/devague/render/review_md.py
@@ -1,0 +1,42 @@
+"""Renderer: the human-review artifact — every *proposed* (unconfirmed) item.
+
+Explicitly NON-authoritative and distinct from spec-md: it exists so a human can
+review LLM proposals (in-terminal or out of band) before confirming any. Nothing
+here is authoritative until the user runs ``devague confirm``. See issue #17.
+"""
+
+from __future__ import annotations
+
+from devague.frame import Frame
+
+_BANNER = (
+    "> **Review artifact — nothing confirmed yet.** These are unconfirmed, "
+    "LLM-proposed items; they are NOT authoritative and NOT a buildable spec. "
+    "Confirm or reject each with `devague confirm <id>` / `devague reject <id>`."
+)
+
+
+def proposed_claims(frame: Frame) -> list:
+    return [c for c in frame.claims if c.status == "proposed"]
+
+
+def proposed_honesty(frame: Frame) -> list:
+    return [(c, h) for c in frame.claims for h in c.honesty_conditions if h.status == "proposed"]
+
+
+def render_review(frame: Frame) -> str:
+    out: list[str] = [f"# Review — {frame.title}", "", _BANNER, ""]
+    claims = proposed_claims(frame)
+    pairs = proposed_honesty(frame)
+    if not claims and not pairs:
+        out += ["No proposed items — nothing awaiting review.", ""]
+        return "\n".join(out).rstrip() + "\n"
+    if claims:
+        out += ["## Proposed claims", ""]
+        out += [f"- `{c.id}` ({c.kind}): {c.text}" for c in claims]
+        out += [""]
+    if pairs:
+        out += ["## Proposed honesty conditions", ""]
+        out += [f"- `{h.id}` (on `{c.id}` {c.kind}): {h.text}" for c, h in pairs]
+        out += [""]
+    return "\n".join(out).rstrip() + "\n"

--- a/devague/store.py
+++ b/devague/store.py
@@ -14,6 +14,12 @@ from devague.frame import SCHEMA_VERSION, Frame, from_dict, to_dict
 
 FRAMES_DIR = Path(".devague/frames")
 CURRENT = Path(".devague/current")
+REVIEWS_DIR = Path(".devague/reviews")
+QUESTIONS_DIR = Path(".devague/questions")
+
+# devague manages .gitignore so review/question working state is uncommitted by
+# default (decision c19, issue #17). The user opts in to promote one into docs.
+_IGNORE_HEADER = "# devague working state (not committed by default)"
 
 
 class IncompatibleSchemaError(ValueError):
@@ -48,6 +54,39 @@ def _now() -> str:
 
 def path_for(slug: str) -> Path:
     return FRAMES_DIR / f"{validate_slug(slug)}.json"
+
+
+def ensure_ignored(*patterns: str) -> None:
+    """Idempotently add ``patterns`` to ./.gitignore (devague-managed block).
+
+    Keeps ``.devague/`` working-state dirs uncommitted by default without
+    clobbering an existing .gitignore (decision c19, issue #17).
+    """
+    gi = Path(".gitignore")
+    existing = gi.read_text(encoding="utf-8").splitlines() if gi.exists() else []
+    missing = [p for p in patterns if p not in existing]
+    if not missing:
+        return
+    out = list(existing)
+    if out and out[-1].strip():
+        out.append("")
+    if _IGNORE_HEADER not in existing:
+        out.append(_IGNORE_HEADER)
+    out.extend(missing)
+    gi.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+
+def review_path(slug: str) -> Path:
+    return REVIEWS_DIR / f"{validate_slug(slug)}.md"
+
+
+def write_review(slug: str, content: str) -> Path:
+    """Persist a review artifact to .devague/reviews/<slug>.md (uncommitted)."""
+    REVIEWS_DIR.mkdir(parents=True, exist_ok=True)
+    ensure_ignored(".devague/reviews/")
+    p = review_path(slug)
+    p.write_text(content, encoding="utf-8")
+    return p
 
 
 def unique_slug(base: str) -> str:

--- a/devague/store.py
+++ b/devague/store.py
@@ -89,6 +89,19 @@ def write_review(slug: str, content: str) -> Path:
     return p
 
 
+def questions_path(slug: str) -> Path:
+    return QUESTIONS_DIR / f"{validate_slug(slug)}.md"
+
+
+def write_questions(slug: str, content: str) -> Path:
+    """Persist a pending-decisions file to .devague/questions/<slug>.md (uncommitted)."""
+    QUESTIONS_DIR.mkdir(parents=True, exist_ok=True)
+    ensure_ignored(".devague/questions/")
+    p = questions_path(slug)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
 def unique_slug(base: str) -> str:
     """Return ``base`` if free, else the first ``base-N`` (N>=2) that is unused."""
     base = base or "frame"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.5.1"
+version = "0.6.0"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_moves.py
+++ b/tests/test_cli_moves.py
@@ -120,6 +120,38 @@ def test_confirm_unknown_id_errors(tmp_path, monkeypatch, capsys) -> None:
     assert "no such" in capsys.readouterr().err
 
 
+def test_confirm_multiple_ids_in_one_call(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2 proposed
+    main(["capture", "--kind", "after_state", "fast", "--origin", "llm"])  # c3 proposed
+    assert main(["confirm", "c2", "c3"]) == 0
+    f = store.load(store.current_slug())
+    assert f.find_claim("c2").status == "confirmed"
+    assert f.find_claim("c3").status == "confirmed"
+
+
+def test_reject_multiple_ids_in_one_call(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2
+    main(["capture", "--kind", "after_state", "fast", "--origin", "llm"])  # c3
+    assert main(["reject", "c2", "c3"]) == 0
+    f = store.load(store.current_slug())
+    assert f.find_claim("c2").status == "rejected"
+    assert f.find_claim("c3").status == "rejected"
+
+
+def test_batch_confirm_is_transactional(tmp_path, monkeypatch, capsys) -> None:
+    # One unknown id in the batch => resolve NONE (no half-applied state).
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2 proposed
+    rc = main(["confirm", "c2", "nope"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no such" in err and "nope" in err
+    # c2 must be untouched — the batch aborted before applying anything.
+    assert store.load(store.current_slug()).find_claim("c2").status == "proposed"
+
+
 def test_park_adds_vagueness(tmp_path, monkeypatch, capsys) -> None:
     _seed(monkeypatch, tmp_path)
     capsys.readouterr()  # drain the "new" output

--- a/tests/test_cli_question.py
+++ b/tests/test_cli_question.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+
+from devague import questions_io, store
+from devague.cli import main
+
+
+def _seed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship review loop"])
+
+
+def test_question_records_pending_decision(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    assert main(["question", "batch atomicity?"]) == 0
+    text = store.questions_path(slug).read_text()
+    assert "q1" in text and "batch atomicity?" in text
+    assert ".devague/questions/" in (tmp_path / ".gitignore").read_text()
+
+
+def test_questions_persist_across_runs(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    main(["question", "first?"])
+    main(["question", "second?"])  # separate invocation — must not clobber q1
+    items = questions_io.parse(store.questions_path(slug).read_text())
+    assert [i["id"] for i in items] == ["q1", "q2"]
+    assert [i["text"] for i in items] == ["first?", "second?"]
+
+
+def test_question_list_json(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["question", "only?"])
+    capsys.readouterr()
+    assert main(["question", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["questions"][0]["id"] == "q1"
+    assert payload["questions"][0]["resolved"] is False
+
+
+def test_question_resolve_records_decision(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    main(["question", "atomicity?"])
+    assert main(["question", "--resolve", "q1", "--decision", "transactional"]) == 0
+    items = questions_io.parse(store.questions_path(slug).read_text())
+    assert items[0]["resolved"] is True
+    assert items[0]["decision"] == "transactional"
+
+
+def test_question_resolve_unknown_id_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["question", "q?"])
+    assert main(["question", "--resolve", "q9", "--decision", "x"]) == 1
+    assert "no such question" in capsys.readouterr().err

--- a/tests/test_cli_question.py
+++ b/tests/test_cli_question.py
@@ -50,6 +50,19 @@ def test_question_resolve_records_decision(tmp_path, monkeypatch) -> None:
     assert items[0]["decision"] == "transactional"
 
 
+def test_question_text_containing_delimiter_round_trips(tmp_path, monkeypatch) -> None:
+    # Regression (Qodo, PR #23): a question whose text contains " — decided: "
+    # must not corrupt on resolve/parse — split from the right.
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    tricky = "Should we use — decided: as syntax?"
+    main(["question", tricky])
+    main(["question", "--resolve", "q1", "--decision", "no"])
+    items = questions_io.parse(store.questions_path(slug).read_text())
+    assert items[0]["text"] == tricky
+    assert items[0]["decision"] == "no"
+
+
 def test_question_resolve_unknown_id_errors(tmp_path, monkeypatch, capsys) -> None:
     _seed(monkeypatch, tmp_path)
     main(["question", "q?"])

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -45,7 +45,43 @@ def test_review_json_shape(tmp_path, monkeypatch, capsys) -> None:
     capsys.readouterr()
     assert main(["review", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert {"slug", "proposed_claims", "proposed_honesty"} <= payload.keys()
+    assert {"slug", "proposed_claims", "proposed_honesty", "path"} <= payload.keys()
     assert payload["proposed_claims"][0]["id"] == "c2"
     assert payload["proposed_honesty"][0]["id"] == "h1"
     assert payload["proposed_honesty"][0]["claim_id"] == "c1"
+
+
+def test_review_persists_artifact_to_devague_reviews(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    assert main(["review"]) == 0
+    path = store.review_path(slug)
+    assert path.exists()
+    # Distinct from docs/specs/, and explicitly non-authoritative.
+    assert ".devague/reviews/" in path.as_posix()
+    assert "docs/specs/" not in path.as_posix()
+    assert "nothing confirmed yet" in path.read_text().lower()
+
+
+def test_review_manages_gitignore(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    main(["review"])
+    gi = (tmp_path / ".gitignore").read_text()
+    assert ".devague/reviews/" in gi
+
+
+def test_review_gitignore_append_is_idempotent(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gitignore").write_text("*.pyc\n")
+    store.ensure_ignored(".devague/reviews/")
+    store.ensure_ignored(".devague/reviews/")  # second call must not duplicate
+    gi = (tmp_path / ".gitignore").read_text()
+    assert gi.count(".devague/reviews/") == 1
+    assert "*.pyc" in gi  # pre-existing entries preserved
+
+
+def test_review_no_write_skips_file(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    assert main(["review", "--no-write"]) == 0
+    assert not store.review_path(slug).exists()

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -85,3 +85,69 @@ def test_review_no_write_skips_file(tmp_path, monkeypatch) -> None:
     slug = store.current_slug()
     assert main(["review", "--no-write"]) == 0
     assert not store.review_path(slug).exists()
+
+
+def test_from_review_round_trip(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)  # c2 proposed, h1 proposed
+    slug = store.current_slug()
+    main(["review"])
+    path = store.review_path(slug)
+    edited = (
+        path.read_text()
+        .replace("pending `c2`", "confirm `c2`")
+        .replace("pending `h1`", "reject `h1`")
+    )
+    path.write_text(edited)
+    assert main(["confirm", "--from-review", str(path)]) == 0
+    f = store.load(slug)
+    assert f.find_claim("c2").status == "confirmed"
+    assert f.find_honesty("h1").status == "rejected"
+
+
+def test_from_review_pending_is_never_auto_confirmed(tmp_path, monkeypatch, capsys) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    main(["review"])  # leaves every line as `pending`
+    rc = main(["confirm", "--from-review", str(store.review_path(slug))])
+    assert rc == 1
+    assert "no decisions" in capsys.readouterr().err
+    f = store.load(slug)
+    assert f.find_claim("c2").status == "proposed"
+    assert f.find_honesty("h1").status == "proposed"
+
+
+def test_from_review_applies_only_marked_lines(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    main(["review"])
+    path = store.review_path(slug)
+    # confirm c2 only; h1 stays `pending` and must be left untouched.
+    path.write_text(path.read_text().replace("pending `c2`", "confirm `c2`"))
+    assert main(["confirm", "--from-review", str(path)]) == 0
+    f = store.load(slug)
+    assert f.find_claim("c2").status == "confirmed"
+    assert f.find_honesty("h1").status == "proposed"
+
+
+def test_from_review_conflicting_decisions_error(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "X"])
+    p = tmp_path / "r.md"
+    p.write_text("- confirm `c1`\n- reject `c1`\n")
+    assert main(["confirm", "--from-review", str(p)]) == 1
+    assert "conflicting" in capsys.readouterr().err
+
+
+def test_from_review_missing_file_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    assert main(["confirm", "--from-review", str(tmp_path / "nope.md")]) == 1
+    assert "cannot read" in capsys.readouterr().err
+
+
+def test_from_review_rejects_ids_and_file_together(tmp_path, monkeypatch, capsys) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    main(["review"])
+    rc = main(["confirm", "c2", "--from-review", str(store.review_path(slug))])
+    assert rc == 1
+    assert "not both" in capsys.readouterr().err

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+from devague import store
+from devague.cli import main
+
+
+def _seed_proposed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship review loop"])  # c1 announcement (confirmed)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2 proposed
+    main(["interrogate", "c1", "--honesty", "must be true"])  # h1 proposed (origin llm)
+
+
+def test_review_lists_proposed_with_ids(tmp_path, monkeypatch, capsys) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert main(["review"]) == 0
+    out = capsys.readouterr().out
+    assert "c2" in out and "h1" in out
+    assert "nothing confirmed yet" in out.lower()
+
+
+def test_review_runs_on_non_converged_frame(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    # The frame is nowhere near converged; review must still succeed (un-gated).
+    assert main(["review"]) == 0
+
+
+def test_review_does_not_mutate_state(tmp_path, monkeypatch) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    before = store.path_for(store.current_slug()).read_text()
+    main(["review"])
+    main(["review", "--json"])
+    after = store.path_for(store.current_slug()).read_text()
+    assert before == after  # byte-identical: review never saves
+    f = store.load(store.current_slug())
+    assert f.find_claim("c2").status == "proposed"
+    assert f.find_honesty("h1").status == "proposed"
+
+
+def test_review_json_shape(tmp_path, monkeypatch, capsys) -> None:
+    _seed_proposed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert main(["review", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {"slug", "proposed_claims", "proposed_honesty"} <= payload.keys()
+    assert payload["proposed_claims"][0]["id"] == "c2"
+    assert payload["proposed_honesty"][0]["id"] == "h1"
+    assert payload["proposed_honesty"][0]["claim_id"] == "c1"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -132,6 +132,14 @@ def test_review_md_banner_and_proposed_only() -> None:
     assert_markdownlint_clean(out)
 
 
+def test_review_md_empty_when_no_proposals() -> None:
+    f = Frame(slug="rv2", title="All confirmed")
+    f.add_claim("announcement", "Shipped", origin="user")  # confirmed
+    out = render.render(f, "review-md")
+    assert "nothing awaiting review" in out.lower()
+    assert_markdownlint_clean(out)
+
+
 def test_unknown_format_raises() -> None:
     with pytest.raises(DevagueError):
         render.render(_frame(), "nope")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -120,6 +120,18 @@ def test_frame_md_renders_non_goal_and_decision() -> None:
     assert_markdownlint_clean(out)
 
 
+def test_review_md_banner_and_proposed_only() -> None:
+    f = Frame(slug="rv", title="Review me")
+    f.add_claim("announcement", "Shipped", origin="user")  # confirmed — excluded
+    f.add_claim("audience", "devs", origin="llm")  # c2 proposed — included
+    out = render.render(f, "review-md")
+    assert "review-md" in render.formats()
+    assert "nothing confirmed yet" in out.lower()
+    assert "`c2`" in out and "devs" in out
+    assert "Shipped" not in out  # confirmed items are not part of the review artifact
+    assert_markdownlint_clean(out)
+
+
 def test_unknown_format_raises() -> None:
     with pytest.raises(DevagueError):
         render.render(_frame(), "nope")

--- a/tests/test_review_loop_integration.py
+++ b/tests/test_review_loop_integration.py
@@ -1,0 +1,66 @@
+"""Integration checks for the 0.6.0 Human Review Loop (#17), plan task t7.
+
+- c1/h6, c2/h7, c4/h9 — the announcement is literally true of the shipped CLI:
+  a proposal-heavy frame is reviewed then bulk-resolved in one pass, with no
+  auto-confirm path.
+- c7/h12 — boundary: 0.6.0 added only review/confirm UX; the proposed-vs-
+  confirmed state vocabulary and claim kinds from #5/#16 are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+from devague import frame as frame_mod
+from devague import store
+from devague.cli import main
+
+_KNOWN_STATUSES = {"proposed", "confirmed", "rejected"}
+_CONTRACT_KINDS = {
+    "announcement",
+    "audience",
+    "after_state",
+    "before_state",
+    "why_it_matters",
+    "boundary",
+    "success_signal",
+    "open_question",
+    "non_goal",
+    "requirement",
+    "assumption",
+    "decision",
+}
+
+
+def test_announcement_literally_true_at_scale(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship it"])
+    for i in range(10):  # a frame "full of proposals"
+        main(["capture", "--kind", "requirement", f"req {i}", "--origin", "llm"])
+    capsys.readouterr()
+    assert main(["review", "--json"]) == 0  # review exists + un-gated
+    proposed = [c["id"] for c in json.loads(capsys.readouterr().out)["proposed_claims"]]
+    assert len(proposed) == 10
+    # One batched confirm + one batched reject resolve a chosen set; the rest stay proposed.
+    assert main(["confirm", *proposed[:6]]) == 0
+    assert main(["reject", *proposed[6:8]]) == 0
+    statuses = [
+        c.status for c in store.load(store.current_slug()).claims if c.kind == "requirement"
+    ]
+    assert statuses.count("confirmed") == 6
+    assert statuses.count("rejected") == 2
+    assert statuses.count("proposed") == 2  # untouched — never auto-confirmed
+
+
+def test_no_new_claim_or_condition_states(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "X"])
+    main(["capture", "--kind", "audience", "y", "--origin", "llm"])
+    main(["interrogate", "c1", "--honesty", "z"])
+    main(["confirm", "c2"])
+    main(["reject", "h1"])
+    f = store.load(store.current_slug())
+    seen = {c.status for c in f.claims}
+    seen |= {h.status for c in f.claims for h in c.honesty_conditions}
+    assert seen <= _KNOWN_STATUSES  # no new states introduced
+    assert set(frame_mod.CLAIM_KINDS) == _CONTRACT_KINDS  # no kinds added/removed

--- a/tests/test_review_loop_invariants.py
+++ b/tests/test_review_loop_invariants.py
@@ -1,0 +1,72 @@
+"""Cross-cutting invariants for the Human Review Loop (#17), plan task t6.
+
+These map directly onto the spec's honesty conditions:
+- c16/h5  — no review-flow command auto-confirms a proposed item.
+- c3/h8   — one `review` shows every proposed item; one batched confirm/reject
+            resolves a chosen set, on a NON-converged frame.
+- c5/h10  — anti-fabrication preserved: an llm proposal stays proposed until an
+            explicit user confirm naming that id.
+"""
+
+from __future__ import annotations
+
+import json
+
+from devague import store
+from devague.cli import main
+
+
+def _frame_with_proposals(monkeypatch, tmp_path) -> str:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Human review loop"])  # c1 confirmed announcement
+    main(["capture", "--kind", "audience", "ops + llm", "--origin", "llm"])  # c2 proposed
+    main(["capture", "--kind", "after_state", "one-pass review", "--origin", "llm"])  # c3 proposed
+    main(["interrogate", "c1", "--honesty", "announcement true at release"])  # h1 proposed
+    main(["interrogate", "c1", "--honesty", "no auto-confirm path"])  # h2 proposed
+    return store.current_slug()
+
+
+def _statuses(slug: str) -> tuple[dict, dict]:
+    f = store.load(slug)
+    claims = {c.id: c.status for c in f.claims}
+    honesty = {h.id: h.status for c in f.claims for h in c.honesty_conditions}
+    return claims, honesty
+
+
+def test_review_flow_never_auto_confirms(tmp_path, monkeypatch) -> None:
+    slug = _frame_with_proposals(monkeypatch, tmp_path)
+    before = _statuses(slug)
+    main(["review"])
+    main(["review", "--json"])
+    # An all-`pending` review file confirms nothing (errors, mutates nothing).
+    main(["confirm", "--from-review", str(store.review_path(slug))])
+    assert _statuses(slug) == before
+    claims, honesty = _statuses(slug)
+    assert claims["c2"] == "proposed" and claims["c3"] == "proposed"
+    assert honesty["h1"] == "proposed" and honesty["h2"] == "proposed"
+
+
+def test_one_pass_review_then_batch_resolve(tmp_path, monkeypatch, capsys) -> None:
+    slug = _frame_with_proposals(monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert main(["review", "--json"]) == 0  # un-gated: frame is nowhere near converged
+    payload = json.loads(capsys.readouterr().out)
+    ids = [c["id"] for c in payload["proposed_claims"]]
+    ids += [h["id"] for h in payload["proposed_honesty"]]
+    assert set(ids) == {"c2", "c3", "h1", "h2"}
+    # One batched confirm + one batched reject resolve a chosen set in two calls.
+    assert main(["confirm", "c2", "h1"]) == 0
+    assert main(["reject", "c3"]) == 0
+    claims, honesty = _statuses(slug)
+    assert claims["c2"] == "confirmed" and honesty["h1"] == "confirmed"
+    assert claims["c3"] == "rejected"
+    assert honesty["h2"] == "proposed"  # unnamed => untouched
+
+
+def test_llm_proposal_stays_proposed_until_user_confirm(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "X"])
+    main(["capture", "--kind", "audience", "y", "--origin", "llm"])  # c2 proposed
+    assert store.load(store.current_slug()).find_claim("c2").status == "proposed"
+    main(["confirm", "c2"])  # only an explicit user action flips it
+    assert store.load(store.current_slug()).find_claim("c2").status == "confirmed"


### PR DESCRIPTION
## What

Implements the **0.6.0 Human Review Loop** (#17) — the full 7-task plan exported
by `/spec-to-plan` in #22. Makes the user-only confirmation step ergonomic at
scale while preserving the anti-fabrication guarantee. No LLM in the CLI; no
external services.

## The loop

```bash
devague review                 # list every proposed item with ids (un-gated, no mutation)
devague review --json          # structured
devague confirm c2 h1 h3       # confirm many ids in one transactional call
devague reject c4 c5           # reject many ids in one call
devague confirm --from-review .devague/reviews/<slug>.md   # apply an edited review file
devague question "…"           # record / --list / --resolve pending decisions
```

`review` writes a non-authoritative artifact to `.devague/reviews/<slug>.md`;
each item carries an editable `pending` marker (change to `confirm`/`reject`,
then `confirm --from-review`). `pending` lines are never auto-confirmed; batches
are transactional (one bad id ⇒ nothing changes). devague manages `.gitignore`
so `.devague/reviews/` and `.devague/questions/` stay uncommitted working state.

## Tasks (each its own commit)

| Task | Commit | Covers |
|------|--------|--------|
| t1 multi-id transactional confirm/reject | `feat(t1)` | c14, h3 |
| t2 `devague review` (un-gated, no mutation) | `feat(t2)` | c12, h1 |
| t3 non-authoritative artifact + `.gitignore` | `feat(t3)` | c13, h2 |
| t4 `confirm --from-review` round-trip | `feat(t4)` | c21, h13 |
| t5 `devague question` working state | `feat(t5)` | c15, h4 |
| t6 cross-cutting invariant suite | `test(t6)` | c16,h5,c6,h11,c5,h10,c3,h8 |
| t7 docs + version 0.6.0 + integration | `feat(t7)` | c1,h6,c2,h7,c4,h9,c7,h12 |

All 26 plan coverage targets implemented and tested.

## Verification

- **210 tests pass** (was 181 on main); coverage **96.97%** (gate 95%).
- flake8 / black / isort / markdownlint all clean.
- The no-auto-confirm invariant, review-before-convergence, multi-id transactional
  confirm/reject, and the `--from-review` round-trip each have explicit tests; an
  integration test asserts 0.6.0 introduced **no new claim/condition states**.
- End-to-end smoke (review → edit markers → `--from-review`) verified outside the
  test harness.

Bumps `0.5.1 → 0.6.0`. Closes #17 (and the directions of #11, #14).

- devague (Claude)
