### PR TITLE
fix(render): surface requirement claim text in spec_md (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-23
+
+### Fixed
+
+- `spec_md` now surfaces `requirement` **claim text** — the last remaining item of #21. Requirements render in a `## Requirements` section with their confirmed honesty conditions nested beneath each claim; honesty conditions on non-requirement claims move to a separate `## Honesty conditions` section (previously every honesty condition was dumped into one flat "Requirements / honesty conditions" list and the requirement claim text never rendered). Re-exported the committed specs to match. Closes #21.
+
 ## [0.6.0] - 2026-05-23
 
 ### Added

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -27,8 +27,27 @@ def _before_after(frame: Frame) -> list[str]:
     return lines + [""]
 
 
-def _confirmed_honesty(frame: Frame) -> list[str]:
-    return [h.text for c in frame.claims for h in c.honesty_conditions if h.status == "confirmed"]
+def _requirements_block(frame: Frame) -> list[str]:
+    """Requirement claims (confirmed) with their confirmed honesty conditions nested."""
+    reqs = [c for c in frame.claims if c.kind == "requirement" and c.status == "confirmed"]
+    if not reqs:
+        return []
+    out = ["## Requirements", ""]
+    for c in reqs:
+        out.append(f"- {c.text}")
+        out += [f"  - honesty: {h.text}" for h in c.honesty_conditions if h.status == "confirmed"]
+    return out + [""]
+
+
+def _other_honesty(frame: Frame) -> list[str]:
+    """Confirmed honesty conditions on non-requirement claims (already shown inline)."""
+    return [
+        h.text
+        for c in frame.claims
+        if c.kind != "requirement"
+        for h in c.honesty_conditions
+        if h.status == "confirmed"
+    ]
 
 
 def _hard_questions(frame: Frame) -> list[str]:
@@ -49,7 +68,8 @@ def render_spec(frame: Frame) -> str:
     out += _section("Audience", _texts(frame, "audience"))
     out += _before_after(frame)
     out += _section("Why it matters", _texts(frame, "why_it_matters"))
-    out += _section("Requirements / honesty conditions", _confirmed_honesty(frame))
+    out += _requirements_block(frame)
+    out += _section("Honesty conditions", _other_honesty(frame))
     out += _section("Success signals", _texts(frame, "success_signal"))
     out += _section("Scope / boundaries", _texts(frame, "boundary"))
     out += _section("Non-goals", _texts(frame, "non_goal"))

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -40,11 +40,17 @@ def _requirements_block(frame: Frame) -> list[str]:
 
 
 def _other_honesty(frame: Frame) -> list[str]:
-    """Confirmed honesty conditions on non-requirement claims (already shown inline)."""
+    """Confirmed honesty conditions on **confirmed** non-requirement claims.
+
+    The parent claim must be confirmed too: spec-md renders only confirmed claims
+    (see ``_texts``), so emitting honesty for a proposed/rejected claim would
+    leave an orphan bullet with no parent — inconsistent with the confirmed-only
+    export contract.
+    """
     return [
         h.text
         for c in frame.claims
-        if c.kind != "requirement"
+        if c.kind != "requirement" and c.status == "confirmed"
         for h in c.honesty_conditions
         if h.status == "confirmed"
     ]

--- a/docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md
+++ b/docs/specs/devague-0-6-0-ships-the-human-review-loop-devague.md
@@ -15,7 +15,22 @@
 
 - The user-only confirmation step is devague's whole anti-fabrication guarantee; it must be ergonomic enough to do honestly at scale and support out-of-band review (read proposals somewhere comfortable like NotebookLM or a shared doc, then apply decisions), or it gets skipped or rubber-stamped.
 
-## Requirements / honesty conditions
+## Requirements
+
+- 'devague review' (and 'devague review --json') emits all proposed claims and proposed honesty conditions, with their ids, without requiring or triggering convergence.
+  - honesty: Running 'devague review' on a frame that has NOT converged still exits 0 and lists every proposed claim and proposed honesty condition with ids; it never invokes the convergence gate nor mutates any claim/condition state.
+- Review output is clearly labelled unconfirmed and non-authoritative, visually distinct from the buildable spec that 'export' produces only after convergence.
+  - honesty: The review artifact carries an explicit 'nothing confirmed yet — non-authoritative' banner and is written to a path under `.devague/reviews/<slug>.md`, distinct from docs/specs/, so it cannot be mistaken for the buildable spec.
+- 'devague confirm' accepts multiple claim/honesty ids in one invocation, and 'devague reject' likewise.
+  - honesty: 'devague confirm a b c' resolves every listed id in a single call (and 'reject a b c' likewise), and the handling of a batch containing an invalid/unknown id follows one defined, tested rule.
+- Open questions / pending user decisions can be written as durable .devague working state (e.g. `.devague/questions/<slug>.md`), treated as uncommitted working state by default unless the user intentionally promotes one into docs.
+  - honesty: A pending question the CLI writes persists across runs under `.devague/questions/<slug>.md`, is treated as uncommitted working state by default, and a documented path exists to apply a confirmed decision back into the frame.
+- No command in the review flow auto-confirms LLM-proposed content; every confirm/reject stays an explicit user action.
+  - honesty: An automated test asserts that no review-flow command (review, multi-id confirm/reject, any --json path) transitions an llm-origin proposed item to confirmed without an explicit user confirm naming that id.
+- `devague confirm --from-review <file>` applies a reviewed decision set parsed from the review artifact; the artifact 'devague review' emits is documented and round-trippable (review -> edit decisions -> apply).
+  - honesty: A review artifact emitted by 'devague review' can be edited with confirm/reject decisions and fed to `devague confirm --from-review <file>` to apply exactly those decisions — proven by a round-trip test — and applying it still auto-confirms nothing the file did not mark confirmed.
+
+## Honesty conditions
 
 - At 0.6.0 release the announcement is literally true of the shipped CLI: 'devague review' exists, and a frame full of proposed items can be reviewed then bulk confirmed/rejected in one pass with no path that auto-confirms.
 - Both audiences are served: the operator gets a single review + bulk-decide path, and the LLM agent's proposals stay visibly 'proposed' until the operator explicitly acts.
@@ -24,12 +39,6 @@
 - The anti-fabrication guarantee is preserved exactly: ergonomics improve but no proposal becomes authoritative without an explicit user action, asserted by test.
 - The success signals are verified by the committed test suite, not asserted by hand.
 - 0.6.0 adds only review/confirm UX; the proposed-vs-confirmed state model and convergence gate from #5/#16 are unchanged — no new claim or condition states are introduced.
-- Running 'devague review' on a frame that has NOT converged still exits 0 and lists every proposed claim and proposed honesty condition with ids; it never invokes the convergence gate nor mutates any claim/condition state.
-- The review artifact carries an explicit 'nothing confirmed yet — non-authoritative' banner and is written to a path under `.devague/reviews/<slug>.md`, distinct from docs/specs/, so it cannot be mistaken for the buildable spec.
-- 'devague confirm a b c' resolves every listed id in a single call (and 'reject a b c' likewise), and the handling of a batch containing an invalid/unknown id follows one defined, tested rule.
-- A pending question the CLI writes persists across runs under `.devague/questions/<slug>.md`, is treated as uncommitted working state by default, and a documented path exists to apply a confirmed decision back into the frame.
-- An automated test asserts that no review-flow command (review, multi-id confirm/reject, any --json path) transitions an llm-origin proposed item to confirmed without an explicit user confirm naming that id.
-- A review artifact emitted by 'devague review' can be edited with confirm/reject decisions and fed to `devague confirm --from-review <file>` to apply exactly those decisions — proven by a round-trip test — and applying it still auto-confirms nothing the file did not mark confirmed.
 
 ## Success signals
 

--- a/docs/specs/devague-now-ships-a-documented-spec-contract-every.md
+++ b/docs/specs/devague-now-ships-a-documented-spec-contract-every.md
@@ -15,7 +15,7 @@
 
 - An LLM and devague can only coordinate reliably around a contract that is documented, validated, and machine-readable — convergence must mean something, not vibes
 
-## Requirements / honesty conditions
+## Honesty conditions
 
 - A frame round-trips losslessly (save then load yields an identical frame) including schema_version, the new claim types, and the structured convergence payload; existing 0.4.0 frames still load
 - Every move accepts and emits documented JSON, and the contract spells out per-move input / output / state-transition / validation-errors so an LLM can drive devague without guessing internal state
@@ -42,7 +42,7 @@
 - The claim-type vocabulary adds non_goal, requirement, assumption, and decision to the shipped set, each with a documented convergence-gate impact
 - Every frame carries a schema_version field; load validates by version so existing frames keep loading as the schema grows
 
-## Non-goals
+## Scope / boundaries
 
 - Not a full PRD generator and not a fixed wizard; the move-driven, deterministic model stays
 - The local contract requires no GitHub, agents, or external services

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.6.0"
+version = "0.6.1"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -79,7 +79,8 @@ def test_spec_md_omits_empty_before_after_section() -> None:
 def _rich_frame() -> Frame:
     """A frame exercising the kinds added by the #5/#16 contract."""
     f = Frame(slug="r", title="Rich Feature")
-    f.add_claim("announcement", "Shipped", origin="user")
+    ann = f.add_claim("announcement", "Shipped", origin="user")
+    f.add_honesty(ann, "must be honest", origin="user")  # non-requirement honesty
     f.add_claim("boundary", "scope is X only", origin="user")
     f.add_claim("non_goal", "does not call an LLM", origin="user")
     f.add_claim("non_goal", "no external services", origin="user")
@@ -103,6 +104,18 @@ def test_spec_md_renders_non_goal_and_decision() -> None:
     # boundary keeps its own section, distinct from non-goals
     assert "## Scope / boundaries" in out
     assert "scope is X only" in out
+    assert_markdownlint_clean(out)
+
+
+def test_spec_md_renders_requirement_claim_text_with_nested_honesty() -> None:
+    # #21 remaining item: requirement *claim* text must render, not only its honesty.
+    out = render.render(_rich_frame(), "spec-md")
+    assert "## Requirements" in out
+    assert "- review lists proposed items" in out  # the requirement claim text
+    assert "  - honesty: review never mutates state" in out  # nested under it
+    # honesty on non-requirement claims still appears, in its own section
+    assert "## Honesty conditions" in out
+    assert "must be honest" in out  # the announcement's honesty (non-requirement)
     assert_markdownlint_clean(out)
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -153,6 +153,18 @@ def test_review_md_empty_when_no_proposals() -> None:
     assert_markdownlint_clean(out)
 
 
+def test_spec_md_omits_honesty_for_unconfirmed_claims() -> None:
+    # #24 (Qodo): a proposed/rejected claim carrying a confirmed honesty must not
+    # leave an orphan honesty bullet — spec-md renders confirmed claims only.
+    f = Frame(slug="o", title="Orphan")
+    f.add_claim("announcement", "Shipped", origin="user")  # confirmed
+    proposed = f.add_claim("audience", "maybe devs", origin="llm")  # proposed
+    f.add_honesty(proposed, "honesty whose parent is unconfirmed", origin="user")
+    out = render.render(f, "spec-md")
+    assert "honesty whose parent is unconfirmed" not in out
+    assert "maybe devs" not in out  # the proposed claim text is omitted too
+
+
 def test_unknown_format_raises() -> None:
     with pytest.raises(DevagueError):
         render.render(_frame(), "nope")


### PR DESCRIPTION
## What

Closes the last open item of **#21**: `spec_md` rendered requirements only via
their honesty conditions — the requirement **claim text itself never appeared**.
(The rest of #21 — `non_goal` / `decision` / `assumption` / `open_question`
rendering and the `frame_md` gap — already shipped in #22; the issue stayed open
only because the squash dropped the `closes #21` keyword.)

## Change (option A)

- `spec_md` now renders a `## Requirements` section: each confirmed `requirement`
  claim's **text**, with its confirmed honesty conditions nested beneath it
  (mirrors how `frame_md` nests honesty under claims).
- Honesty conditions on **non-requirement** claims move to a separate
  `## Honesty conditions` section (previously every honesty condition was dumped
  into one flat "Requirements / honesty conditions" list).
- Re-exported both committed specs so they match the renderer.

## Before / after (requirements)

```diff
-## Requirements / honesty conditions
-
-- <honesty condition text>          # claim text was never shown
+## Requirements
+
+- <requirement claim text>
+  - honesty: <its honesty condition>
+
+## Honesty conditions
+
+- <honesty on announcement/audience/… claims>
```

## Verification

- **212 tests** pass (+1: `test_spec_md_renders_requirement_claim_text_with_nested_honesty`); coverage ≥ 95%.
- flake8 / black / isort / markdownlint clean.
- Re-export is faithful: the only committed-spec deltas are the new section
  structure (and the markdownlint hand-fixes the renderer can't infer from
  source text).

Bumps `0.6.0 → 0.6.1`. Closes #21.

- devague (Claude)
