### PR TITLE
feat(skills): re-sync canonical kit to guildmaster; add agent-config + pypi-maintainer (#38)

### DIFF
--- a/.claude/skills/agent-config/SKILL.md
+++ b/.claude/skills/agent-config/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: agent-config
+description: >
+  Show a Culture agent's full configuration in one read-only view: its
+  system-prompt file (CLAUDE.md / AGENTS.md / GEMINI.md), the parallel
+  culture.yaml, and the agent's local .claude/skills index. Use when an
+  operator says "show agent <name>", "what does <agent> look like", or before
+  teaching/onboarding an agent and you need to see its current kit + config.
+  Backs the `guild show` verb. Vendored from steward (cite-don't-import);
+  inventory only — it reports, it does not judge alignment or drift.
+type: command
+---
+
+# agent-config — surface a Culture agent's config in one view
+
+guildmaster is the mesh's skills supplier and owns the **inventory** surfaces:
+"what kit + config does this agent have?" This skill answers exactly that for a
+single agent, showing the three artifacts that together define it:
+
+1. **System-prompt file** (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — the
+   prompt-side guidance for the agent's backend. The script detects which file
+   is present from a backend-fingerprint registry.
+2. **`culture.yaml`** — the runtime-side config (`agents:` list with `suffix`,
+   `backend`, `model`, `system_prompt`, `channels`, `tags`, `acp_command`,
+   `extras`). Lives parallel to the prompt file at the project root.
+3. **`.claude/skills/*/SKILL.md`** — the per-project skills the agent can
+   invoke, one line each (name + truncated description).
+
+This is the **inventory half** of the steward → guildmaster split
+([issue #12](https://github.com/agentculture/guildmaster/issues/12)): it reports
+the config, it does **not** interpret drift or judge alignment. The relationship
+graph and the "is this agent aligned?" judgment stay with `steward overview` /
+`steward doctor`.
+
+## When to use
+
+- Before `guild teach` / `guild onboard` — see an agent's current kit + config.
+- When an operator asks "show me agent `<name>`" or "what does `<agent>` run".
+- Read it, don't guess — before answering a question about what an agent does.
+
+## How to run
+
+One script, two ways to call it (or just run `guild show`, which wraps it):
+
+```bash
+# Path mode — point at any directory with a prompt file + culture.yaml
+.claude/skills/agent-config/scripts/show.sh ../culture
+
+# Suffix mode — resolve a registered agent suffix via the Culture server's
+# manifest (location set by culture_server_yaml in skills.local.yaml)
+.claude/skills/agent-config/scripts/show.sh daria
+```
+
+Output is three sections: the detected system-prompt file, `culture.yaml` (or
+`(missing)`), and a one-line summary per local skill (name + description,
+truncated to 120 chars).
+
+## What to look at in `culture.yaml`
+
+| Field | Why it matters |
+|-------|----------------|
+| `suffix` | Identifies the agent on the mesh. |
+| `backend` | One of `claude` / `codex` / `copilot` / `acp`. The all-backends rule means a feature in one must land in all four. |
+| `model` | Drift here changes behavior silently. |
+| `system_prompt` | Should not contradict the prompt file. |
+| `channels` | Where the agent listens. |
+| `tags`, `extras`, `acp_command` | Backend-specific. |
+
+## Notes
+
+- **Read-only.** The script never edits agent files. It reports; it does not
+  flag or fix drift — that judgment is steward's lane.
+- **Backend-aware.** Prompt-file detection comes from
+  `data/backend-fingerprints.yaml` (the `prompt:` mapping), falling back to the
+  built-in `(CLAUDE.md AGENTS.md GEMINI.md)` list if the registry is absent.
+- **Per-machine config.** Suffix mode reads `culture_server_yaml` from
+  `.claude/skills.local.yaml` (git-ignored), falling back to
+  `.claude/skills.local.yaml.example`.
+- **Vendored from steward** (`agent-config`). guildmaster owns this copy and may
+  diverge; re-sync from steward's canonical copy when it changes. Divergences:
+  the SKILL.md is reframed for guildmaster's inventory role and adds
+  `type: command` for the culture backend's skill loader.

--- a/.claude/skills/agent-config/data/backend-fingerprints.yaml
+++ b/.claude/skills/agent-config/data/backend-fingerprints.yaml
@@ -1,0 +1,30 @@
+# Canonical backend fingerprint registry. Vendored from steward's agent-config
+# skill (cite-don't-import); guildmaster owns this copy. Read by the agent-config
+# show.sh (bash), which `guild show` shells out to. Upstream steward also reads
+# it from a Python detector; guildmaster has no parallel detector, so only the
+# `backends:` prompt mapping below is load-bearing here. Keep that mapping in
+# sync with upstream when re-syncing.
+#
+# `prompt`        — the backend's system-prompt filename at the repo root.
+# `steering`      — files/dirs distinctive enough to attribute to this backend.
+# `shared_steering` — files/dirs that belong to NO specific backend. A repo
+#                   declared as any backend may have these without triggering a
+#                   mismatch. `.agents` is a generic Culture agent-config
+#                   convention. `.claude/settings.json` and
+#                   `.claude/settings.local.json` are generic Claude Code
+#                   (editor/CLI) workspace config files — they appear in any
+#                   repo that uses Claude Code as the development tool,
+#                   regardless of the agent backend, so they must never be used
+#                   to infer the backend or flag a mismatch. The claude backend
+#                   is identified solely by its `CLAUDE.md` prompt file.
+#                   `.github/copilot-instructions.md` is generic GitHub Copilot
+#                   editor/IDE config — any repo may have it regardless of the
+#                   declared agent backend, so it must not trigger a mismatch.
+backends:
+  claude:  { prompt: CLAUDE.md, steering: [] }
+  codex:   { prompt: AGENTS.md, steering: [".codex"] }
+  acp:     { prompt: AGENTS.md, steering: [".kiro"] }
+  copilot: { prompt: AGENTS.md, steering: [] }
+  gemini:  { prompt: GEMINI.md, steering: [".gemini"] }
+shared_steering: [".agents", ".claude/settings.json", ".claude/settings.local.json", ".github/copilot-instructions.md"]
+prompt_fallback: AGENTS.md

--- a/.claude/skills/agent-config/scripts/show.sh
+++ b/.claude/skills/agent-config/scripts/show.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Show a Culture agent's full configuration in one view:
+# the detected system-prompt file (CLAUDE.md / AGENTS.md / GEMINI.md), the
+# parallel culture.yaml, and the .claude/skills/ index.
+#
+# Usage: show.sh <path-or-agent-suffix>
+#
+# Path mode:   show.sh ../culture
+# Suffix mode: show.sh daria   (resolved via culture_server_yaml in skills.local.yaml)
+#
+# Exit codes:
+#   0   success
+#   1   environment error (missing manifest, missing PyYAML for suffix mode)
+#   2   user error (no target given, unknown suffix, target path doesn't exist)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML scalar from CFG. Schema is intentionally tiny:
+#   key: value     (with optional surrounding quotes / trailing comment)
+# No PyYAML dependency.
+read_cfg() {
+    awk -v key="$1" '
+        $0 ~ ("^" key ":[[:space:]]*") {
+            sub("^" key ":[[:space:]]*", "")
+            sub(/[[:space:]]*#.*$/, "")
+            sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, "")
+            sub(/^["\047]/, ""); sub(/["\047]$/, "")
+            print
+            exit
+        }
+    ' "$CFG"
+}
+
+target="${1:-}"
+if [ -z "$target" ]; then
+    echo "Usage: $(basename "$0") <path-or-agent-suffix>" >&2
+    exit 2
+fi
+
+if [ -d "$target" ]; then
+    DIR="$target"
+else
+    SERVER_YAML_RAW="$(read_cfg culture_server_yaml)"
+    SERVER_YAML="${SERVER_YAML_RAW/#\~/$HOME}"
+    if [ ! -f "$SERVER_YAML" ]; then
+        echo "no server manifest at $SERVER_YAML — set culture_server_yaml in $CFG" >&2
+        echo "or pass an explicit path instead of suffix '$target'" >&2
+        exit 1
+    fi
+    # Suffix mode parses Culture's server manifest, whose schema is dictated by
+    # Culture (not by us) and includes nested mappings — too rich for awk.
+    # We use python+PyYAML here, with a friendly install hint if it's missing.
+    if ! python3 -c 'import yaml' 2>/dev/null; then
+        echo "suffix mode needs Python + PyYAML to parse $SERVER_YAML" >&2
+        echo "  install: pip install --user pyyaml   (or: uv pip install pyyaml)" >&2
+        echo "  or pass an explicit path instead of suffix '$target'" >&2
+        exit 1
+    fi
+    # Use a dedicated exit code (2) for "unknown suffix" so the steward CLI
+    # wrapper can distinguish user errors (typo'd suffix) from env errors
+    # (missing manifest / PyYAML).
+    if ! DIR=$(python3 - "$SERVER_YAML" "$target" <<'PY'
+import sys, yaml, pathlib
+manifest_path, suffix = sys.argv[1], sys.argv[2]
+m = yaml.safe_load(pathlib.Path(manifest_path).read_text()) or {}
+agents = m.get('agents', {})
+entry = agents.get(suffix)
+if entry is None:
+    print(f"no agent registered with suffix {suffix!r} in {manifest_path}", file=sys.stderr)
+    sys.exit(2)
+print(entry['directory'] if isinstance(entry, dict) else entry)
+PY
+); then
+        exit 2
+    fi
+fi
+
+DIR="${DIR/#\~/$HOME}"
+
+# Recognized prompt filenames come from the shared registry (single source
+# of truth with the Python detector). Fall back to the built-in list if the
+# registry isn't present (e.g. skill vendored without the data file).
+REGISTRY="$SKILL_DIR/data/backend-fingerprints.yaml"
+prompt_files=()
+if [ -f "$REGISTRY" ]; then
+    while IFS= read -r pf; do
+        [ -n "$pf" ] && prompt_files+=("$pf")
+    done < <(grep -oE 'prompt:[[:space:]]*[^,}[:space:]]+' "$REGISTRY" | awk '{print $NF}' | sort -u)
+fi
+[ ${#prompt_files[@]} -eq 0 ] && prompt_files=(CLAUDE.md AGENTS.md GEMINI.md)
+
+shown=0
+for pf in "${prompt_files[@]}"; do
+    if [ -f "$DIR/$pf" ]; then
+        echo "=== $DIR/$pf ==="
+        cat "$DIR/$pf"
+        echo
+        shown=1
+    fi
+done
+if [ "$shown" -eq 0 ]; then
+    echo "=== $DIR (system prompt) ==="
+    echo "(no recognized prompt file: ${prompt_files[*]})"
+    echo
+fi
+echo "=== $DIR/culture.yaml ==="
+if [ -f "$DIR/culture.yaml" ]; then cat "$DIR/culture.yaml"; else echo "(missing)"; fi
+echo
+echo "=== $DIR/.claude/skills/ ==="
+found=0
+for s in "$DIR"/.claude/skills/*/SKILL.md; do
+    [ -f "$s" ] || continue
+    found=1
+    name=$(awk '/^name:/{print $2; exit}' "$s")
+    desc=$(awk '
+        /^description:/ {
+            sub(/^description:[[:space:]]*/, "")
+            buf = $0
+            flag = 1
+            next
+        }
+        flag && /^[a-z_-]+:/ { flag = 0 }
+        flag { buf = buf " " $0 }
+        END { gsub(/^[[:space:]]+|[[:space:]]+$/, "", buf); print buf }
+    ' "$s")
+    printf "  %-30s %s\n" "$name" "${desc:0:120}"
+done
+if [ "$found" -eq 0 ]; then
+    echo "  (no skills)"
+fi

--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -10,8 +10,9 @@ description: >
   performs the fan-out. Use when the user says "assign to workforce",
   "fan out the plan", "parallel subagents", or after /spec-to-plan exports a
   plan. Authored and maintained in agentculture/devague (origin = devague);
-  steward pulls this skill from here and broadcasts it to the AgentCulture
-  mesh — it is NOT vendored from steward like the other skills here.
+  guildmaster pulls this skill from here and broadcasts it to the AgentCulture
+  mesh — it is NOT vendored from guildmaster like the other skills here.
+type: command
 ---
 
 # assign-to-workforce — fan out a converged plan's waves to parallel agents
@@ -235,7 +236,7 @@ This is a **first-party** skill — its origin is `agentculture/devague`, where
 the devague agent maintains it alongside the tools it operates (dogfooding),
 next to its siblings `/think` and `/spec-to-plan`. It is the *third* skill in
 that outbound family, covering the implementation leg after a plan converges.
-The flow runs the *opposite* direction of the vendored steward skills: steward
-pulls this **from** devague and broadcasts it to the rest of the AgentCulture
-mesh. The `cite, don't import` policy still holds: downstream repos copy it,
+The flow runs the *opposite* direction of the vendored guildmaster skills:
+guildmaster pulls this **from** devague and broadcasts it to the rest of the
+AgentCulture mesh. The `cite, don't import` policy still holds: downstream repos copy it,
 they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: cicd
 description: >
-  Steward's CI/CD lane, layered on `agex pr`. Delegates lint / open /
-  read / reply / delta to agex; adds two steward extensions — `status`
+  guildmaster's CI/CD lane, layered on `agex pr`. Delegates lint / open /
+  read / reply / delta to agex; adds two extensions — `status`
   (SonarCloud quality gate + hotspots + unresolved-thread tally) and
   `await` (read --wait + status with non-zero exit on Sonar ERROR or
-  unresolved threads). Use when: creating PRs in steward, handling
+  unresolved threads). Use when: creating PRs in guildmaster, handling
   review feedback, polling CI status, or the user says "create PR",
   "review comments", "address feedback", "resolve threads". Renamed
   from `pr-review` in steward 0.7.0; rebased on agex in 0.12.0.
 ---
 
-# CI/CD — Steward edition
+# CI/CD — guildmaster edition
 
 `agex pr` (in `agentculture/agex-cli`) is the upstream for the
 five core PR-lifecycle verbs — `lint`, `open`, `read`, `reply`,
@@ -25,13 +25,42 @@ What's left in this skill is **the steward-specific gating layer**:
   Sonar `ERROR` / unresolved threads. The single command to run after
   pushing a fix when you want "wake me when this PR is triage-able."
 
-Those two are the steward unique surface today. They're filed as a
-feature ask upstream
-([agex-cli#41](https://github.com/agentculture/agex-cli/issues/41));
-once they land they migrate out of this skill.
+Those two are the steward unique surface today. The `await` combo verb
+landed natively in agex
+([agex-cli#41](https://github.com/agentculture/agex-cli/issues/41), now
+closed); the gate extras that aren't yet native — SonarCloud hotspots,
+deploy-preview URL, an explicit resolved/unresolved thread tally — are
+tracked upstream in
+[agex-cli#52](https://github.com/agentculture/agex-cli/issues/52) and
+migrate out of this skill once they land.
 
 The workflow is encapsulated in `scripts/workflow.sh` — follow that
 (or call `agex pr` directly).
+
+## The agex-cli inversion (upstream-as-consumer)
+
+One consumer is special: **agex-cli itself**, the repo that owns `agex pr`.
+Vendoring this skill there verbatim would re-vendor bash that just wraps the
+Python agex-cli already ships, so agex-cli vendors it **adapted-thin**
+([agex-cli#53](https://github.com/agentculture/agex-cli/pull/53)):
+`workflow.sh` is the only script and it forwards
+`lint | open | read | reply | delta | await` straight to the native
+`agex pr <verb>` — including the native `agex pr await` combo verb (agex-cli
+0.21.0). The steward `status` / `await` shell extensions and the vendored
+helpers (`pr-reply.sh`, `_resolve-nick.sh`, `portability-lint.sh`) are all
+redundant there, each superseded by a native verb. For that one consumer the
+skill collapses to a **pure delegate**.
+
+The only gate bits not yet native are SonarCloud **hotspots**, the
+**deploy-preview URL**, and an explicit **resolved/unresolved thread tally** —
+tracked upstream in
+[agex-cli#52](https://github.com/agentculture/agex-cli/issues/52). Once those
+land, steward retires `pr-status.sh` too and `workflow.sh status/await`
+delegates to native `agex pr` everywhere.
+
+**For broadcasts:** a skill-update brief to agex-cli should expect this thin
+`workflow.sh`-only shape, not steward's five-file layout. (Ref:
+[steward#53](https://github.com/agentculture/steward/issues/53).)
 
 ## Prerequisites
 

--- a/.claude/skills/cicd/scripts/portability-lint.sh
+++ b/.claude/skills/cicd/scripts/portability-lint.sh
@@ -22,7 +22,7 @@ esac
 
 # ----- Check 1: hard-coded /home/<user>/... paths -----
 # devague-divergence: drop GNU-only `xargs -r` (fails on BSD/macOS); `$files`
-# is already guarded non-empty above. Upstream to steward; remove on re-vendor.
+# is already guarded non-empty above. Upstream to guildmaster; remove on re-vendor.
 hits1=$(echo "$files" | xargs grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
 
 # ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
@@ -32,7 +32,7 @@ hits1=$(echo "$files" | xargs grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || 
 md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
 if [ -n "$md_yaml" ]; then
     # devague-divergence: drop GNU-only `xargs -r` (see Check 1); `$md_yaml`
-    # is guarded non-empty by the `if` above. Upstream to steward.
+    # is guarded non-empty by the `if` above. Upstream to guildmaster.
     hits2=$(echo "$md_yaml" | xargs grep -nE '~/\.[A-Za-z]' 2>/dev/null \
         | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
         | grep -vE '~/\.culture/' \

--- a/.claude/skills/communicate/SKILL.md
+++ b/.claude/skills/communicate/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: communicate
 description: >
-  Cross-repo + mesh communication from steward: file tracked GitHub issues
+  Cross-repo + mesh communication from guildmaster: file tracked GitHub issues
   on sibling repos, fetch issues from sibling repos to inline current state
   into briefs, and send live messages to Culture mesh channels. Use when
-  the next step lives outside steward (a brief for a sibling-repo agent, a
+  the next step lives outside guildmaster (a brief for a sibling-repo agent, a
   status ping for a Culture channel, or pulling an issue body + comments
-  into context). Issue posts auto-sign with `- steward (Claude)`; mesh
-  messages are unsigned (the IRC nick is the speaker). Not for in-steward
+  into context). Issue posts auto-sign with `- guildmaster (Claude)`; mesh
+  messages are unsigned (the IRC nick is the speaker). Not for in-guildmaster
   issues — use `gh issue create` or the `cicd` skill for those. Renamed
   from `coordinate` in steward 0.8.0; absorbed `gh-issues` in 0.9.1.
   Issue I/O is backed by `agtag` (>=0.1) starting in 0.11.0.

--- a/.claude/skills/communicate/scripts/templates/skill-new-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-new-brief.md
@@ -1,0 +1,85 @@
+<!-- markdownlint-disable MD041 -->
+<!-- This file is the NEW-SKILL template rendered by announce-skill-update -->
+<!-- when --new is passed. It posts as an issue body where GitHub supplies -->
+<!-- the title, so there's no H1 here on purpose. Placeholders use the -->
+<!-- `{{NAME}}` syntax; {{ORIGIN_BLOCK}} is empty unless --origin is given. -->
+
+## A new skill is available to vendor
+
+`{{SKILL}}` is a **new** skill in the AgentCulture mesh. Your repo does
+not have it yet — this brief tells you how to **add it fresh** (there is no
+older vendored copy to replace). If you maintain a `docs/skill-sources.md`
+provenance ledger, add a row for it; if not, just drop it into
+`.claude/skills/`.
+
+{{ORIGIN_BLOCK}}
+
+Relevant guildmaster CHANGELOG entries (where guildmaster picked the skill up):
+
+{{CHANGELOG_BLOCK}}
+
+## Cite locations (source of truth)
+
+- Local sibling checkout (preferred when available):
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
+
+guildmaster re-broadcasts this skill to the mesh, so its copy is the citation
+point even when the skill originates in another sibling (see origin note
+above, if present). The directory ships a `SKILL.md` and a `scripts/`
+directory per the AgentCulture skills-portability rule (each skill is
+self-contained; nothing reaches across skill boundaries at runtime).
+
+## What's in the upstream now
+
+`{{SKILL}}/scripts/` ({{UPSTREAM_SCRIPT_COUNT}} files):
+
+{{UPSTREAM_SCRIPT_LIST}}
+
+{{DELTA_BLOCK}}
+
+{{NOTE_BLOCK}}
+
+## What to do
+
+```bash
+# 0. Branch.
+git checkout -b skill/{{SKILL}}-add
+
+# 1. Add the skill fresh from upstream (no existing copy to remove).
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
+chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
+
+# 2. If you keep docs/skill-sources.md, add a row pointing at
+#    ../guildmaster/.claude/skills/{{SKILL}}/ (record any local divergence).
+
+# 3. Bump version per project convention (CI version-check enforces in
+#    AgentCulture siblings); add a CHANGELOG entry.
+```
+
+## Acceptance criteria
+
+- `.claude/skills/{{SKILL}}/SKILL.md` is present with frontmatter
+  `name: {{SKILL}}`. **On the culture/agex backend, also add
+  `type: command`** — `core.skill_loader` requires all of `name`,
+  `description`, and `type:`, and a SKILL.md lacking `type:` is silently
+  skipped by `backends/claude_code/probe.py`.
+- `.claude/skills/{{SKILL}}/scripts/` contains the
+  {{UPSTREAM_SCRIPT_COUNT}} files listed above (and only those, unless your
+  repo intentionally adds extras — record divergence in the SKILL.md
+  frontmatter `description` per the AgentCulture vendoring policy).
+- All scripts are executable (`chmod +x`).
+- If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with the
+  upstream `../guildmaster/.claude/skills/{{SKILL}}/`.
+- `CHANGELOG.md` has a new version entry describing the addition; the
+  version is bumped per project convention; CI's `version-check` job is green.
+
+## References
+
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
+- `{{SKILL}}` SKILL.md:
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+- AgentCulture skills-portability rule (each vendor owns and may adapt its
+  copy): the `communicate` SKILL.md "Conventions in use" section.

--- a/.claude/skills/communicate/scripts/templates/skill-update-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-update-brief.md
@@ -7,17 +7,17 @@
 
 Your repo's `.claude/skills/{{SKILL}}/` (or its older vendored
 name — see your `docs/skill-sources.md` if you keep a provenance
-ledger) is a vendored copy of the steward skill that has since
-moved on. Relevant CHANGELOG entries from steward:
+ledger) is a vendored copy of the guildmaster skill that has since
+moved on. Relevant CHANGELOG entries from guildmaster:
 
 {{CHANGELOG_BLOCK}}
 
 ## Cite locations (source of truth)
 
 - Local sibling checkout (preferred when available):
-  `../steward/.claude/skills/{{SKILL}}/`
-- Remote, if the workspace doesn't include a local steward checkout:
-  <https://github.com/agentculture/steward/tree/main/.claude/skills/{{SKILL}}>
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
 
 The directory ships with a `SKILL.md` and a `scripts/` directory
 per the AgentCulture skills-portability rule (each skill is
@@ -44,14 +44,14 @@ git checkout -b skill/{{SKILL}}-resync
 #    If your old vendored name differs (e.g. pr-review → cicd),
 #    `git rm` the old dir first.
 git rm -r .claude/skills/<old-name-if-different>   # skip if name is already {{SKILL}}
-cp -R ../steward/.claude/skills/{{SKILL}} .claude/skills/
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
 chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
 
 # 2. Adapt identifiers per the existing "identifier-only adapted"
 #    pattern in your docs/skill-sources.md (if you keep one):
-#    - SKILL.md prose framing: replace "steward" with your repo
+#    - SKILL.md prose framing: replace "guildmaster" with your repo
 #      name where it identifies the consumer (NOT where it cites
-#      steward as the upstream).
+#      guildmaster as the upstream).
 #    - For any script that hard-codes a signature literal, change it
 #      to `- <your-repo> (Claude)`. (The communicate skill no longer
 #      hard-codes one — agtag resolves the nick from your local
@@ -80,9 +80,9 @@ grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
   AgentCulture vendoring policy).
 - All scripts are executable (`chmod +x`).
 - If the skill hard-codes a signature literal anywhere, your
-  vendored copy uses your repo's signature, not `- steward (Claude)`.
+  vendored copy uses your repo's signature, not `- guildmaster (Claude)`.
 - If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with
-  the upstream `../steward/.claude/skills/{{SKILL}}/`; no row
+  the upstream `../guildmaster/.claude/skills/{{SKILL}}/`; no row
   remains for the old vendored name.
 - `grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md`
   returns zero hits, or only historical mentions in CHANGELOG.
@@ -92,10 +92,10 @@ grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
 
 ## References
 
-- Steward CHANGELOG (release-by-release deltas):
-  <https://github.com/agentculture/steward/blob/main/CHANGELOG.md>
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
 - `{{SKILL}}` SKILL.md:
-  <https://github.com/agentculture/steward/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
 - AgentCulture skills-portability rule (why each vendor adapts
   signature literals locally): the `communicate` SKILL.md
   "Per-channel signature rules" + "Conventions in use" sections.

--- a/.claude/skills/pypi-maintainer/SKILL.md
+++ b/.claude/skills/pypi-maintainer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pypi-maintainer
+description: >
+  Switch a PyPI package install between the production index, TestPyPI
+  pre-release builds, and a local editable checkout. Use when an agent
+  maintains a package and needs to verify a TestPyPI dev build before
+  promoting to production, or when the user says "install from
+  test-pypi", "switch to local", "change package source", or
+  "install from pypi".
+---
+
+# PyPI Maintainer
+
+Switch the install source for a package the agent maintains. Three sources
+are supported: production PyPI, TestPyPI (pre-release / dev builds), and a
+local editable checkout. The same script works for any package an
+AgentCulture sibling publishes — pass the package name as the first
+argument.
+
+## When to use
+
+- Verifying a PR's TestPyPI dev build before merging.
+- Reproducing a user-reported bug against the published version.
+- Hot-patching against a local checkout while a fix is in flight.
+- Restoring the production install after local-mode debugging.
+
+## Usage
+
+```bash
+# Production PyPI
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> pypi
+
+# TestPyPI (pre-release dev builds)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi
+
+# TestPyPI, pinned to a specific dev version
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi --version 0.4.0.dev42
+
+# Local editable checkout (defaults to current directory)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local
+
+# Local editable from an explicit path
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local --path ../<package>
+```
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `uv` — the script delegates to `uv tool install` and `uv tool list`
+  (or `uv pip install` for `local`).
+
+## Why TestPyPI needs special flags
+
+When a package is published to **both** PyPI and TestPyPI, `uv tool install`
+finds the production version on PyPI first and never looks at TestPyPI.
+The script passes `--index-strategy unsafe-best-match` so uv compares the
+two index sets and picks the highest version, plus `--prerelease=allow`
+because TestPyPI builds carry dev suffixes (e.g. `0.4.0.dev42`).
+
+## After running
+
+The script prints the resolved version once install completes — cross-check
+that against the expected version (PR run number, local `pyproject.toml`)
+before continuing.
+
+## Arguments
+
+| Position / flag | Meaning |
+|-----------------|---------|
+| `<package>` (required) | The PyPI distribution name, e.g. `steward-cli`, `culture`, `daria-cli`. |
+| `<source>` (required)  | One of `pypi`, `test-pypi`, `local`. |
+| `--version VERSION`    | Pin to a specific version (TestPyPI builds typically need this). |
+| `--path PATH`          | Local-source-only: path to the editable checkout (default: cwd). |

--- a/.claude/skills/pypi-maintainer/scripts/switch-source.sh
+++ b/.claude/skills/pypi-maintainer/scripts/switch-source.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# switch-source.sh — Switch a PyPI package install between pypi / test-pypi / local.
+#
+# Usage:
+#   switch-source.sh <package> pypi
+#   switch-source.sh <package> test-pypi [--version VERSION]
+#   switch-source.sh <package> local [--path PATH]
+#
+# Generalised from the original culture-specific change-package skill so any
+# AgentCulture sibling that publishes a PyPI package can vendor and use it.
+
+set -euo pipefail
+
+PACKAGE=""
+SOURCE=""
+VERSION=""
+LOCAL_PATH=""
+
+usage() {
+  cat <<EOF >&2
+Usage: switch-source.sh <package> <pypi|test-pypi|local> [options]
+
+Options:
+  --version VERSION   Pin to a specific version (most useful for test-pypi
+                      dev builds, e.g. --version 0.4.0.dev42).
+  --path PATH         Local source only: path to editable checkout
+                      (default: current directory).
+  -h, --help          Show this help.
+EOF
+}
+
+# --- Parse args ---
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    usage
+    exit 1
+  fi
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) require_value "$1" "$#"; VERSION="$2"; shift 2 ;;
+    --path)    require_value "$1" "$#"; LOCAL_PATH="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --*)       echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    *)         POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+PACKAGE="${POSITIONAL[0]}"
+SOURCE="${POSITIONAL[1]}"
+
+# --- Resolve install spec for pinned versions ---
+SPEC="$PACKAGE"
+if [[ -n "$VERSION" ]]; then
+  SPEC="${PACKAGE}==${VERSION}"
+fi
+
+case "$SOURCE" in
+  pypi)
+    echo "Installing $SPEC from production PyPI..."
+    uv tool install "$SPEC" --force
+    ;;
+  test-pypi)
+    echo "Installing $SPEC from TestPyPI..."
+    uv tool install "$SPEC" \
+      --index-url https://test.pypi.org/simple/ \
+      --extra-index-url https://pypi.org/simple/ \
+      --index-strategy unsafe-best-match \
+      --prerelease=allow \
+      --force
+    ;;
+  local)
+    if [[ -z "$LOCAL_PATH" ]]; then
+      LOCAL_PATH="$(pwd)"
+    fi
+    if [[ ! -f "$LOCAL_PATH/pyproject.toml" ]]; then
+      echo "Error: $LOCAL_PATH does not contain a pyproject.toml" >&2
+      exit 1
+    fi
+    echo "Installing $PACKAGE in editable mode from $LOCAL_PATH..."
+    uv tool install --from "$LOCAL_PATH" --editable "$PACKAGE" --force
+    ;;
+  *)
+    echo "Unknown source: $SOURCE (expected pypi, test-pypi, or local)" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+# --- Report what is now active ---
+echo
+echo "Installed tools matching '$PACKAGE':"
+uv tool list 2>/dev/null | awk -v pkg="$PACKAGE" 'tolower($1) == tolower(pkg) {print "  " $0}'

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -9,9 +9,10 @@ description: >
   risks, and export a plan only once it *converges*. Use when the user says
   "spec to plan", "stp", "turn this spec into a plan", "plan this spec", "make a
   build plan", or after the /think skill exports a spec. Authored and maintained
-  in agentculture/devague (origin = devague); steward pulls this skill from here
-  and broadcasts it to the AgentCulture mesh — it is NOT vendored from steward
-  like the other skills here.
+  in agentculture/devague (origin = devague); guildmaster pulls this skill from
+  here and broadcasts it to the AgentCulture mesh — it is NOT vendored from
+  guildmaster like the other skills here.
+type: command
 ---
 
 # spec-to-plan — work a converged spec forwards into a buildable plan
@@ -223,7 +224,7 @@ implementation (or `superpowers:writing-plans`).
 This is a **first-party** skill — its origin is `agentculture/devague`, where the
 devague agent maintains it alongside the tool it operates (dogfooding), next to
 its sibling `/think`. It is the *inverse* of the other skills under
-`.claude/skills/`, which devague vendors **from** steward. When ready, steward
+`.claude/skills/`, which devague vendors **from** guildmaster. guildmaster
 pulls it **from** devague and broadcasts it to the rest of the AgentCulture mesh.
 The `cite, don't import` policy still holds: downstream repos copy it, they don't
 symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -10,8 +10,10 @@ description: >
   a spec", "announcement frame", or "devague", or when a feature request is too
   vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
   skill to turn it into a plan. Authored and maintained in agentculture/devague
-  (origin = devague); steward pulls this skill from here and broadcasts it to the
-  AgentCulture mesh — it is NOT vendored from steward like the other skills here.
+  (origin = devague); guildmaster pulls this skill from here and broadcasts it to
+  the AgentCulture mesh — it is NOT vendored from guildmaster like the other skills
+  here.
+type: command
 ---
 
 # think — work an idea backwards into a buildable spec
@@ -194,7 +196,7 @@ is **commit, then `/spec-to-plan`**.
 This is a **first-party** skill — its origin is `agentculture/devague`, where the
 devague agent maintains it alongside the tool it operates (dogfooding). It is the
 *inverse* of the other skills under `.claude/skills/`, which devague vendors
-**from** steward. When this skill is ready, steward pulls it **from** devague and
+**from** guildmaster. guildmaster pulls this skill **from** devague and
 broadcasts it to the rest of the AgentCulture mesh. The `cite, don't import`
 policy still holds: downstream repos copy it, they don't symlink or depend on it.
 See `docs/skill-sources.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-05-25
+
+### Added
+
+- Vendored two new skills from guildmaster (#38): `agent-config` (read-only Culture agent-config inventory backing guildmaster's `guild show`) and `pypi-maintainer` (switch a PyPI install between the production index, TestPyPI, and a local editable checkout). `pypi-maintainer` is a strong fit — devague publishes to PyPI + TestPyPI via `.github/workflows/publish.yml`.
+
+### Changed
+
+- Skills supplier repointed `steward` -> `guildmaster` after the 2026-05-24 steward->guildmaster cutover (#38). Re-synced `cicd` and `communicate` from guildmaster (`communicate` gains `scripts/templates/skill-new-brief.md`); `doc-test-alignment` / `run-tests` / `sonarclaude` / `version-bump` are content-unchanged with provenance updated in `docs/skill-sources.md` and `CLAUDE.md`.
+- devague's three origin skills (`think` / `spec-to-plan` / `assign-to-workforce`) now declare `type: command` at the source — the field guildmaster had to add on re-broadcast (required by culture/agex backends) and that `docs/skills.md` already specified — and their provenance prose repoints to guildmaster. They are deliberately NOT re-vendored back from guildmaster's re-broadcast copies: devague is their upstream.
+
+### Fixed
+
+- Preserved devague's intentional `cicd/scripts/portability-lint.sh` divergence (drops GNU-only `xargs -r`, which fails on BSD/macOS) across the guildmaster re-sync, instead of reintroducing the portability regression from the upstream copy.
+
 ## [0.12.0] - 2026-05-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
+**Skills re-synced to guildmaster + two new skills (0.13.0, #38).** The vendored
+canonical kit now sources from `guildmaster` (the supplier role moved from
+`steward` at the 2026-05-24 cutover): `cicd` / `communicate` re-synced (the `cicd`
+`portability-lint.sh` `xargs -r` divergence is preserved), the other four are
+content-unchanged with the ledger repointed, and two new skills were vendored —
+`agent-config` (read-only agent-config inventory) and `pypi-maintainer` (devague
+publishes to PyPI/TestPyPI). devague's three **origin** skills (`think` /
+`spec-to-plan` / `assign-to-workforce`) were **not** re-vendored back — devague is
+their upstream — but each gained `type: command` at the source. Provenance:
+`docs/skill-sources.md`.
+
 **`learn` now teaches skill authoring (0.12.0, #34).** `devague learn` gained an
 optional topic arg: `devague learn skills` (and `skills:all` / `skills:<name>`)
 emits a self-contained recipe for authoring the three operator skills (`think` /
@@ -204,10 +215,14 @@ AgentCulture`); the GitHub remote is `origin/main` and lives under
 workspace are the small Python CLI agents `agtag`, `appsec`, `seer-cli`, and
 `steward` — when in doubt about how something *should* look here, read theirs.
 
-`steward` is the source of truth for shared skills and the cross-repo way of
-working in AgentCulture. Vendored skills are cited, not imported (cite-don't-import):
-copy from `../steward/.claude/skills/<name>/` and track provenance in
-`docs/skill-sources.md`.
+`guildmaster` is the source of truth for shared skills and the cross-repo way of
+working in AgentCulture (the supplier role moved from `steward` at the 2026-05-24
+steward→guildmaster cutover; `steward` is still a sibling but no longer
+broadcasts). Vendored skills are cited, not imported (cite-don't-import): copy
+from `../guildmaster/.claude/skills/<name>/` and track provenance in
+`docs/skill-sources.md`. The exception is devague's own `think` / `spec-to-plan` /
+`assign-to-workforce` — devague is their origin, so guildmaster re-broadcasts them
+*from* here; never re-vendor them back.
 
 ## Stack expectations (when code lands)
 

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -1,48 +1,64 @@
 # Skill sources — vendored skill provenance
 
-devague vendors cross-sibling skills from `steward`, the AgentCulture skill
-supplier. This follows the **cite, don't import** pattern: each skill is
-copied into `.claude/skills/`, owned locally, and may diverge. Nothing
-imports across repos at runtime.
+devague vendors cross-sibling skills from `guildmaster`, the AgentCulture skill
+supplier (the role moved from `steward` to `guildmaster` at the 2026-05-24
+steward→guildmaster cutover; `steward` no longer broadcasts). This follows the
+**cite, don't import** pattern: each skill is copied into `.claude/skills/`,
+owned locally, and may diverge. Nothing imports across repos at runtime.
 
 This file is the upstream/downstream map. When upstream changes, re-sync
 explicitly — these copies do not auto-update.
 
-**Upstream provenance.** All six skills come from
-[`agentculture/steward`](https://github.com/agentculture/steward), **MIT**-licensed
-(the same license as devague). They were vendored from the local steward checkout
-at commit [`21414a9`](https://github.com/agentculture/steward/commit/21414a9)
-(2026-05-22). The table records each skill's re-vendor path, the vendoring date,
-and any local divergence; license (MIT) and upstream repo are shared across all
-rows.
+**Upstream provenance.** All eight inbound skills come from
+[`agentculture/guildmaster`](https://github.com/agentculture/guildmaster),
+**MIT**-licensed (the same license as devague). The canonical kit (`cicd`,
+`communicate`, `version-bump`, `run-tests`, `sonarclaude`, `doc-test-alignment`)
+was first vendored from `steward` at commit
+[`21414a9`](https://github.com/agentculture/steward/commit/21414a9) (2026-05-22)
+and re-synced from the guildmaster checkout at commit
+[`89591d5`](https://github.com/agentculture/guildmaster/commit/89591d5)
+(2026-05-24, guildmaster 0.5.1); `agent-config` and `pypi-maintainer` were
+vendored fresh from the same guildmaster checkout. The table records each skill's
+re-vendor path, the vendoring date, and any local divergence; license (MIT) and
+upstream repo are shared across all rows.
 
 | Skill | Re-vendor from | Vendored | Runtime backing & notes |
 |-------|----------------|----------|-------------------------|
-| `cicd` | `steward` (`../steward/.claude/skills/cicd/`) | 2026-05-22 | **Runtime:** core PR-lifecycle verbs (`lint` / `open` / `read` / `reply` / `delta`) delegate to `agex pr` from `agentculture/agex-cli` — `agex` must be installed (`uv tool install agex-cli`). Steward keeps two extensions on top — `status` (SonarCloud gate + hotspots + unresolved-thread tally) and `await`. **Divergence:** local patch — `scripts/portability-lint.sh` drops GNU-only `xargs -r` in both grep pipelines (it fails on BSD/macOS; empties are already guarded) so the portability gate runs cross-platform; marked with `# devague-divergence:`. Should be upstreamed to steward; drop on next re-vendor. SKILL.md body cites steward-specific constructs (e.g. `steward doctor`) as inherited upstream context, not devague-actionable. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known `pr-status.sh` `--repo` fix may need a local patch if `gh pr view` misbehaves. |
-| `communicate` | `steward` (`../steward/.claude/skills/communicate/`) | 2026-05-22 | **Runtime:** GitHub issue-I/O verbs (`post-issue` / `post-comment` / `fetch-issues`) wrap `agtag` (>=0.1) — `agtag` must be installed. Signatures resolve from the local `culture.yaml` first-agent `suffix` (here: `devague`), overridable via `agtag --as NICK`; mesh messages stay unsigned. **Divergence:** none — vendored verbatim. The `steward announce-skill-update` broadcast verb referenced in the body is steward-cli-only and not available to devague. |
-| `version-bump` | `steward` (`../steward/.claude/skills/version-bump/`) | 2026-05-22 | Pure Python (`scripts/bump.py`), no per-repo customization. **Divergence:** none — vendored verbatim. Watch [agentculture/steward#34](https://github.com/agentculture/steward/issues/34): a known insertion-point bug (`idx > 0` vs `idx != -1`) can mis-handle a `CHANGELOG.md` that starts directly with a `## [` entry; apply the documented local patch only if a bump fails. |
-| `run-tests` | `steward` (`../steward/.claude/skills/run-tests/`) | 2026-05-22 | None — portable verbatim. Coverage source resolves from `[tool.coverage.run]` in `pyproject.toml`. |
-| `sonarclaude` | `steward` (`../steward/.claude/skills/sonarclaude/`) | 2026-05-22 | None — portable verbatim. Project key resolves from `$SONAR_PROJECT` / `--project` (here: `agentculture_devague`). |
-| `doc-test-alignment` | `steward` (`../steward/.claude/skills/doc-test-alignment/`) | 2026-05-22 | **Stub upstream** — `scripts/check.sh` exits with a not-yet-implemented error today; the contract for what it will do lives in its `SKILL.md`. Vendored verbatim to carry the contract. |
+| `cicd` | `guildmaster` (`../guildmaster/.claude/skills/cicd/`) | 2026-05-24 | **Runtime:** core PR-lifecycle verbs (`lint` / `open` / `read` / `reply` / `delta`) delegate to `agex pr` from `agentculture/agex-cli` — `agex` must be installed (`uv tool install agex-cli`). guildmaster keeps two extensions on top — `status` (SonarCloud gate + hotspots + unresolved-thread tally) and `await`. **Divergence:** local patch — `scripts/portability-lint.sh` drops GNU-only `xargs -r` in both grep pipelines (it fails on BSD/macOS; empties are already guarded) so the portability gate runs cross-platform; marked with `# devague-divergence:`. Should be upstreamed to guildmaster; drop on next re-vendor. SKILL.md body cites guildmaster-specific constructs as inherited upstream context, not devague-actionable. |
+| `communicate` | `guildmaster` (`../guildmaster/.claude/skills/communicate/`) | 2026-05-24 | **Runtime:** GitHub issue-I/O verbs (`post-issue` / `post-comment` / `fetch-issues`) wrap `agtag` (>=0.1) — `agtag` must be installed. Signatures resolve from the local `culture.yaml` first-agent `suffix` (here: `devague`), overridable via `agtag --as NICK`; mesh messages stay unsigned. **Divergence:** none — vendored verbatim (now includes the new `scripts/templates/skill-new-brief.md`). The `teach` / `onboard` broadcast verbs referenced in the body are guildmaster-cli-only and not available to devague. |
+| `version-bump` | `guildmaster` (`../guildmaster/.claude/skills/version-bump/`) | 2026-05-24 | Pure Python (`scripts/bump.py`), no per-repo customization. **Divergence:** none — vendored verbatim; content unchanged since steward `21414a9`. Watch the known insertion-point bug (`idx > 0` vs `idx != -1`) that can mis-handle a `CHANGELOG.md` starting directly with a `## [` entry (originally tracked at [steward#34](https://github.com/agentculture/steward/issues/34)); apply the documented local patch only if a bump fails. |
+| `run-tests` | `guildmaster` (`../guildmaster/.claude/skills/run-tests/`) | 2026-05-24 | None — portable verbatim; content unchanged since steward `21414a9`. Coverage source resolves from `[tool.coverage.run]` in `pyproject.toml`. |
+| `sonarclaude` | `guildmaster` (`../guildmaster/.claude/skills/sonarclaude/`) | 2026-05-24 | None — portable verbatim; content unchanged since steward `21414a9`. Project key resolves from `$SONAR_PROJECT` / `--project` (here: `agentculture_devague`). |
+| `doc-test-alignment` | `guildmaster` (`../guildmaster/.claude/skills/doc-test-alignment/`) | 2026-05-24 | **Stub upstream** — `scripts/check.sh` exits with a not-yet-implemented error today; the contract for what it will do lives in its `SKILL.md`. Vendored verbatim; content unchanged since steward `21414a9`. |
+| `agent-config` | `guildmaster` (`../guildmaster/.claude/skills/agent-config/`) | 2026-05-24 | **New (#38).** Read-only inventory view of a Culture agent's config (system-prompt file + `culture.yaml` + `.claude/skills` index); backs guildmaster's `guild show`. Ships `scripts/show.sh` + `data/backend-fingerprints.yaml`. **Divergence:** none — vendored verbatim (carries `type: command`). devague has no `guild` binary; vendored for standalone config inspection. |
+| `pypi-maintainer` | `guildmaster` (`../guildmaster/.claude/skills/pypi-maintainer/`) | 2026-05-24 | **New (#38).** Switches a PyPI package install between the production index, TestPyPI, and a local editable checkout (`scripts/switch-source.sh`, delegates to `uv`). Strong fit — devague publishes to PyPI + TestPyPI via `.github/workflows/publish.yml`. **Divergence:** none — vendored verbatim; ships without a `type:` field (harmless on devague's `claude-code` backend). |
 
 ## Origin skills (outbound)
 
-Not every skill here is inbound. The `think` and `spec-to-plan` skills are
-**authored and maintained in this repo** — devague is their origin/upstream, not
-a downstream consumer. The devague agent dogfoods them to operate the devague CLI
-while improving the tool. The flow runs the *opposite* direction of the table
-above. (The skill names are `think` / `spec-to-plan`; the product/CLI they drive
-is `devague`. `think` was renamed from `devague` in 0.4.0 — when steward re-vendors,
-it must relearn the new name and pick up the new `spec-to-plan` sibling.)
+Not every skill here is inbound. The `think`, `spec-to-plan`, and
+`assign-to-workforce` skills are **authored and maintained in this repo** —
+devague is their origin/upstream, not a downstream consumer. The devague agent
+dogfoods them to operate the devague CLI while improving the tool. The flow runs
+the *opposite* direction of the table above: `guildmaster` re-vendors them from
+here and re-broadcasts them to the mesh. (The skill names are `think` /
+`spec-to-plan` / `assign-to-workforce`; the product/CLI they drive is `devague`.
+`think` was renamed from `devague` in 0.4.0 — when guildmaster re-vendors, it must
+relearn the new name.) Because devague is upstream, these are **not** re-vendored
+back from guildmaster's re-broadcast copies — doing so would be circular (see the
+issue #38 reply).
+
+As of 0.13.0 (#38) all three carry `type: command` at the source, so guildmaster's
+re-broadcast copies (which had to add it on vendor for the culture/agex backend)
+match the source and need no patch.
 
 | Skill | Origin | Downstream | Notes |
 |-------|--------|------------|-------|
-| `think` | **devague** (here: `.claude/skills/think/`) | `steward`, then the AgentCulture mesh | Operator for the **idea→spec** leg of the deterministic devague CLI: portable resolution + a `status` next-move helper over the frame convergence gate. Renamed from `devague` in 0.4.0. When ready, `steward` re-vendors it from `../devague/.claude/skills/think/` and broadcasts it to the mesh. |
-| `spec-to-plan` | **devague** (here: `.claude/skills/spec-to-plan/`) | `steward`, then the AgentCulture mesh | Operator for the **spec→plan** leg (`devague plan ...`): portable resolution + a `status` next-move helper over the plan convergence gate. New in 0.4.0. Re-vendor from `../devague/.claude/skills/spec-to-plan/`. |
-| `assign-to-workforce` | **devague** (here: `.claude/skills/assign-to-workforce/`) | `steward`, then the AgentCulture mesh | Operator for the **implementation** leg (fan out `devague plan waves` to parallel agents in isolated git worktrees, with TDD-gated merges by the main agent). Three human gates only: spec / implementation split plan / final PR. The devague CLI remains non-orchestrating (#20) — this skill is the convention + helper, not new CLI behavior. New in 0.7.0. Re-vendor from `../devague/.claude/skills/assign-to-workforce/`. |
+| `think` | **devague** (here: `.claude/skills/think/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **idea→spec** leg of the deterministic devague CLI: portable resolution, driving the flat `devague <move>` verbs (`status` is now a first-class CLI verb, not embedded Python). Renamed from `devague` in 0.4.0. `guildmaster` re-vendors it from `../devague/.claude/skills/think/` and broadcasts it to the mesh. |
+| `spec-to-plan` | **devague** (here: `.claude/skills/spec-to-plan/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **spec→plan** leg (`devague plan ...`): portable resolution over the plan convergence gate. New in 0.4.0. Re-vendor from `../devague/.claude/skills/spec-to-plan/`. |
+| `assign-to-workforce` | **devague** (here: `.claude/skills/assign-to-workforce/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **implementation** leg (fan out `devague plan waves` to parallel agents in isolated git worktrees, with TDD-gated merges by the main agent). Three human gates only: spec / implementation split plan / final PR. The devague CLI remains non-orchestrating (#20) — this skill is the convention + helper, not new CLI behavior. New in 0.7.0. Re-vendor from `../devague/.claude/skills/assign-to-workforce/`. |
 
 `cite, don't import` applies to both — downstream copies them, no
-symlink/dependency. Written portable-first so they pass steward's
+symlink/dependency. Written portable-first so they pass guildmaster's
 `portability-lint.sh`.
 
 ## Vendoring policy
@@ -50,6 +66,9 @@ symlink/dependency. Written portable-first so they pass steward's
 - **Cite, don't import.** Skills are copied, not symlinked or installed as
   a dependency.
 - **Re-sync explicitly.** When upstream changes, re-vendor from
-  `../steward/.claude/skills/<name>/`.
+  `../guildmaster/.claude/skills/<name>/`.
 - **Diverge intentionally.** Record any divergence in the table above and
   in the downstream `SKILL.md` frontmatter `description`.
+- **Don't re-vendor devague-origin skills.** `think` / `spec-to-plan` /
+  `assign-to-workforce` are authored here; pull fixes forward into this repo, not
+  back from guildmaster's re-broadcast copies.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -7,7 +7,7 @@ companion to `devague learn skills`, which surfaces a condensed, always-availabl
 version of the same recipe.
 
 These three skills are devague's **outbound** skills — devague is their
-origin/upstream (it dogfoods them to drive its own CLI), and steward re-vendors
+origin/upstream (it dogfoods them to drive its own CLI), and guildmaster re-vendors
 them to the rest of the AgentCulture mesh under the `cite, don't import` policy.
 See [`skill-sources.md`](skill-sources.md) for the provenance map. This guide is
 about *creating* them in a runtime that doesn't have them yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.12.0"
+version = "0.13.0"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Skills update from guildmaster (#38)

Applies guildmaster's skills-propagation brief, repointing the vendored skill
supplier from `steward` to `guildmaster` after the 2026-05-24 cutover.

### What changed

- **Re-synced `cicd` + `communicate`** from guildmaster `89591d5` (guildmaster
  0.5.1). `communicate` gains the new `scripts/templates/skill-new-brief.md`. The
  four byte-identical skills (`doc-test-alignment` / `run-tests` / `sonarclaude` /
  `version-bump`) are content-unchanged — only their provenance is repointed.
- **Vendored two new skills** verbatim: `agent-config` (read-only Culture
  agent-config inventory) and `pypi-maintainer` (switch a PyPI install between
  PyPI / TestPyPI / local — devague publishes to PyPI + TestPyPI via
  `.github/workflows/publish.yml`).
- **Ledger + CLAUDE.md** updated for the cutover (`docs/skill-sources.md`,
  `docs/skills.md`); bumped to **0.13.0** with a CHANGELOG entry.

### Two deliberate calls

1. **The three origin skills were NOT re-vendored.** The brief lists `think`,
   `spec-to-plan`, and `assign-to-workforce` as "new — add fresh," but devague is
   their **upstream** (the brief's own origin notes confirm it). Re-vendoring
   guildmaster's re-broadcast copies back here would be circular. Instead I fixed
   the one real gap: added `type: command` at the source — the field guildmaster
   had to patch on re-broadcast (required by culture/agex backends) and that
   `docs/skills.md` already specified — and repointed their provenance prose to
   guildmaster. Filed [guildmaster#20](https://github.com/agentculture/guildmaster/issues/20)
   to have `teach`/`onboard` exclude a skill's origin repo from its targets.
2. **Preserved devague's `cicd/scripts/portability-lint.sh` divergence** (drops
   GNU-only `xargs -r`, which fails on BSD/macOS) rather than reintroducing the
   regression from guildmaster's copy. Filed
   [guildmaster#21](https://github.com/agentculture/guildmaster/issues/21) to fix
   it upstream so the divergence can be dropped on a future re-vendor.

### Verification

- `uv run pytest -n auto` — **290 passed**.
- `markdownlint-cli2` — clean on the lint-eligible docs.
- `cicd portability-lint` — clean (18 files).
- Confirmed the resynced `cicd`/`communicate` files are byte-identical to
  guildmaster, and `portability-lint.sh` still shows only the intentional
  divergence.

Closes #38.

- devague (Claude)
