### PR TITLE
fix(skills): internalise the status helper into the CLI; trap mktemp (#30)

### DIFF
--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -90,10 +90,13 @@ cmd_split_plan() {
         shift
     done
 
-    local waves_json tmp_err waves_rc
+    local waves_json tmp_err waves_rc old_exit_trap
     tmp_err="$(mktemp)"
-    # Clean up on ANY exit path — including a signal between here and the
-    # explicit removal below — so the temp file never leaks (#30).
+    # Clean up the temp file on any exit path — including a signal between its
+    # creation and the explicit removal below — WITHOUT permanently changing the
+    # script's process-global EXIT handling: capture any prior EXIT trap, install
+    # ours, then restore it once the file is safely gone (#30; PR #31 review).
+    old_exit_trap="$(trap -p EXIT)"
     trap 'rm -f "$tmp_err"' EXIT
     set +e
     waves_json="$("${DEVAGUE[@]}" plan waves --json "${extra_args[@]}" 2>"$tmp_err")"
@@ -102,6 +105,8 @@ cmd_split_plan() {
     local waves_err
     waves_err="$(cat "$tmp_err")"
     rm -f "$tmp_err"
+    trap - EXIT
+    eval "${old_exit_trap}"  # empty string is a no-op; re-installs a prior trap if any
 
     if [ "$waves_rc" -ne 0 ]; then
         printf '%s\n' "$waves_err" >&2

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -92,6 +92,9 @@ cmd_split_plan() {
 
     local waves_json tmp_err waves_rc
     tmp_err="$(mktemp)"
+    # Clean up on ANY exit path — including a signal between here and the
+    # explicit removal below — so the temp file never leaks (#30).
+    trap 'rm -f "$tmp_err"' EXIT
     set +e
     waves_json="$("${DEVAGUE[@]}" plan waves --json "${extra_args[@]}" 2>"$tmp_err")"
     waves_rc=$?

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -41,8 +41,9 @@ bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh status
 
 It resolves the CLI portably — an installed `devague` on `PATH` (the normal
 case), falling back to `uv run devague` inside the devague checkout, else an
-install hint. Every move except `status` is forwarded verbatim as `devague plan
-<move>`, so you can equally call the CLI directly (`devague plan <move> …`).
+install hint. Every move — including `status` — is forwarded verbatim as
+`devague plan <move>`, so you can equally call the CLI directly
+(`devague plan <move> …`).
 
 ### Moves
 
@@ -58,17 +59,24 @@ install hint. Every move except `status` is forwarded verbatim as `devague plan
 | `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
 | `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
 | `waves` | Emit deterministic dependency waves (`{plan, waves}`) — scheduling metadata only, *not* orchestration. Read-only, works on an in-progress plan; refuses a cyclic/dangling graph. Devague describes the graph; an operator decides how to run it (#20). |
+| `status` | Read-only: where the plan stands + the recommended next move, re-checked against the live frame (`--json` too). |
 | `show` / `list` | Render a plan / list plans (`--json` for raw state). |
 | `learn` / `explain <move>` | Teach the method / explain one move. |
 
 Risk kinds (shared with the frame engine): `unknown_nonblocking`,
 `unknown_blocking`, `out_of_scope`, `follow_up`.
 
-### `status` — the next-move helper
+### `status` — the next-move verb
 
-`status` is a wrapper-only verb. It reads `devague plan converge --json` +
-`devague plan list --json` and prints where the current plan stands, the
-remaining gaps, and the recommended next move derived from the first gap.
+`status` is a first-class, **read-only** CLI verb (`devague plan status`,
+internalised from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`devague plan list` + `devague plan converge` and prints where the current plan
+stands, the remaining gaps, and the recommended next move derived from the first
+gap. Like `converge`/`export` it re-checks the **live** source frame (so frame
+drift surfaces as an error), but it never mutates state. Pass `--json` for the
+structured payload (`{plan, total, ready_for_plan, blockers, warnings,
+parked_items, required_next_moves}`).
 
 ```text
 plan: my-feature    (1 plan total)

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -67,6 +67,7 @@ Moves (forwarded to `devague plan`; run `devague plan learn` for the method):
   converge     check whether the plan can export
   export       write the buildable plan (only after converge passes)
   waves        emit deterministic dependency waves (scheduling metadata, not orchestration)
+  status       where the plan stands + the recommended next move
   show / list  render a plan / list plans
   learn        teach the method   |   explain <move>  explain one move
 
@@ -74,106 +75,12 @@ Plans persist under .devague/ in the current directory — run from the repo you
 are speccing. Results go to stdout, diagnostics to stderr; pass --json to any
 move for structured output.
 
-Note: `status` is a wrapper-only verb; everything else is forwarded verbatim as
-`devague plan <move>`, so new plan moves work without editing this script.
+Note: every move — including `status` — is forwarded verbatim as `devague plan
+<move>`, so new plan moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
 
 Prior leg: a plan is seeded from a converged frame produced by the /think skill.
 EOF
-}
-
-# ── status: read the plan convergence gate and recommend the next move ──────
-cmd_status() {
-    local list_json conv_out conv_err conv_rc req_plan="" prev="" tmp_err
-
-    for arg in "$@"; do
-        case "$prev" in --plan) req_plan="$arg" ;; esac
-        case "$arg" in --plan=*) req_plan="${arg#--plan=}" ;; esac
-        prev="$arg"
-    done
-
-    list_json="$("${DEVAGUE[@]}" plan list --json 2>/dev/null || true)"
-
-    tmp_err="$(mktemp)"
-    set +e
-    conv_out="$("${DEVAGUE[@]}" plan converge --json "$@" 2>"$tmp_err")"
-    conv_rc=$?
-    set -e
-    conv_err="$(cat "$tmp_err")"
-    rm -f "$tmp_err"
-
-    DEVAGUE_LIST_JSON="$list_json" \
-        DEVAGUE_CONV_JSON="$conv_out" \
-        DEVAGUE_CONV_ERR="$conv_err" \
-        DEVAGUE_CONV_RC="$conv_rc" \
-        DEVAGUE_REQ_PLAN="$req_plan" \
-        python3 - <<'PY'
-import json
-import os
-import sys
-
-
-def load(name):
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return None
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-
-
-lst = load("DEVAGUE_LIST_JSON") or {}
-conv = load("DEVAGUE_CONV_JSON")
-conv_err = os.environ.get("DEVAGUE_CONV_ERR", "").strip()
-req_plan = os.environ.get("DEVAGUE_REQ_PLAN", "").strip()
-try:
-    conv_rc = int(os.environ.get("DEVAGUE_CONV_RC", "0") or "0")
-except ValueError:
-    conv_rc = 0
-
-plans = lst.get("plans") or []
-current = lst.get("current")
-
-if not plans:
-    print("no plans yet — seed one from a converged frame:")
-    print('  devague plan new --frame "<slug>"')
-    print("  (the frame must have converged in the /think skill first)")
-    sys.exit(0)
-
-shown = req_plan or current or "(none selected)"
-total = len(plans)
-print(f"plan: {shown}    ({total} plan{'s' if total != 1 else ''} total)")
-
-if conv is None:
-    # A non-zero converge exit is a real error (deleted/regressed source frame,
-    # bad --plan) — relay devague's own error:/hint: lines instead of masking it.
-    if conv_rc != 0 and conv_err:
-        sys.stderr.write(conv_err + "\n")
-        sys.exit(conv_rc)
-    print("convergence: unknown (could not evaluate the plan)")
-    print("next move: devague plan show     # inspect the plan")
-    sys.exit(0)
-
-if conv.get("ready_for_plan"):
-    print("convergence: PASSED ✓")
-    for w in conv.get("warnings") or []:
-        print(f"  ⚠ {w}")
-    print("next move: devague plan export   # write the buildable plan")
-    sys.exit(0)
-
-blockers = conv.get("blockers") or []
-print(f"convergence: NOT passed — {len(blockers)} gap(s):")
-for b in blockers:
-    print(f"  - {b}")
-for w in conv.get("warnings") or []:
-    print(f"  ⚠ {w}")
-
-moves = conv.get("required_next_moves") or []
-if moves:
-    print()
-    print("recommended next move (first gap):")
-    print(f"  {moves[0]}")
-PY
 }
 
 main() {
@@ -182,14 +89,10 @@ main() {
             usage
             return 0
             ;;
-        status)
-            shift
-            resolve_devague
-            cmd_status "$@"
-            ;;
         *)
-            # Forward everything else to `devague plan <move>` verbatim, so the
-            # CLI's own parser owns the plan surface.
+            # Forward every move to `devague plan <move>` verbatim — including the
+            # internalised `status` verb (`devague plan status`) — so the CLI's own
+            # parser owns the plan surface.
             resolve_devague
             exec "${DEVAGUE[@]}" plan "$@"
             ;;

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -31,8 +31,9 @@ fixed sequence of prompts. **You (the agent) choose the next move; the CLI just
 tracks state and tells you what's still missing.** Run `devague learn` for the
 canonical ten-stage arc and `devague explain <move>` for any single move.
 
-This skill is the operator: a portable wrapper plus one helper (`status`) that
-reads the convergence gate and tells you the recommended next move.
+This skill is the operator: a portable wrapper that resolves the CLI and
+forwards every move verbatim — including `status`, the read-only verb that reads
+the convergence gate and tells you the recommended next move.
 
 ## How to run
 
@@ -47,9 +48,9 @@ bash .claude/skills/think/scripts/think.sh status
 It resolves the CLI portably — an installed `devague` on `PATH` (the normal
 case), falling back to `uv run devague` when you are inside the devague checkout.
 If neither resolves it prints an install hint (`uv tool install devague`). Every
-move except `status` is forwarded verbatim, so you can equally call the CLI
-directly (`devague <move> …`) when it is installed; the wrapper exists for
-portable resolution and the `status` helper.
+move — including `status` — is forwarded verbatim, so you can equally call the
+CLI directly (`devague <move> …`) when it is installed; the wrapper exists only
+for portable resolution.
 
 ### Moves
 
@@ -64,6 +65,7 @@ portable resolution and the `status` helper.
 | `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
 | `converge` | Evaluate the gate; list remaining gaps. |
 | `export` | Write the buildable spec to `docs/specs/` — only after `converge` passes. |
+| `status` | Read-only: where the frame stands + the recommended next move (`--json` too). |
 | `show` / `list` | Render a frame / list frames (`--json` for raw state). |
 | `learn` / `explain <move>` | Teach the method / explain one move. |
 
@@ -84,15 +86,18 @@ per-move input/output/transition/error contract are documented in
 live shape of any move, run it with `--json` (or `devague learn --json` /
 `devague explain <move>`).
 
-### `status` — the next-move helper
+### `status` — the next-move verb
 
-`status` is a wrapper-only verb (the CLI has no `status`). It reads
-`converge --json` + `list --json` and prints where the current frame stands, the
-remaining gaps, and the recommended next move. `converge --json` emits the
-structured result `{ready_for_spec, blockers, warnings, parked_items,
-required_next_moves}` (issue [#5](https://github.com/agentculture/devague/issues/5));
-the helper reads `ready_for_spec`, lists the `blockers` and `warnings`, and shows
-`required_next_moves[0]` as the recommended move — no longer deriving it itself.
+`status` is a first-class, **read-only** CLI verb (`devague status`, internalised
+from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`list` + `converge` and prints where the current frame stands, the remaining
+gaps, and the recommended next move; it never mutates state (the
+`drafting`↔`converged` transition stays in `converge`). It reports
+`ready_for_spec`, lists the `blockers` and `warnings`, and shows
+`required_next_moves[0]` as the recommended move. Pass `--json` for the same
+fields as a structured payload (`{frame, total, ready_for_spec, blockers,
+warnings, parked_items, required_next_moves}`).
 
 ```text
 frame: my-feature    (1 frame total)

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -65,6 +65,7 @@ Moves (forwarded to the devague CLI; run `devague learn` for the full method):
   park         record open vagueness instead of forcing an answer
   converge     check whether the frame can export a spec
   export       write the buildable spec (only after converge passes)
+  status       where the frame stands + the recommended next move
   show / list  render a frame / list frames
   learn        teach the method   |   explain <move>  explain one move
 
@@ -72,114 +73,13 @@ Frames persist under .devague/ in the current directory — run from the repo
 you are speccing. Results go to stdout, diagnostics to stderr; pass --json to
 any move for structured output.
 
-Note: `status` is a wrapper-only verb (the CLI has no `status`); everything
-else is forwarded verbatim, so new devague moves work without editing this
-script.
+Note: every move — including `status` — is forwarded verbatim to the devague
+CLI, so new devague moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
 
 Next leg: once a frame exports a spec, hand off to the /spec-to-plan skill
 (`devague plan ...`) to turn that spec into a buildable plan.
 EOF
-}
-
-# ── status: read the convergence gate and recommend the next move ──────────
-cmd_status() {
-    local list_json conv_out conv_err conv_rc req_frame="" prev="" tmp_err
-
-    # Pull the requested --frame (if any) so the header names the same frame
-    # that convergence is evaluated for; converge still receives it via "$@".
-    for arg in "$@"; do
-        case "$prev" in --frame) req_frame="$arg" ;; esac
-        case "$arg" in --frame=*) req_frame="${arg#--frame=}" ;; esac
-        prev="$arg"
-    done
-
-    list_json="$("${DEVAGUE[@]}" list --json 2>/dev/null || true)"
-
-    # Capture converge's stdout, stderr, and exit code separately. converge
-    # exits 0 even when "not passed", so a non-zero code is a *real* error
-    # (bad/missing --frame, corrupt frame) we must surface, not swallow.
-    tmp_err="$(mktemp)"
-    set +e
-    conv_out="$("${DEVAGUE[@]}" converge --json "$@" 2>"$tmp_err")"
-    conv_rc=$?
-    set -e
-    conv_err="$(cat "$tmp_err")"
-    rm -f "$tmp_err"
-
-    DEVAGUE_LIST_JSON="$list_json" \
-        DEVAGUE_CONV_JSON="$conv_out" \
-        DEVAGUE_CONV_ERR="$conv_err" \
-        DEVAGUE_CONV_RC="$conv_rc" \
-        DEVAGUE_REQ_FRAME="$req_frame" \
-        python3 - <<'PY'
-import json
-import os
-import sys
-
-
-def load(name):
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return None
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-
-
-lst = load("DEVAGUE_LIST_JSON") or {}
-conv = load("DEVAGUE_CONV_JSON")
-conv_err = os.environ.get("DEVAGUE_CONV_ERR", "").strip()
-req_frame = os.environ.get("DEVAGUE_REQ_FRAME", "").strip()
-try:
-    conv_rc = int(os.environ.get("DEVAGUE_CONV_RC", "0") or "0")
-except ValueError:
-    conv_rc = 0
-
-frames = lst.get("frames") or []
-current = lst.get("current")
-
-if not frames:
-    print("no frames yet — start one:")
-    print('  devague new "<announcement>"')
-    print('  first question: "What\'s the announcement? Pretend this shipped'
-          ' successfully — what would you announce?"')
-    sys.exit(0)
-
-shown = req_frame or current or "(none selected)"
-total = len(frames)
-print(f"frame: {shown}    ({total} frame{'s' if total != 1 else ''} total)")
-
-if conv is None:
-    # A non-zero converge exit on an existing frame is a genuine error —
-    # relay devague's own error:/hint: lines to stderr instead of masking it.
-    if conv_rc != 0 and conv_err:
-        sys.stderr.write(conv_err + "\n")
-        sys.exit(conv_rc)
-    print("convergence: unknown (could not evaluate the frame)")
-    print("next move: devague show     # inspect the frame")
-    sys.exit(0)
-
-if conv.get("ready_for_spec"):
-    print("convergence: PASSED ✓")
-    for w in conv.get("warnings") or []:
-        print(f"  ⚠ {w}")
-    print("next move: devague export   # write the buildable spec")
-    sys.exit(0)
-
-blockers = conv.get("blockers") or []
-print(f"convergence: NOT passed — {len(blockers)} gap(s):")
-for b in blockers:
-    print(f"  - {b}")
-for w in conv.get("warnings") or []:
-    print(f"  ⚠ {w}")
-
-moves = conv.get("required_next_moves") or []
-if moves:
-    print()
-    print("recommended next move (first gap):")
-    print(f"  {moves[0]}")
-PY
 }
 
 main() {
@@ -188,14 +88,10 @@ main() {
             usage
             return 0
             ;;
-        status)
-            shift
-            resolve_devague
-            cmd_status "$@"
-            ;;
         *)
-            # Forward everything else to the CLI verbatim (including --version,
-            # and any future devague move), so its own parser owns the surface.
+            # Forward every move to the CLI verbatim (including --version, the
+            # internalised `status` verb, and any future devague move), so its
+            # own parser owns the surface.
             resolve_devague
             exec "${DEVAGUE[@]}" "$@"
             ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-05-24
+
+### Added
+
+- `devague status` and `devague plan status` — first-class, read-only CLI verbs that compose `list` + `converge` and report the convergence verdict, remaining gaps, and the recommended next move (`--json` too). Internalised from the `think` / `spec-to-plan` skill wrappers (#30); they never mutate state and the plan verb re-checks the live source frame for drift. Shared renderer in `devague/cli/_status.py`.
+
+### Changed
+
+- The `think` / `spec-to-plan` skill wrappers are now thin: `status` is forwarded verbatim like every other move instead of being a wrapper-only verb implemented in embedded Python. This removed their `mktemp` temp-file and stdout-ordering hazards entirely (#30, Qodo via steward).
+
+### Fixed
+
+- `assign-to-workforce.sh` no longer leaks its `mktemp` temp file if interrupted by a signal — cleanup is now registered with an `EXIT` trap (#30). Its split-plan orchestration presentation deliberately stays out of the deterministic CLI (#20).
+
 ## [0.10.0] - 2026-05-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
+**`status` internalised into the CLI (0.11.0, #30).** The next-move helper that
+used to live as embedded Python inside the `think` / `spec-to-plan` skill
+wrappers is now a first-class, read-only CLI verb — `devague status` and
+`devague plan status` (sharing `devague/cli/_status.py`). Both compose
+`list` + `converge` and report the verdict, gaps, and recommended next move
+(`--json` too); neither mutates state. This removed the wrappers' `mktemp` +
+embedded-stdout hazards (Qodo via steward); the trio's remaining `mktemp` (in
+`assign-to-workforce.sh`, whose orchestration presentation deliberately stays
+out of the deterministic CLI) gained a cleanup trap.
+
 **Human Review Loop landed (0.6.0, #17).** `devague review` (+ `--json`) lists
 every proposed claim + honesty condition with ids — un-gated by convergence,
 never mutating state — and writes a non-authoritative artifact to
@@ -26,12 +36,12 @@ required_next_moves}` (plans: `ready_for_plan`) — a hard break from the old
 The **frame engine** (idea→spec) — Frame domain model, JSON store, convergence
 gate, renderer registry, and the flat moves `new` / `capture` / `interrogate` /
 `confirm` / `reject` / `review` / `question` / `park` / `converge` / `export` /
-`show` / `list` / `learn` / `explain`. The **plan engine** (spec→plan) is its
-structural peer:
+`status` / `show` / `list` / `learn` / `explain`. The **plan engine** (spec→plan)
+is its structural peer:
 `devague/plan.py`, `plan_convergence.py`, `plan_store.py`, `render/plan_md.py`,
 and the nested group `devague plan <move>` (`new` / `task` / `accept` / `depend`
 / `cover` / `confirm` / `reject` / `risk` / `converge` / `export` / `waves` /
-`show` / `list` / `learn` / `explain`). The two operator skills are `/think` (idea→spec,
+`status` / `show` / `list` / `learn` / `explain`). The two operator skills are `/think` (idea→spec,
 renamed from `/devague`) and `/spec-to-plan` (spec→plan). Coverage ≥ 95 %; all
 linters pass. Run `git ls-files` to see the real surface.
 
@@ -202,8 +212,9 @@ that unless the user asks otherwise. The established sibling shape is:
   split, `--json` support).
 - `devague/cli/_commands/` — one module per verb, each exposing `register()`.
   Frame verbs: `new`, `capture`, `interrogate`, `confirm`, `reject`, `park`,
-  `converge`, `export`, `show`, `list`, `learn`, `explain`. The plan engine adds
-  one module, `_commands/plan.py`, registering the nested `plan` subcommand group.
+  `converge`, `export`, `status`, `show`, `list`, `learn`, `explain` (`status`
+  shares `cli/_status.py` with the plan engine). The plan engine adds one module,
+  `_commands/plan.py`, registering the nested `plan` subcommand group.
 - Frame engine: `devague/frame.py`, `convergence.py`, `store.py`,
   `render/{spec_md,frame_md}.py`. Plan engine (its peer): `devague/plan.py`,
   `plan_convergence.py`, `plan_store.py`, `render/plan_md.py`, `cli/_plans.py`.

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -69,6 +69,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import reject as _reject_cmd
     from devague.cli._commands import review as _review_cmd
     from devague.cli._commands import show as _show_cmd
+    from devague.cli._commands import status as _status_cmd
 
     _learn_cmd.register(sub)
     _explain_cmd.register(sub)
@@ -83,6 +84,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _converge_cmd.register(sub)
     _export_cmd.register(sub)
     _plan_cmd.register(sub)
+    _status_cmd.register(sub)
     _show_cmd.register(sub)
     _list_cmd.register(sub)
 

--- a/devague/cli/_commands/learn.py
+++ b/devague/cli/_commands/learn.py
@@ -16,6 +16,7 @@ MOVES = {
     "park": "Move uncertainty into first-class open vagueness instead of forcing an answer.",
     "converge": "Check whether the frame is solid enough to export a spec.",
     "export": "Write the buildable spec — only once the frame converges.",
+    "status": "Report where the frame stands + the recommended next move (read-only).",
     "show": "Render the Announcement Frame.",
     "list": "List frames.",
 }

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -21,6 +21,7 @@ from devague.cli._frames import resolve as resolve_frame
 from devague.cli._output import emit_result
 from devague.cli._paths import dated_name
 from devague.cli._plans import resolve_plan
+from devague.cli._status import StatusLabels, emit_empty, emit_status
 from devague.convergence import evaluate as evaluate_frame
 from devague.frame import Frame
 from devague.plan import RISK_KINDS, Plan, dependency_waves, targets_from_frame, to_dict
@@ -46,9 +47,21 @@ PLAN_MOVES = {
     "converge": "Check whether the plan can export, against the live frame.",
     "export": "Write the buildable plan — only once the plan converges.",
     "waves": "Emit deterministic dependency waves (scheduling metadata, not orchestration).",
+    "status": "Report where the plan stands + the recommended next move (read-only).",
     "show": "Render the plan.",
     "list": "List plans.",
 }
+
+_STATUS_LABELS = StatusLabels(
+    noun="plan",
+    ready_key="ready_for_plan",
+    export_move="devague plan export   # write the buildable plan",
+    empty_text=(
+        "no plans yet — seed one from a converged frame:\n"
+        '  devague plan new --frame "<slug>"\n'
+        "  (the frame must have converged in the /think skill first)"
+    ),
+)
 
 
 # ── shared helpers ──────────────────────────────────────────────────────────
@@ -319,6 +332,31 @@ def cmd_plan_waves(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_plan_status(args: argparse.Namespace) -> int:
+    """Where the plan stands + the recommended next move — read-only.
+
+    Re-evaluates against the **live** source frame (like ``converge``/``export``),
+    so frame drift surfaces as a real error on stderr before any stdout. Internalised
+    from the ``spec-to-plan`` skill wrapper (issue #30); unlike ``converge`` it never
+    persists the ``drafting``↔``converged`` transition.
+    """
+    json_mode = getattr(args, "json", False)
+    slugs = plan_store.list_slugs()
+    if not slugs:
+        emit_empty(_STATUS_LABELS, json_mode=json_mode)
+        return 0
+    # resolve_plan + _live raise here (before any stdout) on a bad --plan or a
+    # source frame that regressed below convergence — routed to stderr.
+    plan = resolve_plan(args.plan)
+    _frame, targets = _live(plan)
+    plan.targets = targets  # in-memory refresh only; status does not save
+    result = evaluate_plan(plan, targets=targets)
+    emit_status(
+        _STATUS_LABELS, selected=plan.slug, total=len(slugs), result=result, json_mode=json_mode
+    )
+    return 0
+
+
 def cmd_plan_show(args: argparse.Namespace) -> int:
     plan = resolve_plan(args.plan)
     if getattr(args, "json", False):
@@ -464,6 +502,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     pwv = psub.add_parser("waves", help="Emit deterministic dependency waves (metadata only).")
     _plan_opt(pwv)
     pwv.set_defaults(func=cmd_plan_waves)
+
+    pst = psub.add_parser("status", help="Where the plan stands + the recommended next move.")
+    _plan_opt(pst)
+    pst.set_defaults(func=cmd_plan_status)
 
     psh = psub.add_parser("show", help="Render the plan.")
     _plan_opt(psh)

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -344,16 +344,16 @@ def cmd_plan_status(args: argparse.Namespace) -> int:
     slugs = plan_store.list_slugs()
     if not slugs:
         emit_empty(_STATUS_LABELS, json_mode=json_mode)
-        return 0
-    # resolve_plan + _live raise here (before any stdout) on a bad --plan or a
-    # source frame that regressed below convergence — routed to stderr.
-    plan = resolve_plan(args.plan)
-    _frame, targets = _live(plan)
-    plan.targets = targets  # in-memory refresh only; status does not save
-    result = evaluate_plan(plan, targets=targets)
-    emit_status(
-        _STATUS_LABELS, selected=plan.slug, total=len(slugs), result=result, json_mode=json_mode
-    )
+    else:
+        # resolve_plan + _live raise here (before any stdout) on a bad --plan or a
+        # source frame that regressed below convergence — routed to stderr.
+        plan = resolve_plan(args.plan)
+        _frame, targets = _live(plan)
+        plan.targets = targets  # in-memory refresh only; status does not save
+        result = evaluate_plan(plan, targets=targets)
+        emit_status(
+            _STATUS_LABELS, selected=plan.slug, total=len(slugs), result=result, json_mode=json_mode
+        )
     return 0
 
 

--- a/devague/cli/_commands/status.py
+++ b/devague/cli/_commands/status.py
@@ -36,11 +36,13 @@ def cmd_status(args: argparse.Namespace) -> int:
     slugs = store.list_slugs()
     if not slugs:
         emit_empty(_LABELS, json_mode=json_mode)
-        return 0
-    # A bad --frame raises here (before any stdout) so the error reaches stderr.
-    frame = resolve(args.frame)
-    result = evaluate(frame)
-    emit_status(_LABELS, selected=frame.slug, total=len(slugs), result=result, json_mode=json_mode)
+    else:
+        # A bad --frame raises here (before any stdout) so the error reaches stderr.
+        frame = resolve(args.frame)
+        result = evaluate(frame)
+        emit_status(
+            _LABELS, selected=frame.slug, total=len(slugs), result=result, json_mode=json_mode
+        )
     return 0
 
 

--- a/devague/cli/_commands/status.py
+++ b/devague/cli/_commands/status.py
@@ -1,0 +1,51 @@
+"""``devague status`` — where the frame stands + the recommended next move.
+
+A read-only value-add verb that composes ``list`` and ``converge``: it reports
+the selected frame, the convergence verdict (blockers and warnings), and, when
+not converged, the next move for the first gap. This logic used to live in the
+``think`` skill wrapper's embedded Python (issue #30); internalising it makes it
+deterministic and unit-testable and removes the wrapper's temp-file +
+stdout-ordering hazards. ``status`` never mutates state — like ``review`` it only
+reports (the ``drafting``↔``converged`` transition stays in ``converge``).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from devague import store
+from devague.cli._frames import resolve
+from devague.cli._status import StatusLabels, emit_empty, emit_status
+from devague.convergence import evaluate
+
+_LABELS = StatusLabels(
+    noun="frame",
+    ready_key="ready_for_spec",
+    export_move="devague export   # write the buildable spec",
+    empty_text=(
+        "no frames yet — start one:\n"
+        '  devague new "<announcement>"\n'
+        "  first question: \"What's the announcement? Pretend this shipped"
+        ' successfully — what would you announce?"'
+    ),
+)
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    json_mode = getattr(args, "json", False)
+    slugs = store.list_slugs()
+    if not slugs:
+        emit_empty(_LABELS, json_mode=json_mode)
+        return 0
+    # A bad --frame raises here (before any stdout) so the error reaches stderr.
+    frame = resolve(args.frame)
+    result = evaluate(frame)
+    emit_status(_LABELS, selected=frame.slug, total=len(slugs), result=result, json_mode=json_mode)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("status", help="Where the frame stands + the recommended next move.")
+    p.add_argument("--frame", help="Frame slug (default: current).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_status)

--- a/devague/cli/_status.py
+++ b/devague/cli/_status.py
@@ -1,0 +1,99 @@
+"""Shared rendering for the ``status`` value-add verb (frame and plan engines).
+
+``status`` composes ``list`` + ``converge`` into one human-facing summary — where
+the artifact stands and the recommended next move (the first gap's
+``required_next_moves`` entry). It lives in the deterministic CLI (issue #30)
+rather than in the skill wrappers' embedded Python, so it is unit-testable and
+free of the wrappers' temp-file and stdout-ordering hazards: there is no
+subprocess and no ``mktemp``, and a bad ``--frame`` / ``--plan`` raises
+:class:`~devague.cli._errors.DevagueError` (routed to stderr by the chassis)
+*before* any result reaches stdout.
+
+The frame and plan engines are structural peers, so both call through here with
+engine-specific labels carried by :class:`StatusLabels`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from devague.cli._output import emit_result
+from devague.convergence import ConvergenceResult
+
+
+@dataclass(frozen=True)
+class StatusLabels:
+    """Engine-specific strings the shared renderer needs.
+
+    ``noun`` is both the human label and the JSON key for the selected artifact
+    ("frame" / "plan"). ``ready_key`` matches what ``converge --json`` emits
+    ("ready_for_spec" / "ready_for_plan"). ``export_move`` is the suggestion shown
+    when converged; ``empty_text`` is the multi-line guidance when nothing exists.
+    """
+
+    noun: str
+    ready_key: str
+    export_move: str
+    empty_text: str
+
+
+def emit_empty(labels: StatusLabels, *, json_mode: bool) -> None:
+    """Render the no-artifacts state (consistent JSON shape; guidance text)."""
+    if json_mode:
+        emit_result(
+            {
+                labels.noun: None,
+                "total": 0,
+                labels.ready_key: False,
+                "blockers": [],
+                "warnings": [],
+                "parked_items": [],
+                "required_next_moves": [],
+            },
+            json_mode=True,
+        )
+    else:
+        emit_result(labels.empty_text, json_mode=False)
+
+
+def emit_status(
+    labels: StatusLabels,
+    *,
+    selected: str,
+    total: int,
+    result: ConvergenceResult,
+    json_mode: bool,
+) -> None:
+    """Render the convergence verdict + recommended next move for one artifact."""
+    if json_mode:
+        emit_result(
+            {
+                labels.noun: selected,
+                "total": total,
+                labels.ready_key: result.ready,
+                "blockers": result.blockers,
+                "warnings": result.warnings,
+                "parked_items": result.parked_items,
+                "required_next_moves": result.required_next_moves,
+            },
+            json_mode=True,
+        )
+        return
+
+    plural = "s" if total != 1 else ""
+    lines = [f"{labels.noun}: {selected}    ({total} {labels.noun}{plural} total)"]
+    if result.ready:
+        lines.append("convergence: PASSED ✓")
+        lines += [f"  ⚠ {w}" for w in result.warnings]
+        lines.append(f"next move: {labels.export_move}")
+    else:
+        lines.append(f"convergence: NOT passed — {len(result.blockers)} gap(s):")
+        lines += [f"  - {b}" for b in result.blockers]
+        lines += [f"  ⚠ {w}" for w in result.warnings]
+        if result.required_next_moves:
+            lines += [
+                "",
+                "recommended next move (first gap):",
+                f"  {result.required_next_moves[0]}",
+            ]
+    emit_result("\n".join(lines), json_mode=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.10.0"
+version = "0.11.0"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,204 @@
+"""Tests for the internalised ``status`` verbs (``devague status`` / ``devague plan status``).
+
+``status`` used to live as embedded Python inside the ``think`` / ``spec-to-plan``
+skill wrappers; issue #30 moved it into the deterministic CLI. These tests pin the
+in-CLI contract directly (no subprocess): the human/JSON output shape, that a bad
+``--frame`` / ``--plan`` errors to stderr with no stdout, that the verb is
+**read-only** (never flips ``drafting``↔``converged``), and that the plan verb
+re-checks the live source frame for drift.
+"""
+
+from __future__ import annotations
+
+import json
+
+from devague import plan_store, store
+from devague.cli import main
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+_ALL_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame whose gate passes (but do NOT run ``converge``)."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the plan engine"])  # c1 announcement (auto-confirmed)
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _converged_plan(monkeypatch, tmp_path) -> str:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    args = ["plan", "task", "Build everything", "--accept", "all targets satisfied"]
+    for tid in _ALL_TARGETS:
+        args += ["--covers", tid]
+    main(args)
+    return slug
+
+
+# ── frame status ──────────────────────────────────────────────────────────────
+def test_frame_status_no_frames_text(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "no frames yet" in out
+    assert 'devague new "<announcement>"' in out
+
+
+def test_frame_status_no_frames_json(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "frame": None,
+        "total": 0,
+        "ready_for_spec": False,
+        "blockers": [],
+        "warnings": [],
+        "parked_items": [],
+        "required_next_moves": [],
+    }
+
+
+def test_frame_status_names_gaps_and_first_move(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Devague ships a documented spec contract"])
+    capsys.readouterr()
+    assert main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "frame: devague-ships-a-documented-spec-contract" in out
+    assert "NOT passed" in out
+    assert "missing confirmed 'audience' claim" in out
+    assert "recommended next move (first gap):" in out
+    assert "devague capture --kind audience" in out
+
+
+def test_frame_status_json_shape_when_not_converged(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "An idea"])
+    capsys.readouterr()
+    assert main(["status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["frame"] == store.current_slug()
+    assert payload["total"] == 1
+    assert payload["ready_for_spec"] is False
+    assert payload["blockers"]
+    assert len(payload["required_next_moves"]) == len(payload["blockers"])
+
+
+def test_frame_status_passed(tmp_path, monkeypatch, capsys) -> None:
+    _converged_frame(monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "PASSED" in out
+    assert "devague export" in out
+
+
+def test_frame_status_bad_frame_errors_to_stderr(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "A real frame"])
+    capsys.readouterr()
+    rc = main(["status", "--frame", "ghost"])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "no such frame" in captured.err
+    assert captured.out == ""  # nothing leaks to stdout on the error path (#30)
+
+
+def test_frame_status_is_read_only(tmp_path, monkeypatch) -> None:
+    # The frame's gate passes, but `converge` was never run — status must not
+    # silently flip drafting→converged the way the old wrapper's `converge` call did.
+    slug = _converged_frame(monkeypatch, tmp_path)
+    assert store.load(slug).status == "drafting"
+    main(["status"])
+    assert store.load(slug).status == "drafting"
+
+
+# ── plan status ───────────────────────────────────────────────────────────────
+def test_plan_status_no_plans_text(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "no plans yet" in out
+    assert "devague plan new --frame" in out
+
+
+def test_plan_status_no_plans_json(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "plan": None,
+        "total": 0,
+        "ready_for_plan": False,
+        "blockers": [],
+        "warnings": [],
+        "parked_items": [],
+        "required_next_moves": [],
+    }
+
+
+def test_plan_status_names_gaps(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    assert main(["plan", "status"]) == 0
+    out = capsys.readouterr().out
+    assert f"plan: {slug}" in out
+    assert "NOT passed" in out
+    assert "devague plan task" in out
+
+
+def test_plan_status_passed(tmp_path, monkeypatch, capsys) -> None:
+    _converged_plan(monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert main(["plan", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "PASSED" in out
+    assert "devague plan export" in out
+
+
+def test_plan_status_json_passed_shape(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan(monkeypatch, tmp_path)
+    capsys.readouterr()
+    assert main(["plan", "status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["plan"] == slug
+    assert payload["total"] == 1
+    assert payload["ready_for_plan"] is True
+
+
+def test_plan_status_bad_plan_errors_to_stderr(tmp_path, monkeypatch, capsys) -> None:
+    _converged_plan(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["plan", "status", "--plan", "ghost"])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "no such plan" in captured.err
+    assert captured.out == ""
+
+
+def test_plan_status_is_read_only(tmp_path, monkeypatch) -> None:
+    slug = _converged_plan(monkeypatch, tmp_path)
+    assert plan_store.load(slug).status == "drafting"
+    main(["plan", "status"])
+    assert plan_store.load(slug).status == "drafting"
+
+
+def test_plan_status_surfaces_frame_drift(tmp_path, monkeypatch, capsys) -> None:
+    # Regress the source frame after the plan was seeded; plan status must
+    # surface the drift as a real error (stderr), not a misleading verdict.
+    slug = _converged_plan(monkeypatch, tmp_path)
+    main(["reject", "c2"])  # drop a required confirmed claim → frame un-converges
+    capsys.readouterr()
+    rc = main(["plan", "status", "--plan", slug])
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "regressed" in captured.err
+    assert captured.out == ""

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.9.0"
+version = "0.11.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #30.

## What & why

Qodo (via steward's verbatim re-vendor of devague's skills) flagged two
robustness bugs in the shared `status`-helper shape copied across the `think`,
`spec-to-plan`, and `assign-to-workforce` wrapper scripts:

1. **`mktemp` without a cleanup trap** — the temp file leaks if the script is
   signalled between `mktemp` and `rm -f`.
2. **stdout polluted on the error path** — the `frame:`/`plan:` summary line was
   written to stdout *before* the embedded Python knew `converge` had errored, so
   a genuine-error run exited non-zero with a stray summary line on stdout.

Both bugs exist *because* the next-move logic lived as embedded bash+Python,
duplicated across wrappers. So rather than patch three copies, this **internalises
the logic into the deterministic CLI**, which kills the bug class structurally.

## Changes

- **New read-only CLI verbs** `devague status` and `devague plan status` — compose
  `list` + `converge` and report the convergence verdict, remaining gaps, and the
  recommended next move (`--json` too). A bad `--frame`/`--plan` raises
  `DevagueError` (→ stderr) **before** any stdout, so the error path can't pollute
  stdout. The plan verb re-checks the **live** source frame for drift, like
  `converge`/`export`. Neither verb mutates state (the `drafting`<->`converged`
  transition stays in `converge`, mirroring `review`).
- **Shared renderer** `devague/cli/_status.py` — frame and plan engines are peers.
- **Thinned wrappers** — `think.sh` / `spec-to-plan.sh` now forward `status`
  verbatim like every other move; their `mktemp` + embedded-stdout hazards are
  gone entirely (net -115 lines across the diff).
- **`assign-to-workforce.sh`** keeps its split-plan rendering — that orchestration
  presentation deliberately stays out of the deterministic CLI (#20) — and its
  `mktemp` gains an `EXIT` cleanup trap to fix the leak-on-signal case.
- Docs (`CLAUDE.md`, both `SKILL.md`), `CHANGELOG`, version bump 0.10.0 -> 0.11.0.

## Tests / checks

- New `tests/test_cli_status.py` (15 tests): output shape, `--json`, empty state,
  bad-frame/plan -> stderr with empty stdout, **read-only** invariant, and plan
  frame-drift surfacing.
- Existing skill wrapper tests still pass against the thinned wrappers.
- Full suite: **278 passed**; flake8 / black / isort clean; new modules 100%
  coverage, total 97%.

steward can re-vendor the `think` / `spec-to-plan` skills once this lands.

- devague (Claude)
