### PR TITLE
fix(skills): align origin-trio provenance to guildmaster + repo-agnostic PR step (0.13.1)

### DIFF
--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -154,7 +154,8 @@ and their tests pass.
 ### Human gate 3 — the final PR
 
 Once all waves are merged and the full test suite passes, the main agent opens
-a PR via the `cicd` skill (`agex pr open`). The human reviews and merges. This
+a PR via the repo's PR workflow (e.g. the `cicd` skill's `agex pr open`, the
+`pr-review` skill, or `gh pr create`). The human reviews and merges. This
 is the last and only remaining human gate.
 
 ## Hard rules (do not violate)
@@ -222,8 +223,8 @@ git worktree remove ../worktrees/agent-t3
 git worktree add ../worktrees/agent-t4 -b agent/t4
 # ... spawn, await, merge with TDD gate, remove worktree ...
 
-# 6. Open the final PR (human gate 3)
-bash .claude/skills/cicd/scripts/workflow.sh open
+# 6. Open the final PR (human gate 3) via your repo's PR workflow —
+#    e.g. the cicd skill (`agex pr open`), the pr-review skill, or `gh pr create`.
 ```
 
 The exported plan-md from `devague plan export` is the standing brief for

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -12,7 +12,7 @@
 # the dependency graph; it does not spawn agents, manage worktrees, or pick
 # a backend. This wrapper is the operator-facing helper.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so
 # it is written to run anywhere — portable bash, no devague-checkout assumptions.
 #
@@ -73,7 +73,8 @@ you are implementing. Results go to stdout, diagnostics to stderr.
 Human gates (three only):
   1. The exported spec (already closed by the /think leg).
   2. This implementation split plan (go/no-go to assign to workforce).
-  3. The final PR (opened by the main agent via `cicd` / `agex pr open`).
+  3. The final PR (opened by the main agent via the repo's PR workflow,
+     e.g. `cicd` / `agex pr open`, `pr-review`, or `gh pr create`).
 
 The devague CLI is non-orchestrating (#20): `devague plan waves` describes
 the graph; the operator performs the fan-out. One worktree per task; TDD

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -8,7 +8,7 @@
 # and names the recommended next move. It is the forward leg: seed a plan from a
 # *converged* frame, then work it into a buildable plan.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
 # is written to run anywhere — portable bash, no devague-checkout assumptions.
 #

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -181,7 +181,8 @@ idea→spec leg cleanly before moving on:
    disk. Use a focused message, e.g. `git commit -m "spec: <slug> (devague
    /think)"`. The frame and the spec are the evidence trail for every confirmed
    claim — keep them together. (Per the repo's standing convention this normally
-   becomes a branch + PR via the `cicd` skill; commit-only is fine when the user
+   becomes a branch + PR via your repo's PR workflow — e.g. the `cicd` or
+   `pr-review` skill; commit-only is fine when the user
    asks for it.)
 2. **Hand off to `/spec-to-plan`.** The forward leg is the sibling skill:
    `devague plan new --frame <slug>` seeds a plan from the converged frame and

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -9,7 +9,7 @@
 # `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
 # convergence gate and names the recommended next move.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
 # is written to run anywhere — portable bash, no devague-checkout assumptions.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-06-10
+
+### Fixed
+
+- Completed the steward→guildmaster provenance repoint from #38: the three origin skills' `scripts/*.sh` header comments still read "steward pulls this skill" while their `SKILL.md` frontmatter already said "guildmaster pulls". Aligned all three script headers (`think` / `spec-to-plan` / `assign-to-workforce`) to "guildmaster pulls", removing the contradiction. (Surfaced by Qodo on a downstream agentirc vendoring PR.)
+- Made the `assign-to-workforce` final-PR step repo-agnostic: the worked example and flow referenced `.claude/skills/cicd/scripts/workflow.sh open` and "the `cicd` skill", which broke for downstream repos that vendor the trio but use a different PR workflow (e.g. agentirc's `pr-review`). Reworded the four `cicd` mentions to name the repo's PR workflow generically (`cicd` / `pr-review` / `gh pr create`).
+
 ## [0.13.0] - 2026-05-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.13.0"
+version = "0.13.1"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What

Two follow-up fixes to the #38 steward→guildmaster cutover, both surfaced by Qodo on a **downstream agentirc vendoring PR** ([agentculture/agentirc#34](https://github.com/agentculture/agentirc/pull/34)) where this trio was copied verbatim:

1. **Provenance contradiction (bug).** #38 repointed the `SKILL.md` frontmatter prose to "**guildmaster** pulls this skill" but left the three `scripts/*.sh` header comments reading "**steward** pulls this skill" — a direct contradiction in the same skill about the canonical sync source. Aligned all three script headers (`think` / `spec-to-plan` / `assign-to-workforce`) to guildmaster.
2. **`cicd` portability.** `assign-to-workforce`'s worked example and flow hard-coded `.claude/skills/cicd/scripts/workflow.sh open` and "the `cicd` skill". `cicd` is canonical in the guildmaster mesh, but downstream repos that vendor this trio may use a different PR workflow (e.g. agentirc's `pr-review`), so the worked example breaks there. Reworded the four `cicd` mentions to name the repo's PR workflow generically (`cicd` / `pr-review` / `gh pr create`).

Bug 2 from the same Qodo review (the EXIT-trap `eval` in `assign-to-workforce.sh`) is intentionally **not** changed — it's the already-reviewed implementation from #30 / PR #31 / #32 and is functionally correct.

## Why upstream

The trio is first-party to devague (origin = devague; guildmaster re-broadcasts). Fixing it here means the correction propagates to every downstream copy on the next re-sync, rather than forking each vendored copy. The agentirc PR applies the **identical** edits so the two trees stay byte-convergent until re-sync.

## Changes

- 5 skill files: 3 provenance headers + 4 `cicd` → repo-agnostic wording (docs/comments only — no CLI behaviour change).
- `pyproject.toml`: 0.13.0 → 0.13.1 (CI version-check gate).
- `CHANGELOG.md`: 0.13.1 entry under Fixed.

## Verification

- `bash -n` clean on all three scripts.
- `cicd/scripts/portability-lint.sh` clean (7 files).

- devague (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)