### PR TITLE
Spec + plan: assign-to-workforce — subagent-driven plan implementation (#13)

### DIFF
--- a/.devague/current_plan
+++ b/.devague/current_plan
@@ -1,1 +1,1 @@
-devague-0-6-0-ships-the-human-review-loop-devague
+devague-turns-a-converged-plan-into-parallel-simpl

--- a/.devague/frames/devague-turns-a-converged-plan-into-parallel-simpl.json
+++ b/.devague/frames/devague-turns-a-converged-plan-into-parallel-simpl.json
@@ -1,0 +1,353 @@
+{
+  "slug": "devague-turns-a-converged-plan-into-parallel-simpl",
+  "title": "Devague plans get parallel, TDD-gated, simpler-model implementation via assign-to-workforce",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-05-23T19:47:38Z",
+  "updated": "2026-05-23T20:21:25Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "Devague turns a converged plan into parallel, simpler-model-executable work: /spec-to-plan yields plans whose tasks are independently parallelizable and scoped tightly enough for a cheap model to build, and a cited subagent-driven-development skill fans out 'devague plan waves' to one subagent per task per wave \u2014 contention-safe, acceptance-gated, and human-merged. The CLI stays deterministic and non-orchestrating (#20).",
+      "origin": "user",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "End-to-end the flow runs on a real converged plan \u2014 'devague plan waves' -> one subagent per task per wave in isolated worktrees -> resident-agent acceptance review -> human spec+PR gate \u2014 without adding any orchestration or LLM call to the devague CLI.",
+          "status": "rejected"
+        },
+        {
+          "id": "h16",
+          "text": "End-to-end the flow runs on a real converged plan \u2014 'devague plan waves' -> human approves the implementation split plan (plan map, per-task subagent/model assignment, go/no-go to workforce) -> one subagent per task per wave in isolated worktrees -> main-agent TDD-gated merges (no human per task) -> human spec & final-PR gates \u2014 without adding any orchestration or LLM call to the devague CLI.",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "The devague/AgentCulture operator agent that implements a converged plan, plus the human who owns the merge gate. Per-task work may be delegated to cheaper/simpler models.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h20",
+          "text": "Each named audience really interacts with the flow: the operator agent drives waves and merges, the human owns the three gates (spec / split plan / PR), and cheaper models execute individual tasks \u2014 no silent fourth approver.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "A converged plan can be built by fanning out independent tasks to parallel subagents \u2014 including a simpler model per task \u2014 instead of one agent building serially.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h21",
+          "text": "The parallel + cheap-model build yields the same result as a serial build would \u2014 fan-out changes speed and cost, not correctness; the merged result passes the same TDD tests.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "'devague plan waves' emits the schedule, but there is no devague convention for who fans it out, how files stay contention-safe, how a task is accepted, or how plans should be authored to be parallel- and simple-model-friendly.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h22",
+          "text": "Today there genuinely is no devague convention for fan-out / contention / acceptance: 'devague plan waves' (#20) emits the schedule but stops at description, and nothing downstream consumes it yet.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "Parallel + cheap-model execution makes plans much faster and cheaper to build and forces tighter task scoping \u2014 but only pays off if it stays safe and reviewable.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h23",
+          "text": "The speed/cost win is real, not assumed: parallel waves plus cheap per-task models cut wall-clock and token cost versus one serial agent, while the TDD gates keep quality from dropping.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c6",
+      "kind": "boundary",
+      "text": "Devague's CLI does not orchestrate: it does not spawn subagents, manage worktrees, mark tasks done, or pick a backend (#20 stands). This work is a convention + cited skill, not new CLI and not a CI/CD runner.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "This work adds no LLM calls and no orchestration to the devague CLI.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c7",
+      "kind": "success_signal",
+      "text": "An operator takes a converged plan, runs 'devague plan waves', and fans out each wave to subagents with zero file collisions, each task gated on its own acceptance criteria, and nothing merged without the human.",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "Same-wave tasks that touch the same file are made safe by an explicit mechanism \u2014 the dependency graph alone does NOT guarantee file-disjointness.",
+          "status": "rejected"
+        },
+        {
+          "id": "h4",
+          "text": "The human merge gate is enforced: no subagent output merges without human review (mirrors the no-auto-confirm rule).",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c8",
+      "kind": "requirement",
+      "text": "/spec-to-plan yields plans whose tasks are independently parallelizable AND scoped tightly enough that a simpler/cheaper model can execute each one against its acceptance criteria.",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "Within-wave independence is real: same-wave tasks have no inter-task dependency and can be built concurrently.",
+          "status": "rejected"
+        },
+        {
+          "id": "h2",
+          "text": "'Scoped for a simpler model' is operational, not a vibe: each task's acceptance criteria are crisp enough to validate a cheap model's output without re-deriving the design.",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c9",
+      "kind": "decision",
+      "text": "Orchestration lives in a cited, devague-specific subagent-driven-development skill (citing superpowers:subagent-driven-development) plus a CLAUDE.md convention \u2014 not in the deterministic CLI.",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "The new skill is cited (copied), not imported, with provenance recorded in docs/skill-sources.md (cite-don't-import).",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c10",
+      "kind": "decision",
+      "text": "File-contention safety: each subagent runs in an isolated git worktree, so same-file overlap surfaces as a merge conflict at reconcile time rather than a live race. (resolves q1)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c11",
+      "kind": "decision",
+      "text": "Parallel/simple-model fitness is enforced two ways: /spec-to-plan skill guidance for small, parallel, crisply-accepted tasks, PLUS a deterministic NON-blocking plan_convergence warning (e.g. missing acceptance criteria, over-serialized waves). No hard gate, no LLM in the CLI. (resolves q2)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c12",
+      "kind": "decision",
+      "text": "Two-tier acceptance gate: the resident/operating agent reviews each subagent's output against that task's acceptance criteria and records it in a review-style artifact (mirroring the #17 Human Review Loop); the human reviews the exported spec and the final PR \u2014 the human merge gate. (resolves q3)",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "The per-task acceptance review the resident agent writes is non-authoritative working state; only the human's PR review merges anything.",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c13",
+      "kind": "decision",
+      "text": "The plan stays model-agnostic; per-task subagent assignment (scope + chosen model) is the resident agent's proposal, presented as a clear, editable table the human approves or edits, and the human decides whether to run subagent-driven at all. Devague does not pick a backend (#20). (resolves q4)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c14",
+      "kind": "success_signal",
+      "text": "An operator takes a converged plan, runs 'devague plan waves', and fans out each wave to subagents in isolated worktrees with no live file races. The main/operating agent merges each task's worktree gated by TDD \u2014 the task's tests pass before AND after merge \u2014 plus its acceptance criteria; no human is needed per task. The human gates only the exported spec and the final PR.",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "Same-wave tasks touching the same file are made safe by isolated worktrees \u2014 the dependency graph alone does NOT guarantee file-disjointness; overlaps reconcile at merge.",
+          "status": "rejected"
+        },
+        {
+          "id": "h10",
+          "text": "Per-task merges need no human: the main agent gates each subagent's worktree merge with TDD (the task's tests pass before and after merge); the only human gates are spec approval and the final PR.",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c15",
+      "kind": "decision",
+      "text": "Orchestration lives in a cited, devague-specific skill named 'assign-to-workforce' (citing superpowers:subagent-driven-development) plus a CLAUDE.md convention \u2014 not in the deterministic CLI. The name is deliberately broader than 'subagents' to leave room for teammate agents and generalist agents in future.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "The assign-to-workforce skill is cited (copied), not imported, with provenance recorded in docs/skill-sources.md (cite-don't-import).",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c16",
+      "kind": "decision",
+      "text": "Two-tier gate: per task, the main/operating agent gates the subagent's worktree merge with TDD (tests pass before and after merge) against the task's acceptance criteria \u2014 NO human per task; the human's gate is only the exported spec and the final PR. Per-task acceptance is recorded as uncommitted working state (mirroring the #17 Human Review Loop).",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "Per-task acceptance is the main agent's, expressed as tests (TDD) plus the task's acceptance criteria, recorded as non-authoritative working state; the authoritative human gates are the spec and the final PR.",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c17",
+      "kind": "decision",
+      "text": "The assign-to-workforce skill and any skill changes are shared via 'devague learn' \u2014 'devague learn' carries the instructions for how to invoke subagent-driven-development / assign-to-workforce (how to fan out a converged plan's waves).",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c18",
+      "kind": "success_signal",
+      "text": "An operator takes a converged plan, runs 'devague plan waves', and presents the implementation split plan for the human to approve \u2014 the plan/tasks map, the per-task subagent + model assignment, and the go/no-go on assigning the plan to the workforce. Approved waves fan out to subagents in isolated worktrees with no live file races; the main agent merges each task's worktree gated by TDD (tests pass before and after merge) \u2014 no human per task. The human's remaining gates are the exported spec and the final PR.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "Same-wave tasks touching the same file are made safe by isolated worktrees \u2014 the dependency graph alone does NOT guarantee file-disjointness; overlaps reconcile at merge.",
+          "status": "confirmed"
+        },
+        {
+          "id": "h14",
+          "text": "Per-task merges need no human: the main agent gates each subagent's worktree merge with TDD (tests pass before and after merge). The human's three gates are the spec, the implementation split plan (plan map + assignments + go/no-go to workforce), and the final PR.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c19",
+      "kind": "decision",
+      "text": "The human's gates are exactly three: (1) the exported spec, (2) the implementation split plan \u2014 the plan/tasks map, the per-task subagent + model assignment, and the go/no-go on assigning the plan to the workforce \u2014 and (3) the final PR. The human is NOT in the per-task worktree-merge loop: the main/operating agent gates each merge with TDD (tests pass before and after merge) against the task's acceptance criteria. Per-task acceptance is uncommitted working state (mirroring the #17 Human Review Loop).",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h15",
+          "text": "Per-task acceptance is the main agent's (TDD tests + the task's acceptance criteria), recorded as non-authoritative working state; the authoritative human gates are the spec, the implementation split plan, and the final PR.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c20",
+      "kind": "announcement",
+      "text": "Devague turns a converged plan into parallel, simpler-model-executable work. /spec-to-plan yields plans whose tasks are independently parallelizable and given TDD acceptance criteria \u2014 scoped tightly enough for a cheap model to build test-first. A cited 'assign-to-workforce' skill (shared via 'devague learn') fans out 'devague plan waves' to one subagent per task per wave in isolated git worktrees; the main agent merges each task via TDD (its tests pass before AND after merge), while the human gates the spec, the implementation split plan, and the final PR. The CLI stays deterministic and non-orchestrating (#20).",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h17",
+          "text": "End-to-end the flow runs on a real converged plan \u2014 'devague plan waves' -> human approves the implementation split plan (plan map, per-task subagent/model assignment, go/no-go to workforce) -> one subagent per task per wave in isolated worktrees -> main-agent TDD-gated merges (tests pass before and after merge; no human per task) -> human spec & final-PR gates \u2014 without adding any orchestration or LLM call to the devague CLI.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "/spec-to-plan yields plans whose tasks are independently parallelizable AND given TDD acceptance criteria \u2014 tests specified first, scoped tightly enough that a simpler/cheaper model can build each one test-first and have its output validated by those tests.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h18",
+          "text": "Within-wave independence is real: same-wave tasks have no inter-task dependency and can be built concurrently.",
+          "status": "confirmed"
+        },
+        {
+          "id": "h19",
+          "text": "'Scoped for a simpler model' is operational via TDD, not a vibe: each task ships with tests crisp enough to validate a cheap model's output (the tests pass) without re-deriving the design.",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    }
+  ],
+  "open_vagueness": []
+}

--- a/.devague/plans/devague-turns-a-converged-plan-into-parallel-simpl.json
+++ b/.devague/plans/devague-turns-a-converged-plan-into-parallel-simpl.json
@@ -1,0 +1,217 @@
+{
+  "slug": "devague-turns-a-converged-plan-into-parallel-simpl",
+  "title": "Devague plans get parallel, TDD-gated, simpler-model implementation via assign-to-workforce",
+  "frame_slug": "devague-turns-a-converged-plan-into-parallel-simpl",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-05-23T20:24:19Z",
+  "updated": "2026-05-23T20:35:22Z",
+  "targets": [
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "The devague/AgentCulture operator agent that implements a converged plan, plus the human who owns the merge gate. Per-task work may be delegated to cheaper/simpler models."
+    },
+    {
+      "id": "h20",
+      "kind": "honesty",
+      "text": "Each named audience really interacts with the flow: the operator agent drives waves and merges, the human owns the three gates (spec / split plan / PR), and cheaper models execute individual tasks \u2014 no silent fourth approver."
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "A converged plan can be built by fanning out independent tasks to parallel subagents \u2014 including a simpler model per task \u2014 instead of one agent building serially."
+    },
+    {
+      "id": "h21",
+      "kind": "honesty",
+      "text": "The parallel + cheap-model build yields the same result as a serial build would \u2014 fan-out changes speed and cost, not correctness; the merged result passes the same TDD tests."
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "'devague plan waves' emits the schedule, but there is no devague convention for who fans it out, how files stay contention-safe, how a task is accepted, or how plans should be authored to be parallel- and simple-model-friendly."
+    },
+    {
+      "id": "h22",
+      "kind": "honesty",
+      "text": "Today there genuinely is no devague convention for fan-out / contention / acceptance: 'devague plan waves' (#20) emits the schedule but stops at description, and nothing downstream consumes it yet."
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "Parallel + cheap-model execution makes plans much faster and cheaper to build and forces tighter task scoping \u2014 but only pays off if it stays safe and reviewable."
+    },
+    {
+      "id": "h23",
+      "kind": "honesty",
+      "text": "The speed/cost win is real, not assumed: parallel waves plus cheap per-task models cut wall-clock and token cost versus one serial agent, while the TDD gates keep quality from dropping."
+    },
+    {
+      "id": "c6",
+      "kind": "boundary",
+      "text": "Devague's CLI does not orchestrate: it does not spawn subagents, manage worktrees, mark tasks done, or pick a backend (#20 stands). This work is a convention + cited skill, not new CLI and not a CI/CD runner."
+    },
+    {
+      "id": "h5",
+      "kind": "honesty",
+      "text": "This work adds no LLM calls and no orchestration to the devague CLI."
+    },
+    {
+      "id": "c18",
+      "kind": "success_signal",
+      "text": "An operator takes a converged plan, runs 'devague plan waves', and presents the implementation split plan for the human to approve \u2014 the plan/tasks map, the per-task subagent + model assignment, and the go/no-go on assigning the plan to the workforce. Approved waves fan out to subagents in isolated worktrees with no live file races; the main agent merges each task's worktree gated by TDD (tests pass before and after merge) \u2014 no human per task. The human's remaining gates are the exported spec and the final PR."
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "Same-wave tasks touching the same file are made safe by isolated worktrees \u2014 the dependency graph alone does NOT guarantee file-disjointness; overlaps reconcile at merge."
+    },
+    {
+      "id": "h14",
+      "kind": "honesty",
+      "text": "Per-task merges need no human: the main agent gates each subagent's worktree merge with TDD (tests pass before and after merge). The human's three gates are the spec, the implementation split plan (plan map + assignments + go/no-go to workforce), and the final PR."
+    },
+    {
+      "id": "c20",
+      "kind": "announcement",
+      "text": "Devague turns a converged plan into parallel, simpler-model-executable work. /spec-to-plan yields plans whose tasks are independently parallelizable and given TDD acceptance criteria \u2014 scoped tightly enough for a cheap model to build test-first. A cited 'assign-to-workforce' skill (shared via 'devague learn') fans out 'devague plan waves' to one subagent per task per wave in isolated git worktrees; the main agent merges each task via TDD (its tests pass before AND after merge), while the human gates the spec, the implementation split plan, and the final PR. The CLI stays deterministic and non-orchestrating (#20)."
+    },
+    {
+      "id": "h17",
+      "kind": "honesty",
+      "text": "End-to-end the flow runs on a real converged plan \u2014 'devague plan waves' -> human approves the implementation split plan (plan map, per-task subagent/model assignment, go/no-go to workforce) -> one subagent per task per wave in isolated worktrees -> main-agent TDD-gated merges (tests pass before and after merge; no human per task) -> human spec & final-PR gates \u2014 without adding any orchestration or LLM call to the devague CLI."
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "/spec-to-plan yields plans whose tasks are independently parallelizable AND given TDD acceptance criteria \u2014 tests specified first, scoped tightly enough that a simpler/cheaper model can build each one test-first and have its output validated by those tests."
+    },
+    {
+      "id": "h18",
+      "kind": "honesty",
+      "text": "Within-wave independence is real: same-wave tasks have no inter-task dependency and can be built concurrently."
+    },
+    {
+      "id": "h19",
+      "kind": "honesty",
+      "text": "'Scoped for a simpler model' is operational via TDD, not a vibe: each task ships with tests crisp enough to validate a cheap model's output (the tests pass) without re-deriving the design."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "Author the assign-to-workforce skill: SKILL.md + a portable helper script, plus its first-party provenance entry",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "SKILL.md documents the full flow: read 'devague plan waves' -> present the implementation split plan (tasks map + per-task subagent+model proposal) -> human go/no-go -> one subagent per task per wave in isolated git worktrees -> main-agent TDD-gated merge (the task's tests pass before AND after merge) -> human gates spec + split-plan + final PR",
+        "scripts/assign-to-workforce.sh resolves devague portably (mirrors think.sh) and prints the split-plan from 'devague plan waves --json'; on a converged plan it exits 0 and lists the waves",
+        "docs/skill-sources.md records assign-to-workforce as first-party (origin=devague); the skill states the CLI is never orchestrated by devague (#20)"
+      ],
+      "deps": [],
+      "covers": [
+        "c18",
+        "c20",
+        "h13",
+        "h14",
+        "h17"
+      ]
+    },
+    {
+      "id": "t2",
+      "summary": "Document the assign-to-workforce convention in CLAUDE.md",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "CLAUDE.md gains a 'Subagent-driven implementation (assign-to-workforce)' section stating the three human gates (spec / implementation split plan / final PR), worktree contention safety, the main-agent TDD merge gate (no human per task), and the boundary that the CLI never spawns/orchestrates/marks-done/picks-backend (#20)",
+        "The section names the operator-agent and human roles and notes today's gap (waves emits the schedule but nothing downstream consumes it)",
+        "markdownlint-cli2 passes on CLAUDE.md and doc-test-alignment finds the section consistent with the skill"
+      ],
+      "deps": [],
+      "covers": [
+        "c2",
+        "c4",
+        "c5",
+        "c6",
+        "h5",
+        "h20",
+        "h22"
+      ]
+    },
+    {
+      "id": "t3",
+      "summary": "Add a deterministic, non-blocking plan_convergence warning for parallel/TDD fitness",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "Tests written first: 'devague plan converge --json' emits a non-blocking warnings[] entry for a confirmed task with no acceptance criteria, and for an over-serialized graph (e.g. a needless single-task wave / trivial chain)",
+        "Warnings never change ready_for_plan/blockers \u2014 convergence still passes; a clean plan emits zero warnings",
+        "A unit test asserts same-wave tasks have no inter-task dependency (within-wave independence holds)"
+      ],
+      "deps": [],
+      "covers": [
+        "c21",
+        "h18",
+        "h19"
+      ]
+    },
+    {
+      "id": "t4",
+      "summary": "Carry assign-to-workforce invocation instructions in 'devague learn' (implements decision c17)",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "Tests written first: 'devague learn' (and --json) output contains an assign-to-workforce / subagent-driven-development section covering when to fan out, the three gates, and worktree+TDD",
+        "A unit test asserts the learn text includes the assign-to-workforce guidance"
+      ],
+      "deps": [],
+      "covers": []
+    },
+    {
+      "id": "t5",
+      "summary": "Coach /spec-to-plan to yield small, file-disjoint, TDD-accepted (parallelizable) tasks",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "spec-to-plan SKILL.md gains guidance: prefer many small, file-disjoint tasks; give each TDD acceptance criteria (tests first); reference the new convergence warning; state that a parallel build must equal a serial build because the tests are the contract",
+        "markdownlint-cli2 passes; the skill's worked example yields a plan whose waves contain >1 task (demonstrably parallel)"
+      ],
+      "deps": [],
+      "covers": [
+        "c3",
+        "h21"
+      ]
+    },
+    {
+      "id": "t6",
+      "summary": "Dogfood: run assign-to-workforce on a real converged plan and capture the worked example",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "A worked example (in the skill or docs/) runs the flow on a real converged plan's waves: split-plan -> parallel subagents in worktrees -> TDD-gated merges, recording the qualitative speed/cost difference vs a serial build, with the TDD gates holding",
+        "The example is reproducible from the committed plan + 'devague plan waves' output"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "h23"
+      ]
+    }
+  ],
+  "risks": [
+    {
+      "id": "r1",
+      "text": "Quantitative speed/cost benchmarking (measured wall-clock/token savings) is out of scope for #13; the win is demonstrated qualitatively via the worked example, not measured",
+      "kind": "unknown_nonblocking",
+      "task_id": "t6"
+    },
+    {
+      "id": "r2",
+      "text": "A turnkey orchestrator that actually spawns subagents/worktrees is out of scope; assign-to-workforce is operator guidance + a waves/split-plan helper \u2014 the operating agent performs the fan-out (CLI stays non-orchestrating, #20)",
+      "kind": "out_of_scope",
+      "task_id": "t1"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,8 @@ __marimo__/
 
 # devague: local current-frame pointer (frames under .devague/frames/ are committed)
 .devague/current
+
+# devague working state (not committed by default)
+.devague/questions/
+
+.devague/reviews/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-05-23
+
+### Added
+
+- Spec + plan for subagent-driven implementation (#13). Drove `devague` /think then /spec-to-plan to produce a converged spec (`docs/specs/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md`) and a buildable, parallelizable plan (`docs/plans/...`) for the **assign-to-workforce** convention: a cited skill that fans out `devague plan waves` to one subagent per task per wave in isolated git worktrees, with main-agent TDD-gated per-task merges (no human per task) and exactly three human gates — the spec, the implementation split plan (tasks map + per-task subagent/model assignment + go/no-go), and the final PR. Planning artifacts only (no code yet); the CLI stays deterministic and non-orchestrating (#20).
+
 ## [0.9.0] - 2026-05-23
 
 ### Added

--- a/docs/plans/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md
+++ b/docs/plans/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md
@@ -1,0 +1,57 @@
+# Build Plan — Devague plans get parallel, TDD-gated, simpler-model implementation via assign-to-workforce
+
+slug: `devague-turns-a-converged-plan-into-parallel-simpl` · status: `exported` · from frame: `devague-turns-a-converged-plan-into-parallel-simpl`
+
+> Devague turns a converged plan into parallel, simpler-model-executable work. /spec-to-plan yields plans whose tasks are independently parallelizable and given TDD acceptance criteria — scoped tightly enough for a cheap model to build test-first. A cited 'assign-to-workforce' skill (shared via 'devague learn') fans out 'devague plan waves' to one subagent per task per wave in isolated git worktrees; the main agent merges each task via TDD (its tests pass before AND after merge), while the human gates the spec, the implementation split plan, and the final PR. The CLI stays deterministic and non-orchestrating (#20).
+
+## Tasks
+
+### t1 — Author the assign-to-workforce skill: SKILL.md + a portable helper script, plus its first-party provenance entry
+
+- covers: c18, c20, h13, h14, h17
+- acceptance:
+  - SKILL.md documents the full flow: read 'devague plan waves' -> present the implementation split plan (tasks map + per-task subagent+model proposal) -> human go/no-go -> one subagent per task per wave in isolated git worktrees -> main-agent TDD-gated merge (the task's tests pass before AND after merge) -> human gates spec + split-plan + final PR
+  - scripts/assign-to-workforce.sh resolves devague portably (mirrors think.sh) and prints the split-plan from 'devague plan waves --json'; on a converged plan it exits 0 and lists the waves
+  - docs/skill-sources.md records assign-to-workforce as first-party (origin=devague); the skill states the CLI is never orchestrated by devague (#20)
+
+### t2 — Document the assign-to-workforce convention in CLAUDE.md
+
+- covers: c2, c4, c5, c6, h5, h20, h22
+- acceptance:
+  - CLAUDE.md gains a 'Subagent-driven implementation (assign-to-workforce)' section stating the three human gates (spec / implementation split plan / final PR), worktree contention safety, the main-agent TDD merge gate (no human per task), and the boundary that the CLI never spawns/orchestrates/marks-done/picks-backend (#20)
+  - The section names the operator-agent and human roles and notes today's gap (waves emits the schedule but nothing downstream consumes it)
+  - markdownlint-cli2 passes on CLAUDE.md and doc-test-alignment finds the section consistent with the skill
+
+### t3 — Add a deterministic, non-blocking plan_convergence warning for parallel/TDD fitness
+
+- covers: c21, h18, h19
+- acceptance:
+  - Tests written first: 'devague plan converge --json' emits a non-blocking warnings[] entry for a confirmed task with no acceptance criteria, and for an over-serialized graph (e.g. a needless single-task wave / trivial chain)
+  - Warnings never change ready_for_plan/blockers — convergence still passes; a clean plan emits zero warnings
+  - A unit test asserts same-wave tasks have no inter-task dependency (within-wave independence holds)
+
+### t4 — Carry assign-to-workforce invocation instructions in 'devague learn' (implements decision c17)
+
+- acceptance:
+  - Tests written first: 'devague learn' (and --json) output contains an assign-to-workforce / subagent-driven-development section covering when to fan out, the three gates, and worktree+TDD
+  - A unit test asserts the learn text includes the assign-to-workforce guidance
+
+### t5 — Coach /spec-to-plan to yield small, file-disjoint, TDD-accepted (parallelizable) tasks
+
+- covers: c3, h21
+- acceptance:
+  - spec-to-plan SKILL.md gains guidance: prefer many small, file-disjoint tasks; give each TDD acceptance criteria (tests first); reference the new convergence warning; state that a parallel build must equal a serial build because the tests are the contract
+  - markdownlint-cli2 passes; the skill's worked example yields a plan whose waves contain >1 task (demonstrably parallel)
+
+### t6 — Dogfood: run assign-to-workforce on a real converged plan and capture the worked example
+
+- depends on: t1
+- covers: h23
+- acceptance:
+  - A worked example (in the skill or docs/) runs the flow on a real converged plan's waves: split-plan -> parallel subagents in worktrees -> TDD-gated merges, recording the qualitative speed/cost difference vs a serial build, with the TDD gates holding
+  - The example is reproducible from the committed plan + 'devague plan waves' output
+
+## Risks
+
+- [unknown_nonblocking] Quantitative speed/cost benchmarking (measured wall-clock/token savings) is out of scope for #13; the win is demonstrated qualitatively via the worked example, not measured (task t6)
+- [out_of_scope] A turnkey orchestrator that actually spawns subagents/worktrees is out of scope; assign-to-workforce is operator guidance + a waves/split-plan helper — the operating agent performs the fan-out (CLI stays non-orchestrating, #20) (task t1)

--- a/docs/specs/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md
+++ b/docs/specs/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md
@@ -1,0 +1,52 @@
+# Devague plans get parallel, TDD-gated, simpler-model implementation via assign-to-workforce
+
+> Devague turns a converged plan into parallel, simpler-model-executable work. /spec-to-plan yields plans whose tasks are independently parallelizable and given TDD acceptance criteria — scoped tightly enough for a cheap model to build test-first. A cited 'assign-to-workforce' skill (shared via 'devague learn') fans out 'devague plan waves' to one subagent per task per wave in isolated git worktrees; the main agent merges each task via TDD (its tests pass before AND after merge), while the human gates the spec, the implementation split plan, and the final PR. The CLI stays deterministic and non-orchestrating (#20).
+
+## Audience
+
+- The devague/AgentCulture operator agent that implements a converged plan, plus the human who owns the merge gate. Per-task work may be delegated to cheaper/simpler models.
+
+## Before → After
+
+- Before: 'devague plan waves' emits the schedule, but there is no devague convention for who fans it out, how files stay contention-safe, how a task is accepted, or how plans should be authored to be parallel- and simple-model-friendly.
+- After: A converged plan can be built by fanning out independent tasks to parallel subagents — including a simpler model per task — instead of one agent building serially.
+
+## Why it matters
+
+- Parallel + cheap-model execution makes plans much faster and cheaper to build and forces tighter task scoping — but only pays off if it stays safe and reviewable.
+
+## Requirements
+
+- /spec-to-plan yields plans whose tasks are independently parallelizable AND given TDD acceptance criteria — tests specified first, scoped tightly enough that a simpler/cheaper model can build each one test-first and have its output validated by those tests.
+  - honesty: Within-wave independence is real: same-wave tasks have no inter-task dependency and can be built concurrently.
+  - honesty: 'Scoped for a simpler model' is operational via TDD, not a vibe: each task ships with tests crisp enough to validate a cheap model's output (the tests pass) without re-deriving the design.
+
+## Honesty conditions
+
+- Each named audience really interacts with the flow: the operator agent drives waves and merges, the human owns the three gates (spec / split plan / PR), and cheaper models execute individual tasks — no silent fourth approver.
+- The parallel + cheap-model build yields the same result as a serial build would — fan-out changes speed and cost, not correctness; the merged result passes the same TDD tests.
+- Today there genuinely is no devague convention for fan-out / contention / acceptance: 'devague plan waves' (#20) emits the schedule but stops at description, and nothing downstream consumes it yet.
+- The speed/cost win is real, not assumed: parallel waves plus cheap per-task models cut wall-clock and token cost versus one serial agent, while the TDD gates keep quality from dropping.
+- This work adds no LLM calls and no orchestration to the devague CLI.
+- The assign-to-workforce skill is cited (copied), not imported, with provenance recorded in docs/skill-sources.md (cite-don't-import).
+- Same-wave tasks touching the same file are made safe by isolated worktrees — the dependency graph alone does NOT guarantee file-disjointness; overlaps reconcile at merge.
+- Per-task merges need no human: the main agent gates each subagent's worktree merge with TDD (tests pass before and after merge). The human's three gates are the spec, the implementation split plan (plan map + assignments + go/no-go to workforce), and the final PR.
+- Per-task acceptance is the main agent's (TDD tests + the task's acceptance criteria), recorded as non-authoritative working state; the authoritative human gates are the spec, the implementation split plan, and the final PR.
+- End-to-end the flow runs on a real converged plan — 'devague plan waves' -> human approves the implementation split plan (plan map, per-task subagent/model assignment, go/no-go to workforce) -> one subagent per task per wave in isolated worktrees -> main-agent TDD-gated merges (tests pass before and after merge; no human per task) -> human spec & final-PR gates — without adding any orchestration or LLM call to the devague CLI.
+
+## Success signals
+
+- An operator takes a converged plan, runs 'devague plan waves', and presents the implementation split plan for the human to approve — the plan/tasks map, the per-task subagent + model assignment, and the go/no-go on assigning the plan to the workforce. Approved waves fan out to subagents in isolated worktrees with no live file races; the main agent merges each task's worktree gated by TDD (tests pass before and after merge) — no human per task. The human's remaining gates are the exported spec and the final PR.
+
+## Scope / boundaries
+
+- Devague's CLI does not orchestrate: it does not spawn subagents, manage worktrees, mark tasks done, or pick a backend (#20 stands). This work is a convention + cited skill, not new CLI and not a CI/CD runner.
+
+## Decisions
+
+- File-contention safety: each subagent runs in an isolated git worktree, so same-file overlap surfaces as a merge conflict at reconcile time rather than a live race. (resolves q1)
+- Parallel/simple-model fitness is enforced two ways: /spec-to-plan skill guidance for small, parallel, crisply-accepted tasks, PLUS a deterministic NON-blocking plan_convergence warning (e.g. missing acceptance criteria, over-serialized waves). No hard gate, no LLM in the CLI. (resolves q2)
+- The plan stays model-agnostic; per-task subagent assignment (scope + chosen model) is the resident agent's proposal, presented as a clear, editable table the human approves or edits, and the human decides whether to run subagent-driven at all. Devague does not pick a backend (#20). (resolves q4)
+- Orchestration lives in a cited, devague-specific skill named 'assign-to-workforce' (citing superpowers:subagent-driven-development) plus a CLAUDE.md convention — not in the deterministic CLI. The name is deliberately broader than 'subagents' to leave room for teammate agents and generalist agents in future.
+- The assign-to-workforce skill and any skill changes are shared via 'devague learn' — 'devague learn' carries the instructions for how to invoke subagent-driven-development / assign-to-workforce (how to fan out a converged plan's waves).
+- The human's gates are exactly three: (1) the exported spec, (2) the implementation split plan — the plan/tasks map, the per-task subagent + model assignment, and the go/no-go on assigning the plan to the workforce — and (3) the final PR. The human is NOT in the per-task worktree-merge loop: the main/operating agent gates each merge with TDD (tests pass before and after merge) against the task's acceptance criteria. Per-task acceptance is uncommitted working state (mirroring the #17 Human Review Loop).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.9.0"
+version = "0.9.1"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What

Spec **and** plan for **subagent-driven (parallel) implementation of devague plans** (#13), produced by dogfooding `devague` itself — `/think` → a converged spec, `/spec-to-plan` → a converged plan. **Docs only; no code yet** — the six-task plan is the implementation roadmap.

## Why

#13 asked us to *define* how subagent-driven implementation works for devague plans. Since it was filed, #20 (`devague plan waves`, just merged via #27) settled the deterministic *describe-the-graph* primitive. This PR defines the **layer on top of `waves`**: the `assign-to-workforce` convention.

## Key decisions (resolved interactively through `/think`)

- **Contention safety** — one git worktree per subagent; same-file overlaps reconcile at merge, no live races.
- **Acceptance** — per-task merges are **main-agent TDD-gated** (the task's tests pass *before AND after* merge); **no human in the per-task loop**.
- **Three human gates** — the spec, the **implementation split plan** (tasks map + per-task subagent/model assignment + the go/no-go on assigning to the workforce), and the final PR.
- **Model-agnostic plan** — the operating agent proposes an *editable* per-task scope+model table; devague never picks a backend (#20 stands).
- **Form** — a cited, first-party skill named **`assign-to-workforce`** (deliberately broader than "subagents" — leaves room for teammate/generalist agents), shared via `devague learn`. The CLI stays deterministic and non-orchestrating.
- **Plan fitness** — `/spec-to-plan` coaches small, file-disjoint, TDD-accepted tasks, backed by a deterministic *non-blocking* `plan_convergence` warning.

## The plan dogfoods the spec

`devague plan waves` on the exported plan yields **wave 0 = {t1, t2, t3, t4, t5}** — five file-disjoint, genuinely parallel tasks — then **wave 1 = {t6}** (the dogfood worked example). Two risks are parked (non-blocking): no quantitative benchmarking, and no turnkey orchestrator (the skill is operator guidance + a helper; the operator fans out).

## Artifacts

- `docs/specs/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md` — 13 confirmed claims, 12 honesty conditions
- `docs/plans/2026-05-23-devague-turns-a-converged-plan-into-parallel-simpl.md` — 6 tasks (all TDD-accepted), 2 risks
- Converged frame + plan state under `.devague/`

Defines the contract asked for in #13; implementation is tracked by the plan's six tasks (follow-up PRs). Built on #20.

- devague (Claude)
