### PR TITLE
feat(skills): carry the sharper method into the operator kit; add /scope (0.15.0)

### DIFF
--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -110,7 +110,13 @@ Once the human approves, the main agent fans out each wave in order:
 
 2. **Spawn a task agent** inside that worktree (using the approved model from
    the split plan), with:
-   - The task id, summary, and acceptance criteria as its brief.
+   - The task id, summary, acceptance criteria, and covered targets as its
+     brief — **quoted verbatim** from `devague plan show --json` (or the
+     exported plan-md). No operator paraphrasing: the plan text *is* the
+     contract the user confirmed, and a reworded brief silently drifts from it.
+     (When the enriched `waves --json` payload lands — devague#53, task t9 —
+     the brief comes straight from that one payload, per-task instructions
+     included.)
    - Instruction to work **test-first** (TDD): write the failing test(s) that
      match the acceptance criteria before implementing.
    - Instruction to commit its work to the worktree branch.
@@ -228,7 +234,9 @@ bash .claude/skills/cicd/scripts/workflow.sh open
 
 The exported plan-md from `devague plan export` is the standing brief for
 each task agent — its task id, summary, acceptance criteria, and the targets
-it covers are already in that file.
+it covers are already in that file. Quote those fields **verbatim** into each
+task agent's brief; the fan-out is honest only if what the subagent builds
+against is exactly what the user confirmed in the plan.
 
 ## Provenance
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -64,7 +64,8 @@ of the method: no wizard.)
 ## How findings land (the shipped surface)
 
 There is no `devague scope` CLI verb yet — findings land through the existing
-moves, driven via the `/think` wrapper:
+`devague` moves (this skill invokes the CLI directly and stays self-contained;
+if `devague` isn't on your PATH: `uv tool install devague`):
 
 | Finding | Move |
 |---------|------|
@@ -104,12 +105,11 @@ git ls-files devague/ | head -30       # the CLI package map
 #       docs/spec-contract.md (schema contract), .claude/skills/think/SKILL.md
 
 # 3–4. hand off to /think and seed with provenance
-d() { bash .claude/skills/think/scripts/think.sh "$@"; }
-d new "devague exports carry per-item instructions" --title "per-item instructions"
-d capture --origin llm --kind requirement "claims gain an optional instruction field — devague/frame.py claim model + docs/spec-contract.md schema both need a bump"
-d capture --origin llm --kind boundary "render/spec_md.py renders instructions verbatim; absent instructions render nothing — the renderer never fabricates filler"
-d capture --origin llm --kind non_goal "no LLM calls land inside the CLI (issue 20) — instruction text is authored by the operator/user, never generated in-CLI"
-d question "do instructions attach to frame claims, plan tasks, or both?"
+devague new "devague exports carry per-item instructions" --title "per-item instructions"
+devague capture --origin llm --kind requirement "claims gain an optional instruction field — devague/frame.py claim model + docs/spec-contract.md schema both need a bump"
+devague capture --origin llm --kind boundary "render/spec_md.py renders instructions verbatim; absent instructions render nothing — the renderer never fabricates filler"
+devague capture --origin llm --kind non_goal "no LLM calls land inside the CLI (issue 20) — instruction text is authored by the operator/user, never generated in-CLI"
+devague question "do instructions attach to frame claims, plan tasks, or both?"
 ```
 
 Every claim above names the file or issue that was actually read — that is the

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: scope
+description: >
+  Explore the scope of a vague idea BEFORE framing it into a spec (the
+  idea→scope leg; the optional opening move ahead of /think). Survey the
+  surfaces the idea touches — code, docs, skills, CI, sibling repos — and seed
+  the coming Announcement Frame with boundary, non-goal, and assumption claims
+  that cite what was actually explored (provenance, not generic disclaimers).
+  Use when the user says "explore scope", "scope this idea", "what does this
+  touch", "map the scope", "scope exploration", or when an idea touches an
+  existing codebase and speccing it cold would mean guessing its boundaries.
+  Hand off to the sibling /think skill to build the frame. Authored and
+  maintained in agentculture/devague (origin = devague); guildmaster pulls this
+  skill from here and broadcasts it to the AgentCulture mesh — it is NOT
+  vendored from guildmaster like the inbound skills here.
+type: command
+---
+
+# scope — explore what an idea touches before you frame it
+
+The skill is named **`scope`**; it is the **opening leg** of the devague method
+— run it *before* the sibling **`/think`** skill frames an idea into a spec.
+Where `/think` converges on *what* to build, `/scope` grounds *where the idea
+lives*: which surfaces it touches, which it must not, and what is genuinely
+unknown — so the frame starts from explored territory instead of guesses.
+
+This comes from the sharper end-to-end method spec (devague#53): scope grounded
+up front means convergence measures real coverage instead of vibes. The
+exploration itself is **agent-side work** — the devague CLI stays deterministic
+and never explores anything (#20).
+
+## When to use — and when to skip
+
+Use `/scope` when the idea touches an existing codebase or ecosystem: a feature
+in a real repo, a process change across skills, anything where boundaries are
+discoverable rather than invented.
+
+**Skip it freely for small ideas.** Scope exploration is *not* a mandatory
+first stage — the move-driven adaptive arc stays intact, and an idea that fits
+in one announcement can go straight to `/think`. (This is a recorded non-goal
+of the method: no wizard.)
+
+## The method
+
+1. **Enumerate candidate surfaces.** List what the idea *might* touch: source
+   packages, CLI verbs, renderers, schemas, tests, docs, skills, CI workflows,
+   sibling repos. `git ls-files` and the repo's `CLAUDE.md` are the usual map.
+2. **Explore each surface read-only.** Read enough of each candidate to decide:
+   touched, not touched, or unknown. Exploration never mutates anything —
+   no edits, no state changes, no CLI moves yet.
+3. **Classify every finding.** Each explored surface yields one of:
+   - **in scope** — the idea changes it → becomes a `requirement` or
+     `assumption` claim in the frame;
+   - **out of scope** — the idea must not change it → becomes a `boundary` or
+     `non_goal` claim;
+   - **genuinely unknown** — can't tell without a decision → becomes a `park`
+     (open vagueness) or a `question` (pending user decision).
+4. **Seed the frame with provenance.** When `/think` starts, capture the
+   findings as claims whose text **cites the surface explored** — "the CLI
+   stays deterministic per issue 20; scope exploration is agent-side"
+   beats "we won't overreach". Provenance, not generic disclaimers: a reviewer
+   should be able to trace every boundary claim back to something you read.
+
+## How findings land (the shipped surface)
+
+There is no `devague scope` CLI verb yet — findings land through the existing
+moves, driven via the `/think` wrapper:
+
+| Finding | Move |
+|---------|------|
+| in scope (the idea changes this) | `capture --kind requirement` / `--kind assumption` (with `--origin llm` if you proposed it) |
+| out of scope (must not change) | `capture --kind boundary` / `--kind non_goal` |
+| genuinely unknown, needs a user decision | `question "<text>"` (later `question --resolve <qid> --decision "<text>"`) |
+| genuinely unknown, not decidable now | `park "<text>" --kind unknown_blocking\|unknown_nonblocking` |
+
+A deterministic **`devague scope` move** — recording explored surfaces and
+findings as first-class frame state with provenance links — is **planned, not
+shipped**: it is task t3 of the committed sharper-end-to-end-method plan
+(`docs/plans/2026-07-01-devague-ships-a-sharper-end-to-end-method-a-guided.md`,
+devague#53). Do not run `devague scope` until it exists; this skill documents
+the surface as built.
+
+## Hard rules (do not violate)
+
+- **Exploration is read-only.** Surveying scope never edits files, never
+  mutates frame state, never runs a mutating CLI move.
+- **Provenance in every seeded claim.** A scope-derived claim cites what was
+  explored. If you didn't read it, don't claim it.
+- **LLM proposals stay proposed.** Findings you capture with `--origin llm`
+  land `proposed`; the user confirms. Same anti-fabrication contract as
+  `/think`.
+- **Don't become a wizard.** Scope exploration is optional-by-size and
+  adaptive. Never block a small idea on a survey it doesn't need.
+
+## Worked example
+
+Scoping "devague exports should carry per-item instructions" against the
+devague repo itself:
+
+```bash
+# 1–2. enumerate + explore (read-only)
+git ls-files devague/ | head -30       # the CLI package map
+# read: devague/frame.py (claim model), devague/render/spec_md.py (renderer),
+#       docs/spec-contract.md (schema contract), .claude/skills/think/SKILL.md
+
+# 3–4. hand off to /think and seed with provenance
+d() { bash .claude/skills/think/scripts/think.sh "$@"; }
+d new "devague exports carry per-item instructions" --title "per-item instructions"
+d capture --origin llm --kind requirement "claims gain an optional instruction field — devague/frame.py claim model + docs/spec-contract.md schema both need a bump"
+d capture --origin llm --kind boundary "render/spec_md.py renders instructions verbatim; absent instructions render nothing — the renderer never fabricates filler"
+d capture --origin llm --kind non_goal "no LLM calls land inside the CLI (issue 20) — instruction text is authored by the operator/user, never generated in-CLI"
+d question "do instructions attach to frame claims, plan tasks, or both?"
+```
+
+Every claim above names the file or issue that was actually read — that is the
+provenance bar.
+
+## After scoping — hand off to /think
+
+Scope exploration produces no artifact of its own (until the planned CLI move
+lands, the findings *are* the seeded claims). When the survey is done, start
+the frame with `/think` and capture the findings as the frame's opening claims.
+The user confirms LLM-proposed ones there, as always.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, the
+*fourth* in the outbound family after `/think`, `/spec-to-plan`, and
+`/assign-to-workforce`, covering the pre-frame exploration leg. guildmaster
+pulls it from here and broadcasts it to the AgentCulture mesh. The
+`cite, don't import` policy still holds: downstream repos copy it, they don't
+symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -55,7 +55,7 @@ install hint. Every move — including `status` — is forwarded verbatim as
 | `accept <tN> "<crit>"` | Add an acceptance criterion to a task. |
 | `depend <tN> --on <tM>` | Record that task `tN` depends on `tM`. |
 | `cover <tN> --target <c*/h*>` | Mark a task as covering a coverage target. |
-| `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** |
+| `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** Takes **one task id per call** — loop for batches (unlike the frame engine's transactional multi-id `confirm`; parity is a recorded follow-up in the 2026-07-01 plan, devague#53). |
 | `risk "<text>" --kind <kind>` | Record a first-class plan risk (`--task <tN>` to attach). |
 | `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
 | `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
@@ -118,6 +118,28 @@ These are the point of the method — convergence must mean something.
 When authoring a plan that will be built via parallel execution (fanned out to
 multiple agents via the downstream `/assign-to-workforce` skill), prefer the
 following discipline to maximize parallelism and minimize merge friction:
+
+### Acceptance criteria are the instruction contract (today)
+
+Until the planned per-task `instruction` field lands (task t5 of the
+sharper-end-to-end-method plan, devague#53), **acceptance criteria are where a
+task's working instructions live**. Write each criterion as something a cheaper
+model can execute test-first without re-deriving the design: name the files or
+modules the task owns, the observable behavior that proves it done, and the
+compatibility constraints ("pre-existing plans load with no error"). A criterion
+a subagent can't act on alone is a summary, not a contract. The enriched
+`waves --json` payload (carrying summary + instructions + acceptance criteria +
+covered targets per task) is planned in the same increment — until then, the
+brief is composed from `plan show --json` + the exported plan-md.
+
+### Text hygiene for exports
+
+The exported plan-md must pass markdown lint. The plan's H1 inherits the
+*frame's* title — set a short, period-free `--title` at `devague new` time (see
+`/think`'s export-hygiene rules). And backtick angle-bracket placeholders in
+task text (`` `instruct <tN>` ``, not `instruct <tN>`) — bare ones fail MD033.
+There is no task-edit move yet, so fixing text after confirmation means
+hand-editing state JSON.
 
 ### Small and crisply scoped
 

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -37,6 +37,15 @@ This skill is the operator: a portable wrapper that resolves the CLI and
 forwards every move verbatim — including `status`, the read-only verb that reads
 the convergence gate and tells you the recommended next move.
 
+**Explore scope first when the idea touches an existing codebase.** The sibling
+**`/scope`** skill is the optional opening leg: survey the surfaces the idea
+touches *before* framing, then seed the frame with `boundary` / `non_goal` /
+`assumption` claims that cite what was actually explored (provenance, not
+generic disclaimers). Small ideas skip it and start here — no wizard. (From the
+sharper end-to-end method spec, devague#53; the deterministic `devague scope`
+move that will record findings as first-class state is planned there, not yet
+shipped.)
+
 ## How to run
 
 The entry point is `scripts/think.sh`. Invoke it from the repository you are
@@ -58,7 +67,7 @@ for portable resolution.
 
 | Move | What it does |
 |------|--------------|
-| `new "<announcement>"` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. |
+| `new "<announcement>" [--title "<short>"]` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. Always pass `--title` (see *Export hygiene*). |
 | `capture --kind <kind> "<text>"` | Record + classify a claim. `--origin llm` lands it as `proposed`. |
 | `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. |
 | `confirm <id> [<id>…]` / `reject <id> [<id>…]` | Resolve one or more claims (`c*`) / honesty conditions (`h*`) in one **transactional** call. **User-only decision.** Also `confirm --from-review <file>` to apply an edited review artifact. |
@@ -113,6 +122,34 @@ recommended next move (first gap):
 
 Run it whenever you're unsure what to do next.
 
+### Export hygiene — keep the artifacts lint-clean
+
+The exported spec-md must pass the repo's markdown lint. Two gotchas found by
+dogfooding (devague#53), both cheap to avoid up front and expensive after —
+there is no retitle/edit move yet, so fixing them later means hand-editing
+state JSON and re-exporting:
+
+- **Always pass `--title "<short title>"` to `new`.** The title becomes the H1
+  of every exported artifact (the plan inherits it too). The default is the
+  full announcement — long, and if it ends with a period the H1 fails MD026
+  (trailing punctuation). Keep the title short, no trailing period.
+- **Backtick angle-bracket tokens.** A placeholder like `--seeds <claim-id>`
+  in claim or honesty-condition text renders as inline HTML (MD033) unless
+  wrapped in backticks. Write `` `--seeds <claim-id>` ``, not the bare form.
+- **Lint before committing:** `markdownlint-cli2 "docs/specs/<file>.md"`.
+
+### Pending decisions — the `question` loop
+
+When a genuine design decision surfaces mid-frame, don't guess and don't stall:
+
+1. `question "<the decision to make>"` — records it as durable working state.
+2. Put it to the user (with concrete options where possible).
+3. `question --resolve <qid> --decision "<what the user chose>"`.
+4. `capture --kind decision "<the choice>"` — a user-origin capture
+   auto-confirms, making the decision a first-class frame claim.
+
+This keeps every user decision traceable from question → resolution → claim.
+
 ## Hard rules (do not violate)
 
 These are the point of the method — convergence must mean something.
@@ -149,7 +186,7 @@ A short end-to-end session (the kind you'd run to spec a feature like
 ```bash
 d() { bash .claude/skills/think/scripts/think.sh "$@"; }
 
-d new "Devague ships a documented spec contract"
+d new "Devague ships a documented spec contract" --title "documented spec contract"
 d capture --kind audience "devague + the assisting LLM"
 d capture --kind after_state "a vague idea becomes a buildable, pressure-tested spec"
 d capture --kind why_it_matters "specs converge on evidence, not vibes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-07-02
+
+### Added
+
+- New fourth origin skill `scope` (idea→scope): guided pre-frame scope exploration — survey the surfaces an idea touches read-only, classify findings, seed the /think frame with provenance-citing boundary/non-goal/assumption claims. Method-only until the `devague scope` CLI move lands (#53 plan t3).
+
+### Changed
+
+- `think` skill: scope-first pointer to /scope, export hygiene (always pass `new --title`; backtick angle-bracket tokens; no retitle/edit move exists), and the question→resolve→decision-claim loop.
+- `spec-to-plan` skill: acceptance-criteria-as-instruction-contract coaching, plan-export text hygiene, and the single-task-id `confirm` note (frame confirm is multi-id; parity is a #53 follow-up).
+- `assign-to-workforce` skill: task briefs must quote summary/acceptance criteria/covered targets verbatim from plan state — no operator paraphrasing (spec #53 honesty condition h5).
+- docs/skills.md + docs/skill-sources.md + CLAUDE.md: the origin-skill family is now four; `devague learn skills` still teaches the three CLI-driving skills until #53 t10/t11 land.
+
 ## [0.14.1] - 2026-07-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
+**Operator kit carries the sharper method + new `/scope` skill (0.15.0).** The
+sharper end-to-end method spec+plan merged in #53 (0.14.1: docs + state only);
+this release carries its *method-level* half into the operator skills. New
+fourth origin skill **`scope`** (idea→scope, the optional pre-frame exploration
+leg — method-only: no script, no CLI verb; findings land via existing moves with
+provenance-citing claims). `think` gained scope-first guidance, export hygiene
+(`new --title`, backtick angle-bracket tokens — no retitle/edit move exists),
+and the `question`→resolve→`decision`-claim loop; `spec-to-plan` gained the
+acceptance-criteria-as-instruction-contract coaching and the single-id `confirm`
+note; `assign-to-workforce` now requires **verbatim** task briefs (no operator
+paraphrasing). The CLI is unchanged — `devague scope`, per-item `--instruction`,
+sharper renderers/gates are the #53 build plan (t1–t14), still unimplemented;
+`devague learn skills` still teaches the three CLI-driving skills until t10/t11.
+
 **Skills re-synced to guildmaster + two new skills (0.13.0, #38).** The vendored
 canonical kit now sources from `guildmaster` (the supplier role moved from
 `steward` at the 2026-05-24 cutover): `cicd` / `communicate` re-synced (the `cicd`
@@ -194,8 +208,10 @@ and hard questions, parking unresolved uncertainty as first-class "open
 vagueness," and only exporting a buildable spec once the frame *converges*. The
 plan method: seed a plan from that converged frame and converge it on coverage,
 acceptance criteria, and an acyclic dependency order before exporting a plan.
-Two operator skills cover the two legs: **`/think`** (idea→spec) and
-**`/spec-to-plan`** (spec→plan); the product/CLI for both is **`devague`**.
+The operator skills cover the legs in flow order: **`/scope`** (idea→explored
+scope, the optional opening leg), **`/think`** (idea→spec), **`/spec-to-plan`**
+(spec→plan), and **`/assign-to-workforce`** (plan→parallel implementation); the
+product/CLI they drive is **`devague`**.
 
 This is a **state machine over claims, honesty conditions, open vagueness, and
 convergence** driven by LLM-chosen moves — not a linear wizard. The CLI is
@@ -220,9 +236,9 @@ working in AgentCulture (the supplier role moved from `steward` at the 2026-05-2
 steward→guildmaster cutover; `steward` is still a sibling but no longer
 broadcasts). Vendored skills are cited, not imported (cite-don't-import): copy
 from `../guildmaster/.claude/skills/<name>/` and track provenance in
-`docs/skill-sources.md`. The exception is devague's own `think` / `spec-to-plan` /
-`assign-to-workforce` — devague is their origin, so guildmaster re-broadcasts them
-*from* here; never re-vendor them back.
+`docs/skill-sources.md`. The exception is devague's own `scope` / `think` /
+`spec-to-plan` / `assign-to-workforce` — devague is their origin, so guildmaster
+re-broadcasts them *from* here; never re-vendor them back.
 
 ## Stack expectations (when code lands)
 

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -35,7 +35,7 @@ upstream repo are shared across all rows.
 
 ## Origin skills (outbound)
 
-Not every skill here is inbound. The `think`, `spec-to-plan`, and
+Not every skill here is inbound. The `scope`, `think`, `spec-to-plan`, and
 `assign-to-workforce` skills are **authored and maintained in this repo** —
 devague is their origin/upstream, not a downstream consumer. The devague agent
 dogfoods them to operate the devague CLI while improving the tool. The flow runs

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -40,19 +40,21 @@ Not every skill here is inbound. The `think`, `spec-to-plan`, and
 devague is their origin/upstream, not a downstream consumer. The devague agent
 dogfoods them to operate the devague CLI while improving the tool. The flow runs
 the *opposite* direction of the table above: `guildmaster` re-vendors them from
-here and re-broadcasts them to the mesh. (The skill names are `think` /
+here and re-broadcasts them to the mesh. (The skill names are `scope` / `think` /
 `spec-to-plan` / `assign-to-workforce`; the product/CLI they drive is `devague`.
 `think` was renamed from `devague` in 0.4.0 — when guildmaster re-vendors, it must
 relearn the new name.) Because devague is upstream, these are **not** re-vendored
 back from guildmaster's re-broadcast copies — doing so would be circular (see the
 issue #38 reply).
 
-As of 0.13.0 (#38) all three carry `type: command` at the source, so guildmaster's
-re-broadcast copies (which had to add it on vendor for the culture/agex backend)
-match the source and need no patch.
+As of 0.13.0 (#38) all origin skills carry `type: command` at the source, so
+guildmaster's re-broadcast copies (which had to add it on vendor for the
+culture/agex backend) match the source and need no patch. `scope` (new in
+0.15.0) shipped with it from day one.
 
 | Skill | Origin | Downstream | Notes |
 |-------|--------|------------|-------|
+| `scope` | **devague** (here: `.claude/skills/scope/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **idea→scope** leg: the optional pre-frame exploration stage from the sharper end-to-end method spec (devague#53). Method-only today — no entry-point script; findings land through existing `devague` moves via the `/think` wrapper. The deterministic `devague scope` CLI move (first-class findings with provenance) is planned in the #53 build plan (task t3); its `devague learn skills` authoring recipe lands with that move (tasks t10/t11). New in 0.15.0. Re-vendor from `../devague/.claude/skills/scope/`. |
 | `think` | **devague** (here: `.claude/skills/think/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **idea→spec** leg of the deterministic devague CLI: portable resolution, driving the flat `devague <move>` verbs (`status` is now a first-class CLI verb, not embedded Python). Renamed from `devague` in 0.4.0. `guildmaster` re-vendors it from `../devague/.claude/skills/think/` and broadcasts it to the mesh. |
 | `spec-to-plan` | **devague** (here: `.claude/skills/spec-to-plan/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **spec→plan** leg (`devague plan ...`): portable resolution over the plan convergence gate. New in 0.4.0. Re-vendor from `../devague/.claude/skills/spec-to-plan/`. |
 | `assign-to-workforce` | **devague** (here: `.claude/skills/assign-to-workforce/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **implementation** leg (fan out `devague plan waves` to parallel agents in isolated git worktrees, with TDD-gated merges by the main agent). Three human gates only: spec / implementation split plan / final PR. The devague CLI remains non-orchestrating (#20) — this skill is the convention + helper, not new CLI behavior. New in 0.7.0. Re-vendor from `../devague/.claude/skills/assign-to-workforce/`. |
@@ -69,6 +71,6 @@ symlink/dependency. Written portable-first so they pass guildmaster's
   `../guildmaster/.claude/skills/<name>/`.
 - **Diverge intentionally.** Record any divergence in the table above and
   in the downstream `SKILL.md` frontmatter `description`.
-- **Don't re-vendor devague-origin skills.** `think` / `spec-to-plan` /
+- **Don't re-vendor devague-origin skills.** `scope` / `think` / `spec-to-plan` /
   `assign-to-workforce` are authored here; pull fixes forward into this repo, not
   back from guildmaster's re-broadcast copies.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,12 +1,14 @@
 # Authoring devague's operator skills
 
-This is the canonical guide for **authoring the three devague operator skills**
+This is the canonical guide for **authoring the devague operator skills**
 in an agent runtime — what files they need, where they live, the entry-point
 shape, and the contract between a skill and devague's state. It is the long-form
 companion to `devague learn skills`, which surfaces a condensed, always-available
-version of the same recipe.
+version of the same recipe. (`devague learn skills` currently teaches the three
+CLI-driving skills; the recipe for the method-only `scope` skill joins it when
+its `devague scope` CLI move lands — see the #53 build plan, tasks t3/t10/t11.)
 
-These three skills are devague's **outbound** skills — devague is their
+These skills are devague's **outbound** skills — devague is their
 origin/upstream (it dogfoods them to drive its own CLI), and guildmaster re-vendors
 them to the rest of the AgentCulture mesh under the `cite, don't import` policy.
 See [`skill-sources.md`](skill-sources.md) for the provenance map. This guide is
@@ -124,13 +126,32 @@ A skill drives the deterministic CLI and adds no business logic of its own:
   merges live in the `assign-to-workforce` skill and the operating agent, not in
   the CLI and not in a CI runner.
 
-## The three operator skills
+## The operator skills
 
 | Skill | Leg | What it drives |
 |-------|-----|----------------|
+| `scope` | idea → explored scope (the optional opening leg) | read-only exploration; findings land via existing `devague` moves |
 | `think` | idea → spec (working backwards) | the flat `devague <move>` verbs |
 | `spec-to-plan` | spec → plan (working forwards) | the `devague plan <move>` group |
 | `assign-to-workforce` | plan → parallel implementation | reads `devague plan waves` (read-only) |
+
+### `scope` — idea → explored scope (method-only)
+
+Survey the surfaces an idea touches **before** framing it: enumerate candidates,
+explore each read-only, classify findings (in scope / out of scope / genuinely
+unknown), then seed the `/think` frame with `boundary` / `non_goal` /
+`assumption` claims that **cite what was explored**. Optional by size — small
+ideas skip straight to `/think` (no wizard). From the sharper end-to-end method
+spec ([devague#53](https://github.com/agentculture/devague/pull/53)).
+
+Method-only today: it ships no entry-point script and drives no CLI verb of its
+own. The deterministic `devague scope` move (findings as first-class frame state
+with provenance) is planned in the #53 build plan (task t3); this skill's
+`devague learn skills` authoring recipe lands with that move (tasks t10/t11).
+
+- Source:
+  [`.claude/skills/scope/`](https://github.com/agentculture/devague/blob/main/.claude/skills/scope/SKILL.md)
+  (`SKILL.md` only).
 
 ### `think` — idea → buildable spec
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.14.1"
+version = "0.15.0"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What

Carries the **method-level half** of the sharper end-to-end method spec (#53) into the operator skill kit, and adds the fourth origin skill. The CLI is deliberately unchanged — `devague scope`, per-item `--instruction`, and the sharper renderers/gates remain the #53 build plan (t1–t14).

## New skill

- **`/scope`** (`.claude/skills/scope/SKILL.md`) — the optional opening leg (idea→explored scope): enumerate the surfaces an idea touches, explore each read-only, classify findings (in scope / out / genuinely unknown), and seed the `/think` frame with **provenance-citing** boundary/non-goal/assumption claims. Explicitly optional by size (no wizard), explicitly method-only today (no script, no CLI verb; findings land via existing moves), with the planned `devague scope` move pointed at #53 plan t3.

## Updated skills

- **`/think`** — scope-first pointer to `/scope`; **export hygiene** (always pass `new --title` short + period-free, backtick angle-bracket tokens; both bit us dogfooding #53 and there is no retitle/edit move); the `question` → `--resolve --decision` → `capture --kind decision` loop for user decisions.
- **`/spec-to-plan`** — acceptance criteria documented as **the instruction contract** until the per-task `instruction` field lands (#53 t5); plan-export text hygiene; `confirm` takes one task id per call (frame `confirm` is multi-id transactional — parity is recorded follow-up risk r2 in the #53 plan).
- **`/assign-to-workforce`** — task briefs must quote summary, acceptance criteria, and covered targets **verbatim** from plan state; no operator paraphrasing (spec #53 honesty condition h5, enforceable at the method level today).

## Docs

`docs/skills.md` (operator-skill guide gains the `scope` section; heading un-numbered to stop drift), `docs/skill-sources.md` (origin table now four rows), `CLAUDE.md` (status + origin-family mentions).

## Notes for review

- **Pre-existing lint hit:** `agex pr lint` flags `user-dotfile-reference` on CHANGELOG.md line 40 — that's the released 0.14.0 entry (`~/.eidetic/memory`, #50), not introduced here; left untouched rather than rewriting a released entry.
- **Sibling drift (alignment files touched):** guildmaster re-vendors the origin skills from this repo — after merge it needs a re-vendor sweep of `think` / `spec-to-plan` / `assign-to-workforce` **plus the new `scope`**. `agex pr delta` couldn't run here (no `.claude/skills.local.yaml`); flagging manually.
- `devague learn skills` still teaches the three CLI-driving skills — the `scope` recipe joins it with the CLI move (#53 t10/t11), noted in `docs/skills.md`.

## Version

0.14.1 → 0.15.0 (minor: new skill).

- devague (Claude)
