### PR TITLE
fix(skills): trio-script stale status header + assign-to-workforce trap nit (#32)

### DIFF
--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -91,12 +91,15 @@ cmd_split_plan() {
     done
 
     local waves_json tmp_err waves_rc old_exit_trap
-    tmp_err="$(mktemp)"
-    # Clean up the temp file on any exit path — including a signal between its
-    # creation and the explicit removal below — WITHOUT permanently changing the
-    # script's process-global EXIT handling: capture any prior EXIT trap, install
-    # ours, then restore it once the file is safely gone (#30; PR #31 review).
+    # Clean up the temp file on any exit path — including a signal after its
+    # creation — WITHOUT permanently changing the script's process-global EXIT
+    # handling. Capture any prior EXIT trap BEFORE mktemp (that capture forks a
+    # subshell, so doing it first keeps it out of the untracked-file window),
+    # then install our cleanup trap on the line immediately after mktemp, and
+    # restore the prior trap once the file is safely gone (#30; PR #31 review;
+    # devague#32).
     old_exit_trap="$(trap -p EXIT)"
+    tmp_err="$(mktemp)"
     trap 'rm -f "$tmp_err"' EXIT
     set +e
     waves_json="$("${DEVAGUE[@]}" plan waves --json "${extra_args[@]}" 2>"$tmp_err")"

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -3,10 +3,10 @@
 #
 # The skill is named `spec-to-plan`; the product/CLI it drives is `devague` (the
 # idea→spec half lives in the sibling /think skill). This wrapper forwards every
-# move to `devague plan <move>` verbatim, and adds one value-add subcommand —
-# `status` — that reads the plan convergence gate and names the recommended next
-# move. It is the forward leg: seed a plan from a *converged* frame, then work it
-# into a buildable plan.
+# move to `devague plan <move>` verbatim — including the `status` verb the CLI
+# internalised in 0.11.0 (devague#30/#31), which reads the plan convergence gate
+# and names the recommended next move. It is the forward leg: seed a plan from a
+# *converged* frame, then work it into a buildable plan.
 #
 # Origin: authored and maintained in agentculture/devague. steward pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so it

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -5,9 +5,9 @@
 # half lives in the sibling /spec-to-plan skill, which drives `devague plan`).
 # devague turns a vague feature idea into a buildable spec by working backwards.
 # This wrapper is the agent-facing operator for the deterministic devague CLI:
-# it resolves the CLI portably, forwards every move verbatim, and adds one
-# value-add subcommand — `status` — that reads the convergence gate and names
-# the recommended next move.
+# it resolves the CLI portably and forwards every move verbatim — including the
+# `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
+# convergence gate and names the recommended next move.
 #
 # Origin: authored and maintained in agentculture/devague. steward pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-24
+
+### Changed
+
+- Trio skill-script header comments (`think.sh`, `spec-to-plan.sh`) no longer claim the wrapper *adds* a `status` subcommand — since 0.11.0 it is forwarded verbatim like every other move (devague#32, steward PR #58 review).
+
+### Fixed
+
+- `assign-to-workforce.sh` now installs its `mktemp` cleanup `EXIT` trap on the line immediately after creating the temp file, capturing the prior trap beforehand so the subshell-forking capture no longer sits inside the untracked-file window (devague#32).
+
 ## [0.11.0] - 2026-05-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.11.0"
+version = "0.11.1"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Resolves the three review items in #32 (filed from steward PR #58's resync of the vendored trio skills to 0.11.0). steward vendors these scripts **byte-identical** from devague (origin), so the fix lands here; steward re-syncs once merged.

### 1. Stale `status` header comment — `think.sh` + `spec-to-plan.sh`

0.11.0 internalised `status` into the CLI (#30/#31). The `usage()` text and `main()` dispatch already reflected pure-forwarding, but the top-of-file header comments still claimed the wrapper *adds* a `status` subcommand. Both now describe `status` as forwarded verbatim like every other move.

### 2. `mktemp` cleanup trap installed too late — `assign-to-workforce.sh`

In `cmd_split_plan()`, `mktemp` ran before the prior-EXIT-trap capture (`$(trap -p EXIT)`, which forks a subshell) and the cleanup-trap install, leaving the temp file untracked across that sliver. The prior trap is now captured **before** `mktemp`, and the cleanup trap installs on the line immediately after — minimising the window. The teardown that restores the prior trap is unchanged.

### 3. EXIT-trap chaining on early exit — **intentionally not changed**

Item 3 was flagged "your call" in the issue. The deliberate PR #31 shape stands: no prior EXIT trap is ever installed, so the real-world impact is nil. Skipped per maintainer decision.

## Alignment

These scripts originate in devague and are broadcast outbound to the mesh via steward — the delta direction is outbound, so no sibling needs an inbound follow-up. steward PR #58's copies stay verbatim and re-sync after merge.

## Verification

- `uv run pytest -n auto` — 278 passed (incl. `test_think_skill.py`, `test_spec_to_plan_skill.py`, which assert forwarding behavior, not header text).
- `bash -n` clean on all three scripts; `help` output sane from a scratch dir.
- `markdownlint-cli2 CHANGELOG.md` — 0 errors.
- `grep -rn 'value-add\|adds one' .claude/skills/` — none.

Version bumped 0.11.0 → 0.11.1 with a CHANGELOG entry.

Closes #32. Ref steward PR #58.

- devague (Claude)
