### PR TITLE
feat: the sharper end-to-end method — scope move, instructions, sharper exports, guided fanout (0.16.0, #53 t1-t14)

### DIFF
--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -48,15 +48,19 @@ bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh help
 It resolves the CLI portably — an installed `devague` on `PATH` (the normal
 case), falling back to `uv run devague` when you are inside the devague
 checkout, else an install hint. The `split-plan` subcommand reads
-`devague plan waves --json` and renders the human-facing implementation split
-plan: task map, proposed per-task agent + model assignment, and the go/no-go
-question. The `waves` subcommand forwards to `devague plan waves` verbatim.
+`devague plan waves --json` — the enriched payload (devague#53 t9) that
+carries every active task's summary, instruction, acceptance criteria, and
+covered targets keyed by task id — and renders the human-facing
+implementation split plan: task map (task id, wave, summary verbatim, whether
+an instruction is present, acceptance-criteria count), proposed per-task
+agent + model assignment, and the go/no-go question. The `waves` subcommand
+forwards to `devague plan waves` verbatim.
 
 ### Usage
 
 | Subcommand | What it does |
 |------------|--------------|
-| `split-plan [--plan S]` | Read `devague plan waves` and print the implementation split plan — task map with per-task agent + model proposal — ready for human go/no-go review. |
+| `split-plan [--plan S]` | Read `devague plan waves --json` and print the implementation split plan — task map (summary/instruction/acceptance-criteria count, verbatim) with per-task agent + model proposal — ready for human go/no-go review. |
 | `waves [--plan S] [--json]` | Forward to `devague plan waves [--json]`. Read-only; lists wave batches. On a converged plan exits 0 listing the waves. |
 | `help` | Print usage. |
 
@@ -78,8 +82,10 @@ implementation stage (per task, the TDD gate is the main agent's).
 
 The split plan contains:
 
-1. **Task map** — every task id, its one-line summary, acceptance criteria, and
-   the wave it belongs to (from `devague plan waves`).
+1. **Task map** — every task id, its one-line summary (verbatim), whether it
+   carries a working instruction, its acceptance-criteria count, and the wave
+   it belongs to — all read straight from `devague plan waves --json` (no
+   operator paraphrasing).
 2. **Per-task agent + model proposal** — for each task: the proposed agent type
    (subagent / teammate / generalist), the proposed model (e.g. a cheaper/faster
    model for a well-scoped task), and the scope justification (why this task is
@@ -98,6 +104,37 @@ bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-pla
 
 Do not proceed to fan-out until the human approves the split plan.
 
+### The `waves --json` payload — the single source for every brief
+
+`devague plan waves --json` emits `{"plan": "<slug>", "waves": [[...], ...],
+"tasks": {...}}` — the ordered dependency-wave batches plus a top-level
+`tasks` object keyed by task id, each entry carrying that task's full working
+contract:
+
+```json
+{
+  "plan": "<slug>",
+  "waves": [["t1"], ["t2", "t3"]],
+  "tasks": {
+    "t1": {
+      "summary": "<task summary>",
+      "instruction": "<verbatim instruction, or \"\" if none>",
+      "acceptance_criteria": ["<criterion>", "..."],
+      "covers": ["<c*/h* id>", "..."]
+    }
+  }
+}
+```
+
+This one payload is enough to build a per-subagent brief with **no external
+context** — no need to also read `devague plan show --json` or the exported
+plan-md. `split-plan` reads it to render the task map above; the fan-out step
+below reads the same payload to build each task agent's brief. Quote
+`summary`, `instruction`, `acceptance_criteria`, and `covers` **verbatim**
+into every brief — never paraphrase them. (Documented identically in the
+sibling `/spec-to-plan` skill, since both skills consume the same payload —
+stay consistent if either changes.)
+
 ### Fan-out — one agent per task per wave in isolated worktrees
 
 Once the human approves, the main agent fans out each wave in order:
@@ -110,13 +147,12 @@ Once the human approves, the main agent fans out each wave in order:
 
 2. **Spawn a task agent** inside that worktree (using the approved model from
    the split plan), with:
-   - The task id, summary, acceptance criteria, and covered targets as its
-     brief — **quoted verbatim** from `devague plan show --json` (or the
-     exported plan-md). No operator paraphrasing: the plan text *is* the
-     contract the user confirmed, and a reworded brief silently drifts from it.
-     (When the enriched `waves --json` payload lands — devague#53, task t9 —
-     the brief comes straight from that one payload, per-task instructions
-     included.)
+   - The task id, summary, working instruction, acceptance criteria, and
+     covered targets as its brief — **quoted verbatim** from `devague plan
+     waves --json` (see *The `waves --json` payload* above). No operator
+     paraphrasing anywhere in this flow: the plan text *is* the contract the
+     user confirmed, and a reworded brief silently drifts from it. If a task
+     has no instruction (`""`), say so rather than inventing one.
    - Instruction to work **test-first** (TDD): write the failing test(s) that
      match the acceptance criteria before implementing.
    - Instruction to commit its work to the worktree branch.
@@ -232,11 +268,11 @@ git worktree add ../worktrees/agent-t4 -b agent/t4
 bash .claude/skills/cicd/scripts/workflow.sh open
 ```
 
-The exported plan-md from `devague plan export` is the standing brief for
-each task agent — its task id, summary, acceptance criteria, and the targets
-it covers are already in that file. Quote those fields **verbatim** into each
-task agent's brief; the fan-out is honest only if what the subagent builds
-against is exactly what the user confirmed in the plan.
+`devague plan waves --json` is the standing brief for each task agent — its
+task id, summary, instruction, acceptance criteria, and the targets it covers
+are all in that one payload. Quote those fields **verbatim** into each task
+agent's brief; the fan-out is honest only if what the subagent builds against
+is exactly what the user confirmed in the plan.
 
 ## Provenance
 

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # assign-to-workforce.sh — fan out devague plan waves to parallel agents.
 #
-# The skill is named `assign-to-workforce`; it reads `devague plan waves`
-# (scheduling metadata produced by the /spec-to-plan skill) and renders the
-# implementation split plan: task map + per-task agent/model proposal + a
-# go/no-go prompt for the human. The actual fan-out (worktree creation,
-# spawning, TDD-gated merges) is performed by the operator/main agent once
-# the human approves the split plan.
+# The skill is named `assign-to-workforce`; it reads `devague plan waves --json`
+# — the enriched payload (devague#53 t9: {"plan", "waves", "tasks"}, the latter
+# keyed by task id with summary/instruction/acceptance_criteria/covers) — and
+# renders the implementation split plan: task map (summary, instruction
+# marker, acceptance-criteria count — all verbatim from the payload) +
+# per-task agent/model proposal + a go/no-go prompt for the human. The actual
+# fan-out (worktree creation, spawning, TDD-gated merges) is performed by the
+# operator/main agent once the human approves the split plan.
 #
 # The devague CLI is non-orchestrating (#20): `devague plan waves` describes
 # the dependency graph; it does not spawn agents, manage worktrees, or pick
@@ -61,9 +63,11 @@ Usage:
 
 Commands:
   split-plan   Read `devague plan waves --json` and render the human-facing
-               implementation split plan: task map + per-task agent/model
-               proposal + go/no-go. Present this to the human before any
-               fan-out; do not proceed without approval.
+               implementation split plan: task map (summary, instruction
+               marker, acceptance-criteria count — all verbatim from the
+               payload) + per-task agent/model proposal + go/no-go. Present
+               this to the human before any fan-out; do not proceed without
+               approval.
   waves        Forward `devague plan waves` (and any extra flags) verbatim.
                On a converged plan exits 0 and lists the dependency waves.
 
@@ -135,6 +139,9 @@ except json.JSONDecodeError as exc:
 
 plan_slug = data.get("plan", "(unknown)")
 waves = data.get("waves") or []
+# The enriched payload (devague#53 t9): every active task's full working
+# contract, keyed by id — summary, instruction, acceptance criteria, covers.
+tasks_meta = data.get("tasks") or {}
 
 print(f"Implementation split plan — plan: {plan_slug}")
 print()
@@ -147,14 +154,21 @@ print()
 print("Task assignments (proposed — edit before approving):")
 print()
 
-headers = ("Task", "Wave", "Summary", "Agent type", "Model", "Scope note")
+headers = ("Task", "Wave", "Summary", "Instruction", "Accept.", "Agent type", "Model", "Scope note")
 rows = []
 for i, wave in enumerate(waves, 1):
     for task_id in wave:
+        meta = tasks_meta.get(task_id) or {}
+        # Verbatim from the payload — no operator paraphrasing (#53 t13, c12/h5).
+        summary = meta.get("summary") or "(no summary recorded)"
+        has_instruction = "yes" if meta.get("instruction") else "no"
+        accept_count = str(len(meta.get("acceptance_criteria") or []))
         rows.append((
             task_id,
             str(i),
-            "(see plan export for summary + acceptance criteria)",
+            summary,
+            has_instruction,
+            accept_count,
             "subagent",
             "cheaper/faster",
             "TDD-scoped task; isolated worktree; tests gate merge",
@@ -178,7 +192,9 @@ print("then confirm: \"Approved — assign to workforce\" or \"Edit first\".")
 print()
 print("Once approved, fan out wave by wave:")
 print("  1. Create one git worktree per task in the wave.")
-print("  2. Spawn a task agent per worktree (brief = task summary + acceptance criteria).")
+print("  2. Spawn a task agent per worktree — its brief quotes `devague plan")
+print("     waves --json`'s summary, instruction, and acceptance criteria for")
+print("     that task id verbatim (no paraphrasing).")
 print("  3. Await all tasks in the wave; then TDD-gate each merge (tests before + after).")
 print("  4. Advance to the next wave.")
 print("  5. Open the final PR (human gate 3) after all waves merge and tests pass.")

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -55,17 +55,42 @@ of the method: no wizard.)
      `non_goal` claim;
    - **genuinely unknown** — can't tell without a decision → becomes a `park`
      (open vagueness) or a `question` (pending user decision).
-4. **Seed the frame with provenance.** When `/think` starts, capture the
-   findings as claims whose text **cites the surface explored** — "the CLI
-   stays deterministic per issue 20; scope exploration is agent-side"
-   beats "we won't overreach". Provenance, not generic disclaimers: a reviewer
-   should be able to trace every boundary claim back to something you read.
+4. **Record findings on the frame, with provenance.** Start the frame with
+   `devague new "<announcement>" --title "<short>"` (this is also `/think`'s
+   first move) — scope entries live on the frame, so it must exist first.
+   Record each explored surface as a first-class finding:
+   `` `devague scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]` ``
+   — text that **cites the surface explored** ("the CLI stays deterministic
+   per issue 20; scope exploration is agent-side" beats "we won't overreach").
+   Capture the claim it seeded first (`capture --kind ...`), then pass its id
+   to `--seeds` — an unknown seed id is refused with a hint. Provenance, not
+   generic disclaimers: a reviewer should be able to trace every boundary claim
+   back to something you read.
 
 ## How findings land (the shipped surface)
 
-There is no `devague scope` CLI verb yet — findings land through the existing
-`devague` moves (this skill invokes the CLI directly and stays self-contained;
-if `devague` isn't on your PATH: `uv tool install devague`):
+This skill invokes the CLI directly and stays self-contained (if `devague`
+isn't on your PATH: `uv tool install devague`).
+
+The **primary** landing surface is the deterministic `devague scope` move,
+shipped in task t3 of the committed sharper-end-to-end-method plan
+(`docs/plans/2026-07-01-devague-ships-a-sharper-end-to-end-method-a-guided.md`,
+devague#53). It records an explored surface + finding as first-class frame
+state (`Frame.scope_entries` / `ScopeEntry`: `id` (`sN`), `surface`, `finding`,
+`seeds`) — deterministic recording only, no LLM calls, no subprocess, no
+filesystem exploration inside the CLI. Like `capture`, it needs a frame to
+already exist, so run `devague new` first:
+
+| Move | What it does |
+|------|--------------|
+| `devague scope "<surface>" --finding "<text>"` | Record a finding on the current frame. |
+| `devague scope "<surface>" --finding "<text>" --seeds <claim-id> [<claim-id> ...]` | Record a finding, linking it to the claim id(s) it went on to seed. An unknown seed id is refused with a hint (`run 'devague show' to see valid claim ids`). |
+| `devague scope --list [--json]` | Read every recorded entry back. |
+
+Boundary / non-goal / in-scope claims still land the same way they always
+did, through the normal frame moves — `devague scope` documents *what surface
+you explored and what you learned*, `capture` records *the claim that
+followed*:
 
 | Finding | Move |
 |---------|------|
@@ -73,13 +98,6 @@ if `devague` isn't on your PATH: `uv tool install devague`):
 | out of scope (must not change) | `capture --kind boundary` / `--kind non_goal` |
 | genuinely unknown, needs a user decision | `question "<text>"` (later `question --resolve <qid> --decision "<text>"`) |
 | genuinely unknown, not decidable now | `park "<text>" --kind unknown_blocking\|unknown_nonblocking` |
-
-A deterministic **`devague scope` move** — recording explored surfaces and
-findings as first-class frame state with provenance links — is **planned, not
-shipped**: it is task t3 of the committed sharper-end-to-end-method plan
-(`docs/plans/2026-07-01-devague-ships-a-sharper-end-to-end-method-a-guided.md`,
-devague#53). Do not run `devague scope` until it exists; this skill documents
-the surface as built.
 
 ## Hard rules (do not violate)
 
@@ -104,23 +122,38 @@ git ls-files devague/ | head -30       # the CLI package map
 # read: devague/frame.py (claim model), devague/render/spec_md.py (renderer),
 #       docs/spec-contract.md (schema contract), .claude/skills/think/SKILL.md
 
-# 3–4. hand off to /think and seed with provenance
+# 3. start the frame (also /think's first move — scope entries live on it)
 devague new "devague exports carry per-item instructions" --title "per-item instructions"
+
+# 4. capture each finding as a claim, then record the scope entry that seeded it
 devague capture --origin llm --kind requirement "claims gain an optional instruction field — devague/frame.py claim model + docs/spec-contract.md schema both need a bump"
+devague scope "devague/frame.py" --finding "claim model needs an optional instruction field per docs/spec-contract.md's schema contract" --seeds c2
+
 devague capture --origin llm --kind boundary "render/spec_md.py renders instructions verbatim; absent instructions render nothing — the renderer never fabricates filler"
+devague scope "render/spec_md.py" --finding "renderer must render instructions verbatim; absent instructions render nothing — never fabricate filler" --seeds c3
+
 devague capture --origin llm --kind non_goal "no LLM calls land inside the CLI (issue 20) — instruction text is authored by the operator/user, never generated in-CLI"
+devague scope "issue 20 (no LLM calls in-CLI)" --finding "instruction text is authored by the operator/user, never generated in-CLI" --seeds c4
+
 devague question "do instructions attach to frame claims, plan tasks, or both?"
+devague scope --list   # read every recorded finding back, with its seeded claim ids
 ```
 
 Every claim above names the file or issue that was actually read — that is the
-provenance bar.
+provenance bar. Note the order: `--seeds` needs the claim id to already exist,
+so `capture` runs first and the matching `scope` call cites it back.
 
 ## After scoping — hand off to /think
 
-Scope exploration produces no artifact of its own (until the planned CLI move
-lands, the findings *are* the seeded claims). When the survey is done, start
-the frame with `/think` and capture the findings as the frame's opening claims.
-The user confirms LLM-proposed ones there, as always.
+The recorded scope entries and the claims captured alongside them both live on
+the same frame — there is nothing separate to export. `devague scope --list`
+is the durable, citable record of what was explored; a converged frame's
+exported spec-md also renders a `## Scope exploration` section from the same
+entries (surface, finding, and seeded claim ids), so the provenance survives
+into the buildable artifact (#53 t6). When the survey is done, continue with
+`/think`'s remaining moves (`interrogate`, `confirm`/`reject`, `converge`,
+`export`) to take the frame the rest of the way. The user confirms
+LLM-proposed claims there, as always.
 
 ## Provenance
 

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -51,15 +51,16 @@ install hint. Every move — including `status` — is forwarded verbatim as
 | Move | What it does |
 |------|--------------|
 | `new --frame <slug>` | Seed a plan from a **converged** frame. Derives the coverage targets (`c*`/`h*`) the plan must satisfy. Refuses an unconverged frame. |
-| `task "<summary>"` | Add a task. `--accept "<crit>"`, `--dep <tN>`, `--covers <c*/h*>` (each repeatable); `--origin llm` lands it `proposed`. |
+| `task "<summary>"` | Add a task. `--accept "<crit>"`, `--dep <tN>`, `--covers <c*/h*>` (each repeatable), `--instruction "<text>"` (verbatim working guidance, at creation); `--origin llm` lands it `proposed`. |
+| `instruct <tN> "<text>"` | Add/update a task's working instruction. Changing it on an already-`confirmed` task flips it back to `proposed` — the user re-confirms (the plan side's mirror of the frame side's `interrogate --instruction` re-confirm rule). |
 | `accept <tN> "<crit>"` | Add an acceptance criterion to a task. |
 | `depend <tN> --on <tM>` | Record that task `tN` depends on `tM`. |
 | `cover <tN> --target <c*/h*>` | Mark a task as covering a coverage target. |
 | `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** Takes **one task id per call** — loop for batches (unlike the frame engine's transactional multi-id `confirm`; parity is a recorded follow-up in the 2026-07-01 plan, devague#53). |
 | `risk "<text>" --kind <kind>` | Record a first-class plan risk (`--task <tN>` to attach). |
-| `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
+| `converge` | Evaluate the gate against the **live** source frame; list remaining gaps, plus non-blocking warnings (e.g. a confirmed task with no instruction). |
 | `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
-| `waves` | Emit deterministic dependency waves (`{plan, waves}`) — scheduling metadata only, *not* orchestration. Read-only, works on an in-progress plan; refuses a cyclic/dangling graph. Devague describes the graph; an operator decides how to run it (#20). |
+| `waves` | Emit deterministic dependency waves — `{plan, waves}` plus a top-level `tasks` object keyed by task id (per-task summary/instruction/acceptance criteria/covers — see *The `waves --json` payload* below) — scheduling + subagent-brief metadata only, *not* orchestration. Read-only, works on an in-progress plan; refuses a cyclic/dangling graph. Devague describes the graph; an operator decides how to run it (#20). |
 | `status` | Read-only: where the plan stands + the recommended next move, re-checked against the live frame (`--json` too). |
 | `show` / `list` | Render a plan / list plans (`--json` for raw state). |
 | `learn` / `explain <move>` | Teach the method / explain one move. |
@@ -119,18 +120,33 @@ When authoring a plan that will be built via parallel execution (fanned out to
 multiple agents via the downstream `/assign-to-workforce` skill), prefer the
 following discipline to maximize parallelism and minimize merge friction:
 
-### Acceptance criteria are the instruction contract (today)
+### Acceptance criteria are the testable contract; instruction is the working guidance
 
-Until the planned per-task `instruction` field lands (task t5 of the
-sharper-end-to-end-method plan, devague#53), **acceptance criteria are where a
-task's working instructions live**. Write each criterion as something a cheaper
-model can execute test-first without re-deriving the design: name the files or
-modules the task owns, the observable behavior that proves it done, and the
-compatibility constraints ("pre-existing plans load with no error"). A criterion
-a subagent can't act on alone is a summary, not a contract. The enriched
-`waves --json` payload (carrying summary + instructions + acceptance criteria +
-covered targets per task) is planned in the same increment — until then, the
-brief is composed from `plan show --json` + the exported plan-md.
+Two fields now do two distinct jobs on every task (shipped: devague#53 t5):
+
+- **`--accept "<criterion>"`** (repeatable) — the **testable contract**: what a
+  test suite checks to prove the task done. Write each as something a cheaper
+  model can be validated against test-first: name the files or modules the task
+  owns, the observable behavior that proves it done, and the compatibility
+  constraints ("pre-existing plans load with no error"). A criterion a subagent
+  can't be validated against alone is a summary, not a contract.
+- **`--instruction "<text>"`** (at `task` time) / **`instruct <tN> "<text>"`**
+  (afterwards) — verbatim **working guidance** carried to the subagent: the
+  approach to take, which files to touch first, anything the acceptance
+  criteria don't spell out. Write it yourself; never invent filler to satisfy
+  the gate. Changing it on an already-`confirmed` task flips the task back to
+  `proposed` — the user re-confirms.
+
+`devague plan converge` warns (non-blocking) when a confirmed task carries no
+instruction:
+
+```text
+task t1 has no instruction — attach operator guidance with `devague plan instruct t1 "<text>"`
+```
+
+Neither field replaces the other: acceptance criteria stay the pass/fail gate;
+instruction is what a subagent reads before it starts, quoted verbatim (never
+paraphrased) into the brief — see *The `waves --json` payload* below.
 
 ### Text hygiene for exports
 
@@ -189,22 +205,52 @@ This is guaranteed only if:
 The TDD gate — tests pass before *and* after the merge — is the main agent's
 proof that parallelism didn't break correctness.
 
+### The `waves --json` payload — the subagent brief
+
+`devague plan waves --json` keeps its original shape — `{"plan": "<slug>",
+"waves": [[...], ...]}`, the ordered task-id scheduling batches — and adds a
+top-level `"tasks"` object, keyed by task id, carrying each task's brief
+verbatim (devague#53 t9, shipping in this same increment):
+
+```json
+{
+  "plan": "<slug>",
+  "waves": [["t1"], ["t2", "t3"]],
+  "tasks": {
+    "t1": {
+      "summary": "<task summary>",
+      "instruction": "<verbatim instruction, or \"\" if none>",
+      "acceptance_criteria": ["<criterion>", "..."],
+      "covers": ["<c*/h* id>", "..."]
+    }
+  }
+}
+```
+
+This is enough to build a per-subagent brief with **no external context** —
+no need to also fetch `plan show --json` or the exported plan-md. Quote
+`instruction` and `acceptance_criteria` verbatim into the brief; don't
+paraphrase them.
+
 ### How to route tasks to the workforce
 
-Once your plan converges, `devague plan waves` emits the dependency-graph as
-**scheduling metadata** (ordered batches of task IDs). This feeds directly into
-the `/assign-to-workforce` skill, which:
+Once your plan converges, `devague plan waves` emits the dependency-graph plus
+the per-task brief above as **scheduling metadata** (ordered batches of task
+IDs, each with its summary/instruction/acceptance criteria/covers). This feeds
+directly into the `/assign-to-workforce` skill, which:
 
 1. Displays the plan, waves, and suggested per-task subagent/model pairing.
 2. Waits for the human to approve the implementation split plan (or edit
    assignments).
 3. Fans out approved waves to isolated subagent worktrees (one per task per
-   wave).
+   wave) — each subagent's brief quotes its task's `instruction` and
+   `acceptance_criteria` verbatim from the payload above.
 4. Returns control to the main agent, which TDD-gates each merge before moving
    to the next wave.
 
 Plan for workforce execution early: narrow task scope, write crisp acceptance
-criteria, and strive for wide waves with disjoint files.
+criteria, attach a working instruction, and strive for wide waves with
+disjoint files.
 
 ## Output contract
 
@@ -225,16 +271,21 @@ p new --frame my-feature        # seeds the plan + its coverage targets
 p show                          # see the c*/h* targets you must cover
 
 p task "Build the core engine" --accept "engine has a convergence gate" \
-    --covers c1 --covers c3
+    --covers c1 --covers c3 --instruction "implement in devague/frame.py; see docs/spec-contract.md for the schema"
 p task "Pressure-test honesty conditions" --dep t1 --covers h1 --covers h2 \
     --accept "every honesty condition maps to a test"
+
+# Add/refine an instruction after the fact — changing it on a confirmed task
+# flips the task back to 'proposed' (the user re-confirms):
+p instruct t2 "write tests/test_honesty.py covering each honesty condition"
 
 # Park a genuine unknown instead of guessing:
 p risk "exact rollout sequencing" --kind unknown_nonblocking
 
 p status        # what's left + the next move
-p converge      # gate; resolve any listed gaps
+p converge      # gate; resolve any listed gaps (warnings never block export)
 p export        # writes docs/plans/my-feature.md once converged
+p waves --json  # scheduling metadata + the per-task subagent brief
 ```
 
 The exported plan-md is a buildable artifact: topologically ordered tasks, each

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -41,10 +41,15 @@ the convergence gate and tells you the recommended next move.
 **`/scope`** skill is the optional opening leg: survey the surfaces the idea
 touches *before* framing, then seed the frame with `boundary` / `non_goal` /
 `assumption` claims that cite what was actually explored (provenance, not
-generic disclaimers). Small ideas skip it and start here — no wizard. (From the
-sharper end-to-end method spec, devague#53; the deterministic `devague scope`
-move that will record findings as first-class state is planned there, not yet
-shipped.)
+generic disclaimers). Small ideas skip it and start here — no wizard. Findings
+now land on the frame itself through the shipped `devague scope` move: start
+the frame with `new` first (scope entries live on it, like any other claim),
+then record each explored surface with
+`` `devague scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]` ``
+— `--seeds` links the finding to claim ids it went on to seed, and an unknown
+seed id is refused with a hint. Read every recorded entry back with
+`` `scope --list [--json]` ``. (From the sharper end-to-end method spec,
+devague#53, task t3.)
 
 ## How to run
 
@@ -68,10 +73,11 @@ for portable resolution.
 | Move | What it does |
 |------|--------------|
 | `new "<announcement>" [--title "<short>"]` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. Always pass `--title` (see *Export hygiene*). |
-| `capture --kind <kind> "<text>"` | Record + classify a claim. `--origin llm` lands it as `proposed`. |
-| `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. |
+| `capture --kind <kind> "<text>" [--instruction "<text>"]` | Record + classify a claim. `--origin llm` lands it as `proposed`. `--instruction` attaches verbatim working guidance (how to verify/implement the claim) at creation time. |
+| `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. `--instruction "<text>"` adds/updates a claim's or honesty condition's instruction — `<id>` may be a claim (`c*`) or, with `--instruction` alone, an honesty condition (`h*`). |
 | `confirm <id> [<id>…]` / `reject <id> [<id>…]` | Resolve one or more claims (`c*`) / honesty conditions (`h*`) in one **transactional** call. **User-only decision.** Also `confirm --from-review <file>` to apply an edited review artifact. |
-| `review` | List every **proposed** (unconfirmed) claim + honesty condition with ids (`--json` too); writes a non-authoritative artifact to `.devague/reviews/<slug>.md`. Un-gated; never mutates. |
+| `review` | List every **proposed** (unconfirmed) claim + honesty condition with ids and their instructions (`--json` too); writes a non-authoritative artifact to `.devague/reviews/<slug>.md`. Un-gated; never mutates. |
+| `scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]` / `scope --list` | Record (or list) a pre-frame exploration finding as first-class state (see the scope pointer above). |
 | `question "<text>"` | Record / list / `--resolve` a pending user decision as durable working state in `.devague/questions/<slug>.md`. |
 | `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
 | `converge` | Evaluate the gate; list remaining gaps. |
@@ -96,6 +102,38 @@ per-move input/output/transition/error contract are documented in
 [#5](https://github.com/agentculture/devague/issues/5)); for the authoritative
 live shape of any move, run it with `--json` (or `devague learn --json` /
 `devague explain <move>`).
+
+### Instructions — verbatim guidance, never fabricated
+
+Claims and honesty conditions may carry an optional `instruction`: verbatim
+text on how to verify or implement the item — write it yourself, don't invent
+filler to satisfy the gate. Two ways to set it:
+
+- `capture --kind <kind> "<text>" --instruction "<text>"` — at creation.
+- `interrogate <c*|h*> --instruction "<text>"` — add or change one on an
+  existing claim or honesty condition (this is the one case where `interrogate`
+  accepts an `h*` id directly, since the instruction targets whichever item you
+  name).
+
+**Re-confirm rule.** Changing the instruction on an already-`confirmed` claim
+or honesty condition flips its status back to `proposed` — the instruction is
+part of what the user confirmed, so a change to it must go back through the
+user. `interrogate` prints a diagnostic note (stderr) when this happens; re-run
+`confirm <id>`.
+
+**Gate warnings, not blockers.** `converge` emits two deterministic,
+warning-only structural-sharpness signals — neither holds back `ready_for_spec`:
+
+- a confirmed spec-affecting claim (`announcement`, `audience`, `after_state`,
+  `before_state`, `why_it_matters`, `boundary`, `success_signal`, `requirement`)
+  with no `instruction`;
+- a confirmed `success_signal` claim (or claims) where none contains a
+  measurable token — a numeral, `%`, or a comparator (`<`/`>`/`≤`/`≥`).
+
+Both are pure predicates over frame state, never LLM judgment on prose — see
+`devague/convergence.py`'s module docstring for the exact rules (S1/S2). A
+frame can converge and export with these warnings still showing; they nudge
+toward a sharper, more directly actionable spec.
 
 ### `status` — the next-move verb
 
@@ -187,7 +225,12 @@ A short end-to-end session (the kind you'd run to spec a feature like
 d() { bash .claude/skills/think/scripts/think.sh "$@"; }
 
 d new "Devague ships a documented spec contract" --title "documented spec contract"
-d capture --kind audience "devague + the assisting LLM"
+
+# Optional scope stage: record what you explored before capturing claims
+d scope "devague/frame.py" --finding "the claim model devague#5 extends lives here"
+
+d capture --kind audience "devague + the assisting LLM" \
+    --instruction "check docs/spec-contract.md names devague + the LLM as readers"
 d capture --kind after_state "a vague idea becomes a buildable, pressure-tested spec"
 d capture --kind why_it_matters "specs converge on evidence, not vibes"
 d capture --kind boundary "not a full PRD generator; no fixed wizard"
@@ -197,11 +240,16 @@ d capture --kind success_signal "a frame exports only after the gate passes"
 d interrogate c1 --honesty "the contract round-trips: save -> load -> identical frame"
 # ...user reviews and runs: d confirm h1
 
+# Attach a working instruction to the now-confirmed honesty condition — this
+# flips h1 back to 'proposed' (the re-confirm rule), so the user re-confirms:
+d interrogate h1 --instruction "run tests/test_contract.py::test_contract_round_trips"
+# ...user reviews and runs: d confirm h1
+
 # Park a genuine unknown instead of guessing:
 d park "exact JSON schema versioning policy" --kind unknown_nonblocking
 
-d status        # what's left + the next move
-d converge      # gate; resolve any listed gaps
+d status        # what's left + the next move (warnings show with a ⚠ marker)
+d converge      # gate; resolve any listed gaps (warnings never block export)
 d export        # writes docs/specs/<slug>.md once converged
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-07-07
+
+### Added
+
+- **The sharper end-to-end method ships** — the full #53 build plan (t1–t14),
+  implemented by a devague-orchestrated workforce fan-out (5 waves, one agent
+  per task, TDD-gated merges):
+  - **`devague scope` move** records explored surfaces as first-class
+    `ScopeEntry` state (`s1`… id, surface, finding, `--seeds` claim links with
+    unknown-id refusal); `scope --list [--json]` reads them back (t1/t3).
+  - **Per-item instructions**: optional verbatim `instruction` text on claims,
+    honesty conditions (`capture --instruction`,
+    `interrogate <c*|h*> --instruction`) and plan tasks
+    (`plan task --instruction`, new `plan instruct <tN>` move). Adding or
+    changing an instruction on a confirmed item flips it back to `proposed`
+    for re-confirmation (t2/t4/t5).
+  - **Sharper exports**: spec-md/frame-md render instruction blocks verbatim
+    plus a scope-provenance section; plan-md renders per-task instruction
+    bullets; absent instructions render nothing (golden-file tested) (t6/t9).
+  - **Enriched `waves --json`**: adds a top-level `tasks` object —
+    `{summary, instruction, acceptance_criteria, covers}` per task id — a
+    self-contained subagent brief; existing keys unchanged (t9).
+  - **Structural sharpness warnings** (soft rollout, warnings-only):
+    instruction-less confirmed spec-affecting claims, non-measurable
+    success signals (deterministic predicate, documented false-positive
+    story), and instruction-less confirmed plan tasks (t7/t8).
+  - **Teaching + skills**: `learn` presents the optional scope stage;
+    `explain scope` / `explain question` work; /think, /spec-to-plan, /scope
+    and /assign-to-workforce SKILL.md teach the shipped surface —
+    assign-to-workforce briefs now come verbatim from `waves --json`
+    (t10/t11/t13).
+  - **Dogfooded e2e + boundary audit** committed as tests: a real idea (the
+    unpark move, #57) runs scope → frame → spec → plan → fanout brief on the
+    shipped surface; the audit pins no LLM imports and no process spawning in
+    the package (#20) (t14).
+
+### Changed
+
+- Frame `SCHEMA_VERSION` and `PLAN_SCHEMA_VERSION` both bumped 1 → 2
+  (fail-closed on newer; v1 files load with empty defaults).
+- `docs/spec-contract.md`, `docs/llm-guidance.md`, `docs/skills.md` document
+  the scope entity, instruction fields, schema bumps, and gate rules (t12).
+
 ## [0.15.0] - 2026-07-02
 
 ### Added

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -68,6 +68,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import question as _question_cmd
     from devague.cli._commands import reject as _reject_cmd
     from devague.cli._commands import review as _review_cmd
+    from devague.cli._commands import scope as _scope_cmd
     from devague.cli._commands import show as _show_cmd
     from devague.cli._commands import status as _status_cmd
 
@@ -81,6 +82,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _review_cmd.register(sub)
     _question_cmd.register(sub)
     _park_cmd.register(sub)
+    _scope_cmd.register(sub)
     _converge_cmd.register(sub)
     _export_cmd.register(sub)
     _plan_cmd.register(sub)

--- a/devague/cli/_commands/capture.py
+++ b/devague/cli/_commands/capture.py
@@ -13,6 +13,11 @@ from devague.frame import CLAIM_KINDS
 def cmd_capture(args: argparse.Namespace) -> int:
     frame = resolve(args.frame)
     claim = frame.add_claim(args.kind, args.text, origin=args.origin)
+    if args.instruction is not None:
+        # A freshly-captured claim has no prior confirmed status to protect —
+        # the re-confirm rule only fires on *changing* an existing item
+        # (see interrogate.py).
+        claim.instruction = args.instruction
     store.save(frame)
     if getattr(args, "json", False):
         emit_result(
@@ -21,6 +26,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
                 "kind": claim.kind,
                 "origin": claim.origin,
                 "status": claim.status,
+                "instruction": claim.instruction,
             },
             json_mode=True,
         )
@@ -34,6 +40,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     p.add_argument("text", help="The claim text.")
     p.add_argument("--kind", required=True, choices=CLAIM_KINDS, help="Claim kind.")
     p.add_argument("--origin", choices=("user", "llm"), default="user", help="Who proposed it.")
+    p.add_argument(
+        "--instruction",
+        help="Optional verbatim instruction: how to verify or implement this claim.",
+    )
     p.add_argument("--frame", help="Frame slug (default: current).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_capture)

--- a/devague/cli/_commands/interrogate.py
+++ b/devague/cli/_commands/interrogate.py
@@ -10,11 +10,13 @@ from devague.cli._frames import resolve
 from devague.cli._output import emit_diagnostic, emit_result
 
 
-def cmd_interrogate(args: argparse.Namespace) -> int:
-    frame = resolve(args.frame)
+def _resolve_target(frame, args):
+    """Return ``(claim, honesty)`` for the target id, validating flag usage.
+
+    For --instruction only, the target id may name a claim (c*) OR an honesty
+    condition (h*) — #53 t4, c10. Every other flag requires a claim.
+    """
     claim = frame.find_claim(args.claim_id)
-    # For --instruction only, the target id may name a claim (c*) OR an
-    # honesty condition (h*) — #53 t4, c10.
     honesty = None if claim is not None else frame.find_honesty(args.claim_id)
     if claim is None and honesty is None:
         raise DevagueError(
@@ -22,7 +24,6 @@ def cmd_interrogate(args: argparse.Namespace) -> int:
             f"no such claim or honesty condition: {args.claim_id}",
             "run 'devague show'",
         )
-
     claim_only_requested = args.honesty or args.risk or args.hard_question or args.contradicts
     if honesty is not None and claim_only_requested:
         raise DevagueError(
@@ -31,7 +32,11 @@ def cmd_interrogate(args: argparse.Namespace) -> int:
             "--honesty/--hard-question/--risk/--contradicts require a claim id",
             "pass a claim id (e.g. c1), or drop those flags and keep --instruction",
         )
+    return claim, honesty
 
+
+def _add_claim_items(frame, claim, args) -> list[dict]:
+    """Record the claim-only additions (honesty / risk / hard question / contradiction)."""
     added: list[dict] = []
     if args.honesty:
         h = frame.add_honesty(claim, args.honesty, origin=args.origin)
@@ -47,20 +52,35 @@ def cmd_interrogate(args: argparse.Namespace) -> int:
     if args.contradicts:
         q = frame.add_hard_question(claim, f"contradiction with {args.contradicts}?", blocking=True)
         added.append({"kind": "hard_question", "id": q.id, "status": "blocking"})
+    return added
 
+
+def _apply_instruction(target, text: str) -> tuple[dict, str | None]:
+    """Set ``instruction`` on the target; a confirmed target flips back to proposed."""
+    flip_note = None
+    if target.status == "confirmed":
+        target.status = "proposed"
+        flip_note = (
+            f"{target.id} was confirmed; the instruction change flips it back to "
+            f"proposed — re-confirm with 'devague confirm {target.id}'"
+        )
+    target.instruction = text
+    return {"kind": "instruction", "id": target.id, "status": target.status}, flip_note
+
+
+def cmd_interrogate(args: argparse.Namespace) -> int:
+    frame = resolve(args.frame)
+    claim, honesty = _resolve_target(frame, args)
+
+    added = _add_claim_items(frame, claim, args)
     flip_note = None
     if args.instruction is not None:
         # --instruction alongside --honesty targets the CLAIM (not the
         # freshly-added honesty condition) — the operator-pinned semantics.
-        target = claim if claim is not None else honesty
-        if target.status == "confirmed":
-            target.status = "proposed"
-            flip_note = (
-                f"{target.id} was confirmed; the instruction change flips it back to "
-                f"proposed — re-confirm with 'devague confirm {target.id}'"
-            )
-        target.instruction = args.instruction
-        added.append({"kind": "instruction", "id": target.id, "status": target.status})
+        entry, flip_note = _apply_instruction(
+            claim if claim is not None else honesty, args.instruction
+        )
+        added.append(entry)
 
     if not added:
         raise DevagueError(

--- a/devague/cli/_commands/interrogate.py
+++ b/devague/cli/_commands/interrogate.py
@@ -7,14 +7,31 @@ import argparse
 from devague import store
 from devague.cli._errors import EXIT_USER_ERROR, DevagueError
 from devague.cli._frames import resolve
-from devague.cli._output import emit_result
+from devague.cli._output import emit_diagnostic, emit_result
 
 
 def cmd_interrogate(args: argparse.Namespace) -> int:
     frame = resolve(args.frame)
     claim = frame.find_claim(args.claim_id)
-    if claim is None:
-        raise DevagueError(EXIT_USER_ERROR, f"no such claim: {args.claim_id}", "run 'devague show'")
+    # For --instruction only, the target id may name a claim (c*) OR an
+    # honesty condition (h*) — #53 t4, c10.
+    honesty = None if claim is not None else frame.find_honesty(args.claim_id)
+    if claim is None and honesty is None:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"no such claim or honesty condition: {args.claim_id}",
+            "run 'devague show'",
+        )
+
+    claim_only_requested = args.honesty or args.risk or args.hard_question or args.contradicts
+    if honesty is not None and claim_only_requested:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"{args.claim_id} is an honesty condition — "
+            "--honesty/--hard-question/--risk/--contradicts require a claim id",
+            "pass a claim id (e.g. c1), or drop those flags and keep --instruction",
+        )
+
     added: list[dict] = []
     if args.honesty:
         h = frame.add_honesty(claim, args.honesty, origin=args.origin)
@@ -30,18 +47,35 @@ def cmd_interrogate(args: argparse.Namespace) -> int:
     if args.contradicts:
         q = frame.add_hard_question(claim, f"contradiction with {args.contradicts}?", blocking=True)
         added.append({"kind": "hard_question", "id": q.id, "status": "blocking"})
+
+    flip_note = None
+    if args.instruction is not None:
+        # --instruction alongside --honesty targets the CLAIM (not the
+        # freshly-added honesty condition) — the operator-pinned semantics.
+        target = claim if claim is not None else honesty
+        if target.status == "confirmed":
+            target.status = "proposed"
+            flip_note = (
+                f"{target.id} was confirmed; the instruction change flips it back to "
+                f"proposed — re-confirm with 'devague confirm {target.id}'"
+            )
+        target.instruction = args.instruction
+        added.append({"kind": "instruction", "id": target.id, "status": target.status})
+
     if not added:
         raise DevagueError(
             EXIT_USER_ERROR,
             "nothing to interrogate",
-            "pass --honesty / --hard-question / --risk / --contradicts",
+            "pass --honesty / --hard-question / --risk / --contradicts / --instruction",
         )
     store.save(frame)
+    if flip_note:
+        emit_diagnostic(flip_note)
     if getattr(args, "json", False):
-        emit_result({"claim": claim.id, "added": added}, json_mode=True)
+        emit_result({"claim": args.claim_id, "added": added}, json_mode=True)
     else:
         emit_result(
-            f"interrogated {claim.id}: " + ", ".join(f"{a['kind']} {a['id']}" for a in added),
+            f"interrogated {args.claim_id}: " + ", ".join(f"{a['kind']} {a['id']}" for a in added),
             json_mode=False,
         )
     return 0
@@ -49,12 +83,25 @@ def cmd_interrogate(args: argparse.Namespace) -> int:
 
 def register(sub: argparse._SubParsersAction) -> None:
     p = sub.add_parser("interrogate", help="Attach honesty conditions / hard questions to a claim.")
-    p.add_argument("claim_id", help="Claim id (e.g. c1).")
+    p.add_argument(
+        "claim_id",
+        help=(
+            "Claim id (e.g. c1); with --instruction only, an honesty "
+            "condition id (e.g. h1) also works."
+        ),
+    )
     p.add_argument("--honesty", help="An honesty condition (what must be true).")
     p.add_argument("--hard-question", dest="hard_question", help="A hard question.")
     p.add_argument("--risk", help="A risk (recorded as a non-blocking hard question).")
     p.add_argument("--contradicts", help="Claim id this contradicts (records a blocking question).")
     p.add_argument("--blocking", action="store_true", help="Mark the hard question blocking.")
+    p.add_argument(
+        "--instruction",
+        help=(
+            "Add or update a verbatim instruction on the target claim/honesty "
+            "condition. Changing it on a confirmed item flips it back to proposed."
+        ),
+    )
     p.add_argument(
         "--origin",
         choices=("user", "llm"),

--- a/devague/cli/_commands/learn.py
+++ b/devague/cli/_commands/learn.py
@@ -9,11 +9,20 @@ from devague.cli._errors import EXIT_USER_ERROR, DevagueError
 from devague.cli._output import emit_result
 
 MOVES = {
+    "scope": (
+        "Record an explored surface + finding as first-class state (optional "
+        "pre-frame leg; --seeds links a finding to the claims it seeded)."
+    ),
     "new": "Start a frame from the announcement (pretend it shipped).",
     "capture": "Record and classify a claim (audience, after_state, boundary, ...).",
     "interrogate": "Pressure-test a claim: honesty conditions, hard questions, contradictions.",
     "confirm": "Confirm a claim or honesty condition (user-only — no fabricated rigor).",
     "reject": "Reject a claim or honesty condition.",
+    "review": (
+        "List every proposed (unconfirmed) claim + honesty condition for "
+        "human review (read-only)."
+    ),
+    "question": "Record, list, or resolve a pending user decision (durable working state).",
     "park": "Move uncertainty into first-class open vagueness instead of forcing an answer.",
     "converge": "Check whether the frame is solid enough to export a spec.",
     "export": "Write the buildable spec — only once the frame converges.",
@@ -118,6 +127,45 @@ STAGES = [
     ("Spec", "what should be built?", "converge -> export"),
 ]
 
+# The optional pre-frame exploration lead-in (#53 t3/t10). It precedes the ten
+# numbered stages above rather than replacing one of them — optional-but-
+# recommended, not mandatory: recommended when the idea touches an existing
+# codebase, freely skippable for a small idea (the method's recorded non-goal:
+# devague never becomes a wizard with a fixed first stage).
+SCOPE_STAGE = {
+    "name": "Scope (optional, before Announcement)",
+    "prompt": "what does this idea touch, and what should it not touch?",
+    "move": 'scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]',
+    "loop": (
+        "Explore read-only first (no CLI moves while surveying), then record "
+        "each surveyed surface + finding with 'devague scope'; pass --seeds "
+        "with the claim ids a finding goes on to seed so the frame's boundary / "
+        "non_goal / assumption claims cite what was actually explored."
+    ),
+    "recommended_when": (
+        "Recommended when the idea touches an existing codebase or ecosystem — "
+        "grounds convergence in explored territory instead of guesses."
+    ),
+    "optional_by_size": (
+        "Optional-by-size, not a mandatory first stage: a small idea can skip "
+        "straight to 'new' (recorded non-goal — devague never becomes a wizard)."
+    ),
+}
+
+# The optional --instruction flags (frame side: #53 t4; plan side: #53 t5) ride
+# alongside the capture/interrogate stages above and carry through to the plan
+# handoff verbatim — noted once here rather than cluttering every stage line.
+INSTRUCTION_FLAGS_NOTE = (
+    "Any claim or honesty condition can also carry an optional --instruction —\n"
+    '  capture --kind <kind> "<text>" --instruction "<text>"\n'
+    '  interrogate <id> --honesty "<text>" --instruction "<text>"\n'
+    "verbatim text on how to verify or implement it; leave it empty rather than\n"
+    "invent one to fill a gate warning. It carries to the plan handoff:\n"
+    '  devague plan task "<summary>" --instruction "<text>"    (at creation)\n'
+    '  devague plan instruct <tN> "<text>"                     (on an existing task)\n'
+    "so a task's working guidance reaches the workforce brief unchanged."
+)
+
 _TEXT = (
     "devague turns a vague idea into a buildable spec by working backwards.\n\n"
     f"First question: {FIRST_QUESTION}\n"
@@ -127,11 +175,17 @@ _TEXT = (
     "The arc emerges from the moves; it is not a fixed wizard. You (the agent)\n"
     "choose the next move; devague tracks state. LLM-proposed claims and honesty\n"
     "conditions stay 'proposed' until the user confirms them.\n\n"
+    "Optional lead-in — scope exploration (recommended when the idea touches an\n"
+    "existing codebase; skip freely for small ideas — not a mandatory first stage):\n"
+    f"  {SCOPE_STAGE['prompt']}  [devague {SCOPE_STAGE['move']}]\n"
+    f"  {SCOPE_STAGE['loop']}\n\n"
     "Guided stages (the recommended sequence — drive them with the moves):\n"
     + "\n".join(
         f"  {i:>2}. {name:<13} {prompt}  [{move}]"
         for i, (name, prompt, move) in enumerate(STAGES, 1)
     )
+    + "\n\n"
+    + INSTRUCTION_FLAGS_NOTE
     + "\n\nMoves:\n"
     + "\n".join(f"  {name:<11} {desc}" for name, desc in MOVES.items())
     + "\n\ndevague is NOT:\n"
@@ -363,6 +417,8 @@ def cmd_learn(args: argparse.Namespace) -> int:
                         for i, (name, prompt, move) in enumerate(STAGES, 1)
                     ],
                     "moves": list(MOVES),
+                    "scope_stage": SCOPE_STAGE,
+                    "instruction_flags": INSTRUCTION_FLAGS_NOTE,
                     "not_a": list(NOT_A),
                     "operating_rules": list(OPERATING_RULES),
                     "guidance_doc": GUIDANCE_DOC_URL,

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -364,7 +364,21 @@ def cmd_plan_waves(args: argparse.Namespace) -> int:
         )
     waves = dependency_waves(plan.tasks)
     if getattr(args, "json", False):
-        emit_result({"plan": plan.slug, "waves": waves}, json_mode=True)
+        # Enough for a subagent brief with no external context (#53 t9, c8/h12):
+        # every active (non-rejected) task appearing in ``waves`` gets its full
+        # working contract — summary, verbatim instruction, acceptance criteria,
+        # and covered targets — keyed by task id.
+        tasks_payload = {
+            t.id: {
+                "summary": t.summary,
+                "instruction": t.instruction,
+                "acceptance_criteria": list(t.acceptance_criteria),
+                "covers": list(t.covers),
+            }
+            for t in plan.tasks
+            if t.status != "rejected"
+        }
+        emit_result({"plan": plan.slug, "waves": waves, "tasks": tasks_payload}, json_mode=True)
     elif not waves:
         emit_result("no tasks to schedule", json_mode=False)
     else:

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from devague import plan_store, store
 from devague.cli._errors import EXIT_USER_ERROR, DevagueError
 from devague.cli._frames import resolve as resolve_frame
-from devague.cli._output import emit_result
+from devague.cli._output import emit_diagnostic, emit_result
 from devague.cli._paths import dated_name
 from devague.cli._plans import resolve_plan
 from devague.cli._status import StatusLabels, emit_empty, emit_status
@@ -33,11 +33,13 @@ PLANS_OUT_DIR = Path("docs/plans")
 
 _JSON_HELP = "Emit structured JSON."
 _TASK_ID_HELP = "Task id."
+_INSTRUCTION_HELP = "Verbatim working instruction — how to verify or implement this task."
 _RESOLVE_HINT = "resolve: "  # prefix for a "; "-joined blocker remediation hint
 
 PLAN_MOVES = {
     "new": "Start a plan from a converged frame (derives coverage targets).",
-    "task": "Add a task; optionally --accept / --dep / --covers inline.",
+    "task": "Add a task; optionally --accept / --dep / --covers / --instruction inline.",
+    "instruct": "Add/update a task's working instruction (may flip confirmed -> proposed).",
     "accept": "Add an acceptance criterion to a task.",
     "depend": "Record that a task depends on another (--on).",
     "cover": "Mark a task as covering a coverage target (c*/h*).",
@@ -153,6 +155,7 @@ def cmd_plan_task(args: argparse.Namespace) -> int:
     for tid in args.covers or []:
         _require_target(plan, tid)
     task = plan.add_task(args.summary, origin=args.origin)
+    task.instruction = args.instruction or ""
     for crit in args.accept or []:
         plan.add_acceptance(task, crit)
     for dep in args.dep or []:
@@ -168,11 +171,49 @@ def cmd_plan_task(args: argparse.Namespace) -> int:
                 "acceptance": len(task.acceptance_criteria),
                 "deps": task.deps,
                 "covers": task.covers,
+                "instruction": task.instruction,
             },
             json_mode=True,
         )
     else:
         emit_result(f"added {task.id} ({task.status})", json_mode=False)
+    return 0
+
+
+def cmd_plan_instruct(args: argparse.Namespace) -> int:
+    """Add/update a task's working instruction (verbatim; never fabricated).
+
+    Re-confirm rule (#53 t5, gate-2 review): setting or changing the instruction on a
+    CONFIRMED task flips it back to 'proposed' — the instruction is part of what the
+    user confirmed, so a change to it must go back through the user. A task that is
+    already 'proposed' (or 'rejected') is unaffected by this rule; only its instruction
+    changes.
+    """
+    plan = resolve_plan(args.plan)
+    task = _require_task(plan, args.id)
+    task.instruction = args.text
+    flipped = task.status == "confirmed"
+    if flipped:
+        task.status = "proposed"
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result(
+            {
+                "id": task.id,
+                "instruction": task.instruction,
+                "status": task.status,
+                "flipped": flipped,
+            },
+            json_mode=True,
+        )
+    else:
+        emit_result(f"{task.id}: instruction set", json_mode=False)
+    if flipped:
+        emit_diagnostic(
+            f"note: {task.id}'s instruction changed on a confirmed task — "
+            "flipped back to 'proposed'; re-confirm it (devague plan confirm "
+            f"{task.id})"
+        )
     return 0
 
 
@@ -456,8 +497,15 @@ def register(sub: argparse._SubParsersAction) -> None:
     pt.add_argument("--dep", action="append", help="A task id this depends on (repeatable).")
     pt.add_argument("--covers", action="append", help="A coverage target id c*/h* (repeatable).")
     pt.add_argument("--origin", choices=("user", "llm"), default="user", help="Who proposed it.")
+    pt.add_argument("--instruction", default="", help=_INSTRUCTION_HELP)
     _plan_opt(pt)
     pt.set_defaults(func=cmd_plan_task)
+
+    pin = psub.add_parser("instruct", help="Add/update a task's working instruction.")
+    pin.add_argument("id", help=_TASK_ID_HELP)
+    pin.add_argument("text", help=_INSTRUCTION_HELP)
+    _plan_opt(pin)
+    pin.set_defaults(func=cmd_plan_instruct)
 
     pa = psub.add_parser("accept", help="Add an acceptance criterion to a task.")
     pa.add_argument("id", help="Task id (e.g. t1).")

--- a/devague/cli/_commands/review.py
+++ b/devague/cli/_commands/review.py
@@ -20,10 +20,17 @@ def _json_payload(frame) -> dict:
     return {
         "slug": frame.slug,
         "proposed_claims": [
-            {"id": c.id, "kind": c.kind, "text": c.text} for c in proposed_claims(frame)
+            {"id": c.id, "kind": c.kind, "text": c.text, "instruction": c.instruction}
+            for c in proposed_claims(frame)
         ],
         "proposed_honesty": [
-            {"id": h.id, "claim_id": c.id, "claim_kind": c.kind, "text": h.text}
+            {
+                "id": h.id,
+                "claim_id": c.id,
+                "claim_kind": c.kind,
+                "text": h.text,
+                "instruction": h.instruction,
+            }
             for c, h in proposed_honesty(frame)
         ],
     }

--- a/devague/cli/_commands/scope.py
+++ b/devague/cli/_commands/scope.py
@@ -1,0 +1,94 @@
+"""``devague scope`` — record an explored surface + finding as first-class state.
+
+The pre-frame exploration leg (`/scope`, #53 t3). Recording is deterministic:
+no LLM calls, no subprocess, no filesystem exploration — the move only
+RECORDS what the operator already explored read-only. Optional ``--seeds``
+links the entry to claim ids it went on to seed; an unknown seed id is
+refused with a hint rather than silently accepted (see
+``Frame.add_scope_entry``).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from devague import store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
+from devague.cli._frames import resolve
+from devague.cli._output import emit_result
+
+
+def _entry_dict(entry) -> dict:
+    return {
+        "id": entry.id,
+        "surface": entry.surface,
+        "finding": entry.finding,
+        "seeds": entry.seeds,
+    }
+
+
+def _record(args: argparse.Namespace, frame) -> int:
+    if not args.finding:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "missing --finding",
+            'pass --finding "<text>" describing what was learned about the surface',
+        )
+    try:
+        entry = frame.add_scope_entry(args.surface, args.finding, seeds=args.seeds)
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            str(exc),
+            "run 'devague show' to see valid claim ids",
+        ) from exc
+    store.save(frame)
+    if getattr(args, "json", False):
+        emit_result(_entry_dict(entry), json_mode=True)
+    else:
+        emit_result(f"recorded {entry.id} ({entry.surface})", json_mode=False)
+    return 0
+
+
+def _list(args: argparse.Namespace, frame) -> int:
+    entries = frame.scope_entries
+    if getattr(args, "json", False):
+        emit_result(
+            {"frame": frame.slug, "scope_entries": [_entry_dict(e) for e in entries]},
+            json_mode=True,
+        )
+    elif not entries:
+        emit_result("no scope entries yet", json_mode=False)
+    else:
+        lines = []
+        for e in entries:
+            line = f"{e.id}: {e.surface} -> {e.finding}"
+            if e.seeds:
+                line += f" [seeds: {', '.join(e.seeds)}]"
+            lines.append(line)
+        emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def cmd_scope(args: argparse.Namespace) -> int:
+    frame = resolve(args.frame)
+    if args.surface:
+        return _record(args, frame)
+    return _list(args, frame)
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("scope", help="Record an explored surface + finding (pre-frame scoping).")
+    p.add_argument("surface", nargs="?", help="The surface explored (omit to list).")
+    p.add_argument("--finding", help="What was learned about the surface.")
+    p.add_argument(
+        "--seeds",
+        nargs="*",
+        default=None,
+        metavar="CLAIM_ID",
+        help="Claim ids this finding seeded (must already exist).",
+    )
+    p.add_argument("--list", action="store_true", help="List recorded scope entries (default).")
+    p.add_argument("--frame", help="Frame slug (default: current).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_scope)

--- a/devague/convergence.py
+++ b/devague/convergence.py
@@ -1,4 +1,34 @@
-"""The convergence gate: is a frame solid enough to export a buildable spec?"""
+"""The convergence gate: is a frame solid enough to export a buildable spec?
+
+Structural-sharpness rules (#53 t7)
+-----------------------------------
+
+Beyond the hard blockers, the gate emits **warning-only** structural-sharpness
+signals. They never move ``ready_for_spec`` — the soft-rollout decision (the
+resolved parked-v2 item): the tightened gate's structural checks land as
+warnings first, so no frame that converges today is newly blocked. Each rule is
+a **pure predicate over frame state** — never LLM text judgment (h6) — and is
+enumerated here with its exact predicate and its known false-positive mode:
+
+- **S1 — instruction present on spec-affecting claims.** For every *confirmed*
+  claim whose ``kind`` is spec-affecting, warn if ``instruction`` is empty (after
+  ``.strip()``). Predicate: ``kind in SPEC_AFFECTING_KINDS and status ==
+  "confirmed" and not instruction.strip()``. Restricted to confirmed claims so a
+  still-proposed claim (already a blocker) is not double-signalled. Known
+  false positive: a self-evident claim that genuinely needs no separate
+  verification instruction is still nudged for one — harmless, warning-only.
+
+- **S2 — measurable success signal.** If the frame has at least one confirmed
+  ``success_signal`` claim but **none** of them contains a measurable token,
+  warn once. A claim text is "measurable" iff it contains a numeral, a ``%``, or
+  a comparator (``<`` ``>`` ``≤`` ``≥``) — the ``_MEASURABLE_TOKEN`` regex. Gated
+  on there being ≥1 confirmed success_signal so it never piles onto the existing
+  "missing a 'success_signal' claim" blocker. Known false positive: a perfectly
+  checkable *binary* success signal worded without a numeral (e.g. "the exported
+  spec shows scope provenance") trips the warning even though it is verifiable —
+  the operator can ignore it or add a count. It never *misses* a woolly numeric
+  claim; it only over-fires on numeral-free-but-checkable prose.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +36,12 @@ import re
 from dataclasses import dataclass, field
 
 from devague.frame import SPEC_AFFECTING_KINDS, Frame
+
+# A success signal counts as measurable if its text carries any of: a numeral, a
+# percent sign, or a comparison operator (ASCII ``<`` / ``>`` or their unicode
+# ``≤`` / ``≥`` forms — ``<=`` / ``>=`` are covered by ``<`` / ``>``). Pure
+# structure; no semantics, no LLM (h6, #53 t7 rule S2).
+_MEASURABLE_TOKEN = re.compile(r"[0-9%<>≤≥]")
 
 
 @dataclass
@@ -83,6 +119,33 @@ def _assumption_warnings(frame: Frame) -> list[str]:
     ]
 
 
+def _sharpness_warnings(frame: Frame, confirmed: list) -> list[str]:
+    """Deterministic structural-sharpness signals (see module docstring: S1, S2).
+
+    Warning-only and never blocking (soft rollout per parked-v2). Pure predicates
+    over frame state — no LLM judgment.
+    """
+    warnings = [
+        # S1: a confirmed spec-affecting claim that ships into the spec without a
+        # verification/implementation instruction is not directly actionable.
+        f"claim {c.id} ({c.kind}) is confirmed but carries no instruction — add "
+        f"one so the exported spec is directly actionable "
+        f'(devague interrogate {c.id} --instruction "<how to verify or implement>")'
+        for c in confirmed
+        if c.kind in SPEC_AFFECTING_KINDS and not c.instruction.strip()
+    ]
+    # S2: at least one confirmed success_signal exists but none is measurable.
+    signals = [c for c in confirmed if c.kind == "success_signal"]
+    if signals and not any(_MEASURABLE_TOKEN.search(c.text) for c in signals):
+        warnings.append(
+            "no confirmed success_signal claim is measurable — none names a "
+            "number, percentage, or comparator; add a measurable target "
+            "(devague capture --kind success_signal "
+            "\"<e.g. '95% of runs converge', 'under 3s'>\")"
+        )
+    return warnings
+
+
 def _parked_items(frame: Frame) -> list[str]:
     """Tracked, non-blocking open vagueness (everything but unknown_blocking)."""
     return [f"[{v.kind}] {v.text}" for v in frame.open_vagueness if v.kind != "unknown_blocking"]
@@ -143,7 +206,7 @@ def evaluate(frame: Frame) -> ConvergenceResult:
     return ConvergenceResult(
         ready=not blockers,
         blockers=blockers,
-        warnings=_assumption_warnings(frame),
+        warnings=_assumption_warnings(frame) + _sharpness_warnings(frame, confirmed),
         parked_items=_parked_items(frame),
         required_next_moves=[suggest_move(b) for b in blockers],
     )

--- a/devague/frame.py
+++ b/devague/frame.py
@@ -11,7 +11,8 @@ from typing import Optional
 
 # Bump when the persisted shape changes incompatibly. `store.load` fails closed
 # on a frame whose schema_version is newer/unknown (see #5, honesty condition h15).
-SCHEMA_VERSION = 1
+# v2 (#53 t1) adds Frame.scope_entries and Claim/HonestyCondition.instruction.
+SCHEMA_VERSION = 2
 
 CLAIM_KINDS = (
     "announcement",
@@ -59,6 +60,10 @@ class HonestyCondition:
     id: str
     text: str
     status: str = "proposed"  # proposed | confirmed | rejected
+    # Optional verbatim operator/user-authored text: how to verify this
+    # condition. Empty string means "no instruction" — never fabricated or
+    # defaulted to prose (#53 t1, c10/h3).
+    instruction: str = ""
 
     def __post_init__(self) -> None:
         if self.status not in HONESTY_STATUSES:
@@ -83,6 +88,10 @@ class Claim:
     honesty_conditions: list[HonestyCondition] = field(default_factory=list)
     hard_questions: list[HardQuestion] = field(default_factory=list)
     links: list[str] = field(default_factory=list)
+    # Optional verbatim operator/user-authored text: how to verify or
+    # implement this claim. Empty string means "no instruction" — never
+    # fabricated or defaulted to prose (#53 t1, c10/h3).
+    instruction: str = ""
 
     def __post_init__(self) -> None:
         if self.kind not in CLAIM_KINDS:
@@ -106,6 +115,19 @@ class Vagueness:
 
 
 @dataclass
+class ScopeEntry:
+    """A recorded scope-exploration finding: a surface explored, and what was
+    learned — the optional pre-frame leg (`/scope`, #53). ``seeds`` links this
+    finding to the claim ids it seeded, if any.
+    """
+
+    id: str
+    surface: str
+    finding: str
+    seeds: list[str] = field(default_factory=list)
+
+
+@dataclass
 class Frame:
     slug: str
     title: str
@@ -115,6 +137,7 @@ class Frame:
     updated: str = ""
     claims: list[Claim] = field(default_factory=list)
     open_vagueness: list[Vagueness] = field(default_factory=list)
+    scope_entries: list[ScopeEntry] = field(default_factory=list)
 
     @staticmethod
     def _next(items: list, prefix: str) -> str:
@@ -184,6 +207,22 @@ class Frame:
         self.open_vagueness.append(v)
         return v
 
+    def add_scope_entry(
+        self, surface: str, finding: str, seeds: Optional[list[str]] = None
+    ) -> ScopeEntry:
+        seed_ids = list(seeds) if seeds else []
+        for sid in seed_ids:
+            if self.find_claim(sid) is None:
+                raise ValueError(f"unknown seed claim id: {sid!r}")
+        entry = ScopeEntry(
+            id=self._next(self.scope_entries, "s"),
+            surface=surface,
+            finding=finding,
+            seeds=seed_ids,
+        )
+        self.scope_entries.append(entry)
+        return entry
+
     def set_status(self, item_id: str, status: str) -> bool:
         claim = self.find_claim(item_id)
         if claim is not None:
@@ -226,13 +265,32 @@ def from_dict(d: dict) -> Frame:
             text=c["text"],
             origin=c.get("origin", "user"),
             status=c.get("status", "confirmed"),
-            honesty_conditions=[HonestyCondition(**h) for h in c.get("honesty_conditions", [])],
+            honesty_conditions=[
+                HonestyCondition(
+                    id=h["id"],
+                    text=h["text"],
+                    status=h.get("status", "proposed"),
+                    instruction=h.get("instruction", ""),
+                )
+                for h in c.get("honesty_conditions", [])
+            ],
             hard_questions=[HardQuestion(**q) for q in c.get("hard_questions", [])],
             links=list(c.get("links", [])),
+            # v1 frames predate this field (#53 t1); default to "no instruction".
+            instruction=c.get("instruction", ""),
         )
         for c in d.get("claims", [])
     ]
     vag = [Vagueness(**v) for v in d.get("open_vagueness", [])]
+    scope_entries = [
+        ScopeEntry(
+            id=s["id"],
+            surface=s["surface"],
+            finding=s["finding"],
+            seeds=list(s.get("seeds", [])),
+        )
+        for s in d.get("scope_entries", [])
+    ]
     return Frame(
         slug=d["slug"],
         title=d["title"],
@@ -243,4 +301,6 @@ def from_dict(d: dict) -> Frame:
         updated=d.get("updated", ""),
         claims=claims,
         open_vagueness=vag,
+        # v1 frames predate this field (#53 t1); default to no scope entries.
+        scope_entries=scope_entries,
     )

--- a/devague/plan.py
+++ b/devague/plan.py
@@ -26,8 +26,8 @@ from devague.frame import (
 
 # Bump when the persisted plan shape changes incompatibly. `plan_store.load`
 # fails closed on a plan whose schema_version is newer/unknown (see #18; the
-# plan-engine peer of frame.SCHEMA_VERSION).
-PLAN_SCHEMA_VERSION = 1
+# plan-engine peer of frame.SCHEMA_VERSION). v2 (#53 t2) adds Task.instruction.
+PLAN_SCHEMA_VERSION = 2
 
 TASK_STATUSES = ("proposed", "confirmed", "rejected")
 # Risks reuse the frame's open-vagueness kinds: a plan risk is the task-level peer of
@@ -45,6 +45,9 @@ class Task:
     acceptance_criteria: list[str] = field(default_factory=list)
     deps: list[str] = field(default_factory=list)  # task ids this task depends on
     covers: list[str] = field(default_factory=list)  # frame claim/honesty ids (c*/h*)
+    # Optional verbatim operator/user-authored working instruction (#53 t2); "" means
+    # "no instruction" — never fabricated, rendered/serialized only as given.
+    instruction: str = ""
 
     def __post_init__(self) -> None:
         if self.origin not in ORIGINS:
@@ -221,6 +224,7 @@ def from_dict(d: dict) -> Plan:
             acceptance_criteria=list(t.get("acceptance_criteria", [])),
             deps=list(t.get("deps", [])),
             covers=list(t.get("covers", [])),
+            instruction=t.get("instruction", ""),
         )
         for t in d.get("tasks", [])
     ]

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -176,7 +176,7 @@ def suggest_move(blocker: str) -> str:
 def _tdd_fitness_warnings(plan: Plan) -> list[str]:
     """Non-blocking warnings that flag poor parallel/TDD fitness.
 
-    Two deterministic, purely structural heuristics:
+    Three deterministic, purely structural heuristics:
 
     1. **Missing acceptance criteria on confirmed tasks.**
        A confirmed task with zero acceptance criteria cannot be validated test-first.
@@ -186,7 +186,13 @@ def _tdd_fitness_warnings(plan: Plan) -> list[str]:
        Proposed and rejected tasks are excluded: proposed tasks are gated by the
        "still proposed" blocker; rejected tasks are not built.
 
-    2. **Over-serialized dependency graph.**
+    2. **Missing instruction on confirmed tasks.**
+       A confirmed task with an empty instruction field lacks operator guidance for
+       implementation. The warning is purely advisory and does not affect convergence;
+       it reminds the operator to attach working instructions. Proposed and rejected
+       tasks are excluded for the same reasons as heuristic 1.
+
+    3. **Over-serialized dependency graph.**
        When every wave produced by :func:`~devague.plan.dependency_waves` contains
        exactly one active confirmed task AND there are at least three such tasks, the
        plan is fully serial — every task blocks the next, no fan-out is possible.
@@ -197,7 +203,7 @@ def _tdd_fitness_warnings(plan: Plan) -> list[str]:
        **confirmed** active (non-rejected) tasks; proposed tasks are unresolved and may
        be rejected, so counting them would produce unstable warnings.
 
-    Neither warning changes ``ready_for_plan`` or ``blockers``.
+    No warning changes ``ready_for_plan`` or ``blockers``.
     """
     warnings: list[str] = []
 
@@ -209,7 +215,15 @@ def _tdd_fitness_warnings(plan: Plan) -> list[str]:
                 " — add TDD acceptance tests before implementation"
             )
 
-    # Heuristic 2: over-serialized graph.
+    # Heuristic 2: confirmed task with no instruction.
+    for t in plan.tasks:
+        if t.status == "confirmed" and not t.instruction:
+            warnings.append(
+                f"task {t.id} has no instruction"
+                f' — attach operator guidance with `devague plan instruct {t.id} "<text>"`'
+            )
+
+    # Heuristic 3: over-serialized graph.
     active_confirmed = [t for t in plan.tasks if t.status == "confirmed"]
     if len(active_confirmed) >= 3:
         waves = dependency_waves(plan.tasks)

--- a/devague/render/frame_md.py
+++ b/devague/render/frame_md.py
@@ -20,12 +20,22 @@ _SECTIONS = [
 ]
 
 
+def _instruction_lines(instruction: str, indent: str = "  ") -> list[str]:
+    """A nested ``- instruction: <verbatim text>`` bullet under an item, or nothing
+    when the item carries no instruction — never fabricated filler (#53 t1/t6,
+    c10/h3).
+    """
+    return [f"{indent}- instruction: {instruction}"] if instruction else []
+
+
 def _claim_lines(claim) -> list[str]:
     mark = "" if claim.status == "confirmed" else f" _({claim.status})_"
     lines = [f"- {claim.text}{mark}"]
+    lines += _instruction_lines(claim.instruction)
     for h in claim.honesty_conditions:
         hm = "" if h.status == "confirmed" else f" _({h.status})_"
         lines.append(f"  - honesty: {h.text}{hm}")
+        lines += _instruction_lines(h.instruction, indent="    ")
     for q in claim.hard_questions:
         qm = "blocking" if q.blocking else "open"
         lines.append(f"  - Q ({qm}): {q.text}")
@@ -52,6 +62,22 @@ def _vagueness_lines(frame: Frame) -> list[str]:
     return lines
 
 
+def _scope_lines(frame: Frame) -> list[str]:
+    """Scope-exploration provenance, mirroring spec_md's scope section (#53 t6):
+    each recorded surface + finding, with the claim ids it seeded. Empty
+    ``scope_entries`` renders nothing.
+    """
+    if not frame.scope_entries:
+        return []
+    lines = ["## Scope exploration", ""]
+    for e in frame.scope_entries:
+        lines.append(f"- `{e.id}` — `{e.surface}`: {e.finding}")
+        if e.seeds:
+            lines.append(f"  - seeds: {', '.join(f'`{s}`' for s in e.seeds)}")
+    lines.append("")
+    return lines
+
+
 def render_frame(frame: Frame) -> str:
     out = [
         f"# Announcement Frame — {frame.title}",
@@ -61,5 +87,6 @@ def render_frame(frame: Frame) -> str:
     ]
     for kind, heading in _SECTIONS:
         out.extend(_section_lines(frame, kind, heading))
+    out.extend(_scope_lines(frame))
     out.extend(_vagueness_lines(frame))
     return "\n".join(out).rstrip() + "\n"

--- a/devague/render/plan_md.py
+++ b/devague/render/plan_md.py
@@ -53,6 +53,12 @@ def _announcement(frame: Optional[Frame]) -> Optional[str]:
 def _task_lines(task: Task) -> list[str]:
     mark = "" if task.status == "confirmed" else f" _({task.status})_"
     body: list[str] = []
+    if task.instruction:
+        # Verbatim working instruction — never fabricated filler when absent (#53
+        # t9), mirroring t6's nested ``- instruction:`` bullet in spec_md.py /
+        # frame_md.py. A task is a heading rather than a claim bullet, so the
+        # instruction renders as the first body bullet, immediately under it.
+        body.append(f"- instruction: {task.instruction}")
     if task.deps:
         body.append(f"- depends on: {', '.join(task.deps)}")
     if task.covers:

--- a/devague/render/review_md.py
+++ b/devague/render/review_md.py
@@ -45,11 +45,19 @@ def render_review(frame: Frame) -> str:
         return "\n".join(out).rstrip() + "\n"
     if claims:
         out += ["## Proposed claims", ""]
-        out += [f"- pending `{c.id}` ({c.kind}): {c.text}" for c in claims]
+        for c in claims:
+            out.append(f"- pending `{c.id}` ({c.kind}): {c.text}")
+            # An absent instruction renders nothing — never fabricated filler
+            # (#53 t4, c10).
+            if c.instruction:
+                out.append(f"  - instruction: {c.instruction}")
         out += [""]
     if pairs:
         out += ["## Proposed honesty conditions", ""]
-        out += [f"- pending `{h.id}` (on `{c.id}` {c.kind}): {h.text}" for c, h in pairs]
+        for c, h in pairs:
+            out.append(f"- pending `{h.id}` (on `{c.id}` {c.kind}): {h.text}")
+            if h.instruction:
+                out.append(f"  - instruction: {h.instruction}")
         out += [""]
     return "\n".join(out).rstrip() + "\n"
 

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -2,58 +2,102 @@
 
 from __future__ import annotations
 
-from devague.frame import Frame
+from devague.frame import Claim, Frame, HonestyCondition
 
 
-def _texts(frame: Frame, kind: str) -> list[str]:
-    return [c.text for c in frame.claims if c.kind == kind and c.status == "confirmed"]
+def _claims(frame: Frame, kind: str) -> list[Claim]:
+    return [c for c in frame.claims if c.kind == kind and c.status == "confirmed"]
 
 
-def _section(heading: str, texts: list[str]) -> list[str]:
-    """A standard ``## heading`` + bullet-list block, or nothing when empty."""
+def _instruction_lines(instruction: str, indent: str = "  ") -> list[str]:
+    """A nested ``- instruction: <verbatim text>`` bullet under an item, or nothing
+    when the item carries no instruction — never fabricated filler (#53 t1/t6,
+    c10/h3).
+    """
+    return [f"{indent}- instruction: {instruction}"] if instruction else []
+
+
+def _claim_bullets(claims: list[Claim], prefix: str = "") -> list[str]:
+    out: list[str] = []
+    for c in claims:
+        out.append(f"- {prefix}{c.text}")
+        out += _instruction_lines(c.instruction)
+    return out
+
+
+def _text_section(heading: str, texts: list[str]) -> list[str]:
+    """A standard ``## heading`` + plain bullet-list block, or nothing when empty.
+
+    For text-only items with no instruction field (e.g. open vagueness).
+    """
     if not texts:
         return []
     return [f"## {heading}", "", *[f"- {t}" for t in texts], ""]
 
 
+def _claim_section(heading: str, claims: list[Claim]) -> list[str]:
+    """A ``## heading`` + bullet-list block of claims, each with its own nested
+    instruction bullet when it carries one, or nothing when empty.
+    """
+    if not claims:
+        return []
+    return [f"## {heading}", "", *_claim_bullets(claims), ""]
+
+
 def _before_after(frame: Frame) -> list[str]:
-    befores = _texts(frame, "before_state")
-    afters = _texts(frame, "after_state")
+    befores = _claims(frame, "before_state")
+    afters = _claims(frame, "after_state")
     if not (befores or afters):
         return []
     lines = ["## Before → After", ""]
-    lines += [f"- Before: {t}" for t in befores]
-    lines += [f"- After: {t}" for t in afters]
+    lines += _claim_bullets(befores, prefix="Before: ")
+    lines += _claim_bullets(afters, prefix="After: ")
     return lines + [""]
 
 
 def _requirements_block(frame: Frame) -> list[str]:
     """Requirement claims (confirmed) with their confirmed honesty conditions nested."""
-    reqs = [c for c in frame.claims if c.kind == "requirement" and c.status == "confirmed"]
+    reqs = _claims(frame, "requirement")
     if not reqs:
         return []
     out = ["## Requirements", ""]
     for c in reqs:
         out.append(f"- {c.text}")
-        out += [f"  - honesty: {h.text}" for h in c.honesty_conditions if h.status == "confirmed"]
+        out += _instruction_lines(c.instruction)
+        for h in c.honesty_conditions:
+            if h.status != "confirmed":
+                continue
+            out.append(f"  - honesty: {h.text}")
+            out += _instruction_lines(h.instruction, indent="    ")
     return out + [""]
 
 
-def _other_honesty(frame: Frame) -> list[str]:
+def _other_honesty(frame: Frame) -> list[HonestyCondition]:
     """Confirmed honesty conditions on **confirmed** non-requirement claims.
 
     The parent claim must be confirmed too: spec-md renders only confirmed claims
-    (see ``_texts``), so emitting honesty for a proposed/rejected claim would
+    (see ``_claims``), so emitting honesty for a proposed/rejected claim would
     leave an orphan bullet with no parent — inconsistent with the confirmed-only
     export contract.
     """
     return [
-        h.text
+        h
         for c in frame.claims
         if c.kind != "requirement" and c.status == "confirmed"
         for h in c.honesty_conditions
         if h.status == "confirmed"
     ]
+
+
+def _honesty_section(heading: str, honesties: list[HonestyCondition]) -> list[str]:
+    """Like ``_claim_section`` but for a flat list of honesty conditions."""
+    if not honesties:
+        return []
+    out = [f"## {heading}", ""]
+    for h in honesties:
+        out.append(f"- {h.text}")
+        out += _instruction_lines(h.instruction)
+    return out + [""]
 
 
 def _hard_questions(frame: Frame) -> list[str]:
@@ -66,22 +110,42 @@ def _follow_up(frame: Frame) -> list[str]:
     return [v.text for v in frame.open_vagueness if v.kind in ("follow_up", "out_of_scope")]
 
 
+def _scope_section(frame: Frame) -> list[str]:
+    """Scope-exploration provenance: each recorded surface + finding, with the
+    claim ids it seeded — citing what was actually explored, not a generic
+    disclaimer (#53 t1/t6, c8/h12/h2). Empty ``scope_entries`` renders nothing.
+    """
+    if not frame.scope_entries:
+        return []
+    out = ["## Scope exploration", ""]
+    for e in frame.scope_entries:
+        out.append(f"- `{e.id}` — `{e.surface}`: {e.finding}")
+        if e.seeds:
+            out.append(f"  - seeds: {', '.join(f'`{s}`' for s in e.seeds)}")
+    return out + [""]
+
+
 def render_spec(frame: Frame) -> str:
     out: list[str] = [f"# {frame.title}", ""]
-    ann = _texts(frame, "announcement")
-    if ann:
-        out += ["> " + ann[0], ""]
-    out += _section("Audience", _texts(frame, "audience"))
+    ann_claims = _claims(frame, "announcement")
+    if ann_claims:
+        ann = ann_claims[0]
+        out.append("> " + ann.text)
+        if ann.instruction:
+            out.append(f"> instruction: {ann.instruction}")
+        out.append("")
+    out += _claim_section("Audience", _claims(frame, "audience"))
     out += _before_after(frame)
-    out += _section("Why it matters", _texts(frame, "why_it_matters"))
+    out += _claim_section("Why it matters", _claims(frame, "why_it_matters"))
     out += _requirements_block(frame)
-    out += _section("Honesty conditions", _other_honesty(frame))
-    out += _section("Success signals", _texts(frame, "success_signal"))
-    out += _section("Scope / boundaries", _texts(frame, "boundary"))
-    out += _section("Non-goals", _texts(frame, "non_goal"))
-    out += _section("Assumptions", _texts(frame, "assumption"))
-    out += _section("Decisions", _texts(frame, "decision"))
+    out += _honesty_section("Honesty conditions", _other_honesty(frame))
+    out += _claim_section("Success signals", _claims(frame, "success_signal"))
+    out += _claim_section("Scope / boundaries", _claims(frame, "boundary"))
+    out += _claim_section("Non-goals", _claims(frame, "non_goal"))
+    out += _claim_section("Assumptions", _claims(frame, "assumption"))
+    out += _scope_section(frame)
+    out += _claim_section("Decisions", _claims(frame, "decision"))
     out += _hard_questions(frame)
-    out += _section("Open questions", _texts(frame, "open_question"))
-    out += _section("Open / follow-up", _follow_up(frame))
+    out += _claim_section("Open questions", _claims(frame, "open_question"))
+    out += _text_section("Open / follow-up", _follow_up(frame))
     return "\n".join(out).rstrip() + "\n"

--- a/docs/llm-guidance.md
+++ b/docs/llm-guidance.md
@@ -31,8 +31,15 @@ what remains before a spec (or plan) can be exported.
 
 ## 2. The state you operate on
 
-Two legs share one chassis:
+Three legs share one chassis (the third optional):
 
+- **Scope (idea → explored scope, optional).** The `/scope` skill's pre-frame
+  survey: `ScopeEntry` records (`surface` explored, `finding`, and the claim
+  `id`s it `seeds`) that ground the frame in what was actually looked at,
+  instead of generic disclaimers. Small ideas skip straight to the frame — this
+  leg is optional by size, never a mandatory first stage. Its state
+  (`Frame.scope_entries`) already exists; the `devague scope` move that writes
+  it is landing in a follow-up (#53 task t3).
 - **Frame (idea → spec).** Claims (each with a *kind* — `announcement`,
   `audience`, `after_state`, `before_state`, `why_it_matters`, `boundary`,
   `success_signal`, `open_question`, `non_goal`, `requirement`, `assumption`,
@@ -51,6 +58,16 @@ Every element carries two orthogonal axes:
 `origin` and `status` are independent. An `llm`-proposed claim is *proposed*
 until a human acts on it; a `user`-provided claim is *confirmed* on arrival.
 Keeping these distinct is the whole point of the tool — see §4.
+
+Claims, honesty conditions, and plan tasks also carry an optional
+**`instruction`** — verbatim text on how to verify or implement that item,
+`""` by default (never fabricated to fill the gap). Setting or changing an
+instruction on an already-`confirmed` item flips its status back to
+`proposed` — it re-enters the user-confirm loop like any other content change.
+The moves that set it (`capture --instruction` / `interrogate --instruction`
+on the frame side, `plan task --instruction` / `plan instruct <tN>` on the plan
+side) are landing in #53 tasks t4/t5; see [`spec-contract.md`](spec-contract.md)
+for the full field contract.
 
 ## 3. You choose the move; order is adaptive
 
@@ -71,6 +88,12 @@ conversation order**. If the user hands you the audience and the success signal
 before the announcement is crisp, capture those now and circle back. Drive
 toward the shape; do not impose a sequence on the user.
 
+An optional scope-exploration stage can precede all of this when the idea
+touches an existing codebase: survey the surfaces it touches, then seed the
+frame's `boundary` / `non_goal` / `assumption` claims with what was actually
+found — provenance, not a generic disclaimer. It's optional by size: skip
+straight to `new` for a small idea; nothing about it is a fixed first stage.
+
 ## 4. Hard rules — the anti-fabrication contract
 
 These are not style preferences. Convergence is only meaningful if these hold.
@@ -88,6 +111,12 @@ These are not style preferences. Convergence is only meaningful if these hold.
 - **Converge, don't vibe.** `export` is gated on `converge` passing. Never
   declare a frame or plan "ready" on a hunch — run `converge` and resolve every
   listed gap first.
+- **Instructions are optional and verbatim — never fabricated.** Leave
+  `instruction` empty rather than invent one just to satisfy a gate warning
+  (once the structural sharpness warnings in #53 t7/t8 land). Changing an
+  instruction on an already-confirmed item deliberately demotes it back to
+  `proposed` — that is the same anti-fabrication contract catching a
+  late-arriving field, not a bug.
 
 ## 5. Good vs. bad operator behavior
 
@@ -99,6 +128,7 @@ These are not style preferences. Convergence is only meaningful if these hold.
 | User asks "is this ready?" | "Yes, looks solid." | run `converge`; report the actual blockers/warnings |
 | The user skipped a stage | march through the stages in order anyway | capture what they gave you; let the arc fill in adaptively |
 | Plan: a task has no clear acceptance test | mark it confirmed and move on | leave it without criteria (the gate blocks it) or `park` the risk |
+| A gate warns a claim/task has no instruction (#53 t7/t8) | invent a generic instruction just to silence the warning | leave it empty, or write a real one and let the user confirm it |
 
 ## 6. The forward leg (spec → plan), in brief
 
@@ -112,6 +142,9 @@ spirit:
 - **Park genuine unknowns as risks** (`unknown_blocking` holds convergence back).
 - **Converge against the live frame** — `converge`/`export` re-load the source
   frame; if it regressed below convergence, re-converge the spec first.
+- **Instructions ride along to the workforce.** A task's optional
+  `instruction` (landing #53 t5) is meant to reach `assign-to-workforce`'s
+  per-subagent brief verbatim — no operator paraphrasing (#53 t9/t13).
 
 ## 7. Output contract
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -153,13 +153,13 @@ unknown), then seed the `/think` frame with `boundary` / `non_goal` /
 ideas skip straight to `/think` (no wizard). From the sharper end-to-end method
 spec ([devague#53](https://github.com/agentculture/devague/pull/53)).
 
-Method-only today: it ships no entry-point script and drives no CLI verb of its
-own. The backing state already exists — `Frame.scope_entries` / `ScopeEntry`
-(`id`, `surface`, `finding`, `seeds`) shipped in #53 task t1 — but the
-deterministic `devague scope` move that writes it (`devague scope "<surface>"
---finding "<text>" [--seeds <claim-id> ...]`, plus `scope --list [--json]`) is
-planned in the #53 build plan (task t3); this skill's `devague learn skills`
-authoring recipe lands with that move (tasks t10/t11).
+The skill ships no entry-point script of its own, but the CLI surface it
+records into is live: `Frame.scope_entries` / `ScopeEntry` (`id`, `surface`,
+`finding`, `seeds`) shipped in #53 task t1, and the deterministic
+`devague scope` move that writes it (`devague scope "<surface>"
+--finding "<text>" [--seeds <claim-id> ...]`, plus `scope --list [--json]`)
+shipped in #53 task t3; this skill's `devague learn skills` authoring recipe
+lands with tasks t10/t11.
 
 - Source:
   [`.claude/skills/scope/`](https://github.com/agentculture/devague/blob/main/.claude/skills/scope/SKILL.md)
@@ -182,9 +182,10 @@ Seed a plan from a **converged** frame (`devague plan new --frame <slug>`), add
 tasks that cover every coverage target with acceptance criteria and an acyclic
 dependency order, park unknowns as first-class risks, and `export` only once the
 plan converges. Coaches small, file-disjoint, TDD-accepted tasks so the
-downstream fan-out can run wide waves. Until the planned per-task `instruction`
-field lands (#53 t5), it coaches acceptance criteria as the de facto
-instruction contract.
+downstream fan-out can run wide waves. The per-task `instruction` field and the
+`plan task --instruction` / `plan instruct <tN>` moves shipped in #53 t2/t5;
+acceptance criteria remain the testable contract, instructions the working
+guidance carried verbatim to the workforce.
 
 - Source:
   [`.claude/skills/spec-to-plan/`](https://github.com/agentculture/devague/blob/main/.claude/skills/spec-to-plan/SKILL.md)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -125,6 +125,15 @@ A skill drives the deterministic CLI and adds no business logic of its own:
   `devague plan waves` (#20). The fan-out, worktree management, and TDD-gated
   merges live in the `assign-to-workforce` skill and the operating agent, not in
   the CLI and not in a CI runner.
+- **Instructions flow verbatim, never invented.** Claims, honesty conditions,
+  and plan tasks may carry an optional `instruction` field — how to verify or
+  implement that item (frame side: `capture --instruction` / `interrogate
+  --instruction`, #53 t4; plan side: `plan task --instruction` / `plan instruct
+  <tN>`, #53 t5). Setting or changing an instruction on an already-confirmed
+  item flips it back to `proposed` — the user re-confirms, same as any other
+  proposed content. `assign-to-workforce` is meant to quote a task's
+  instruction and acceptance criteria verbatim into the per-subagent brief
+  (#53 t9/t13) — no operator paraphrasing.
 
 ## The operator skills
 
@@ -145,9 +154,12 @@ ideas skip straight to `/think` (no wizard). From the sharper end-to-end method
 spec ([devague#53](https://github.com/agentculture/devague/pull/53)).
 
 Method-only today: it ships no entry-point script and drives no CLI verb of its
-own. The deterministic `devague scope` move (findings as first-class frame state
-with provenance) is planned in the #53 build plan (task t3); this skill's
-`devague learn skills` authoring recipe lands with that move (tasks t10/t11).
+own. The backing state already exists — `Frame.scope_entries` / `ScopeEntry`
+(`id`, `surface`, `finding`, `seeds`) shipped in #53 task t1 — but the
+deterministic `devague scope` move that writes it (`devague scope "<surface>"
+--finding "<text>" [--seeds <claim-id> ...]`, plus `scope --list [--json]`) is
+planned in the #53 build plan (task t3); this skill's `devague learn skills`
+authoring recipe lands with that move (tasks t10/t11).
 
 - Source:
   [`.claude/skills/scope/`](https://github.com/agentculture/devague/blob/main/.claude/skills/scope/SKILL.md)
@@ -170,7 +182,9 @@ Seed a plan from a **converged** frame (`devague plan new --frame <slug>`), add
 tasks that cover every coverage target with acceptance criteria and an acyclic
 dependency order, park unknowns as first-class risks, and `export` only once the
 plan converges. Coaches small, file-disjoint, TDD-accepted tasks so the
-downstream fan-out can run wide waves.
+downstream fan-out can run wide waves. Until the planned per-task `instruction`
+field lands (#53 t5), it coaches acceptance criteria as the de facto
+instruction contract.
 
 - Source:
   [`.claude/skills/spec-to-plan/`](https://github.com/agentculture/devague/blob/main/.claude/skills/spec-to-plan/SKILL.md)
@@ -182,7 +196,9 @@ Reads `devague plan waves` (deterministic, read-only scheduling metadata) and
 fans out independent tasks to **one agent per task per wave in isolated git
 worktrees**, with **main-agent TDD-gated merges** (the task's tests pass before
 *and* after the merge). Exactly three human gates; the final PR uses the `cicd`
-skill (`agex pr open`).
+skill (`agex pr open`). Each subagent's brief quotes its task's fields verbatim
+from `plan show --json` / the exported plan-md — including the per-task
+`instruction` once #53 t5/t9 land — never an operator paraphrase.
 
 - Source:
   [`.claude/skills/assign-to-workforce/`](https://github.com/agentculture/devague/blob/main/.claude/skills/assign-to-workforce/SKILL.md)

--- a/docs/spec-contract.md
+++ b/docs/spec-contract.md
@@ -107,10 +107,10 @@ pre-frame leg (the `/scope` skill, #53). Lives on the frame as
   id is refused at construction, the same fail-closed rule as everywhere else.
 
 The domain model (`Frame.add_scope_entry`) and its round-trip through
-`schema_version` 2 already ship. The CLI move that records one —
+`schema_version` 2 ship in #53 task t1, and the CLI move that records one —
 `devague scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]`, plus
-`scope --list [--json]` to read them back — is planned in the #53 build plan
-(task t3); it is not yet part of the Moves table below.
+`scope --list [--json]` to read them back — ships in #53 task t3. An unknown
+seed claim id is refused with a hint and nothing is persisted.
 
 ## Vocabulary
 
@@ -167,19 +167,17 @@ like any other proposed content — this is deliberate, not a bug, and keeps the
 anti-fabrication guarantee intact even for a field that arrives after the
 initial confirm.
 
-The CLI surface that sets instructions is planned, not yet shipped in this
-increment:
+The CLI surface that sets instructions ships in this increment:
 
 - frame side: `capture --instruction "<text>"` (at creation) and
   `interrogate <c*|h*> --instruction "<text>"` (on an existing claim or honesty
   condition) — #53 task t4;
-- plan side: `plan task --instruction "<text>"` (at creation) and a new
-  `plan instruct <tN> --instruction "<text>"` move (on an existing task) — #53
-  task t5.
+- plan side: `plan task --instruction "<text>"` (at creation) and the
+  `plan instruct <tN> "<text>"` move (on an existing task) — #53 task t5.
 
-`devague review` is meant to list each item's instruction alongside it once t4
-lands, so the human review loop sees instructions the same way it sees
-proposed claims and honesty conditions today.
+`devague review` lists each item's instruction alongside it (t4), so the human
+review loop sees instructions the same way it sees proposed claims and honesty
+conditions.
 
 ## Convergence result
 
@@ -201,13 +199,15 @@ on `ready_for_spec`.
 ### Structural sharpness warnings (soft rollout)
 
 Two more deterministic warnings tighten the frame gate without changing what
-blocks convergence — planned for `convergence.py` in #53 task t7:
+blocks convergence — shipped in `convergence.py` by #53 task t7, each rule's
+exact predicate and false-positive story documented in that module's docstring:
 
 - a confirmed spec-affecting claim carries no `instruction`;
-- the frame has no measurable `success_signal` (a deterministic structural
-  heuristic — never LLM judgment on the claim text).
+- the confirmed `success_signal` claims contain no measurability token
+  (a numeral, `%`, or a comparator — a deterministic structural heuristic,
+  never LLM judgment on the claim text).
 
-The plan gate gains the symmetric warning in `plan_convergence.py` (#53 task
+The plan gate carries the symmetric warning in `plan_convergence.py` (#53 task
 t8): a confirmed task carries no `instruction`.
 
 All three land as **warnings only** in this increment: they surface in

--- a/docs/spec-contract.md
+++ b/docs/spec-contract.md
@@ -17,12 +17,18 @@ see [`llm-guidance.md`](llm-guidance.md) (also surfaced in `devague learn`).
 
 ## Versioning
 
-Every frame carries an integer `schema_version` (currently `1`). It is written
+Every frame carries an integer `schema_version` (currently `2`). It is written
 on save and checked on load: a frame whose `schema_version` is newer than this
 devague supports is rejected, fail-closed, with an actionable error. A 0.4.0
 frame predates the field and loads as the current schema, so existing frames
 keep working.
 
+> **v2 (#53 t1).** Bumped to add `Frame.scope_entries` and an `instruction`
+> field on `Claim` and `HonestyCondition` — see *ScopeEntry* under Entities and
+> the *Instructions* section below. A v1 frame predates both: it loads with no
+> scope entries and every `instruction` defaulted to `""` (empty means "no
+> instruction," never fabricated to fill the gap).
+>
 > **Migration note.** Before this contract, devague (0.4.0) shipped no committed
 > contract document and `converge --json` emitted `{passed, missing}`. This
 > contract supersedes that with the structured convergence result below; the old
@@ -41,6 +47,7 @@ A feature-framing workspace.
 - `created`, `updated` — ISO-8601 UTC timestamps, stamped on save.
 - `claims` — list of Claim.
 - `open_vagueness` — list of Vagueness.
+- `scope_entries` — list of ScopeEntry (v2, #53 t1; see below).
 
 ### Claim
 
@@ -54,6 +61,8 @@ A discrete statement that may become part of the spec.
 - `honesty_conditions` — list of HonestyCondition.
 - `hard_questions` — list of HardQuestion.
 - `links` — related claim ids.
+- `instruction` — optional verbatim text: how to verify or implement this
+  claim; `""` means none (v2, #53 t1). See *Instructions* below.
 
 ### HonestyCondition
 
@@ -62,6 +71,8 @@ What must be true for a claim to be honest.
 - `id` — `h1`, `h2`, …
 - `text` — the condition.
 - `status` — `proposed` | `confirmed` | `rejected`.
+- `instruction` — optional verbatim text: how to verify this condition holds;
+  `""` means none (v2, #53 t1). See *Instructions* below.
 
 ### HardQuestion
 
@@ -80,6 +91,26 @@ First-class open vagueness — parked uncertainty, not a markdown afterthought.
 - `text` — the unknown.
 - `kind` — see Vagueness kinds.
 - `claim_id` — optional owning claim.
+
+### ScopeEntry
+
+A recorded scope-exploration finding — the durable record of the optional
+pre-frame leg (the `/scope` skill, #53). Lives on the frame as
+`Frame.scope_entries` (v2, #53 t1).
+
+- `id` — `s1`, `s2`, …
+- `surface` — what was explored (a file, a subsystem, a doc — the operating
+  agent's read-only survey, never devague's own code).
+- `finding` — what was learned about that surface.
+- `seeds` — claim ids this finding seeded (typically `boundary` / `non_goal` /
+  `assumption` claims that cite what was actually explored); an unknown claim
+  id is refused at construction, the same fail-closed rule as everywhere else.
+
+The domain model (`Frame.add_scope_entry`) and its round-trip through
+`schema_version` 2 already ship. The CLI move that records one —
+`devague scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]`, plus
+`scope --list [--json]` to read them back — is planned in the #53 build plan
+(task t3); it is not yet part of the Moves table below.
 
 ## Vocabulary
 
@@ -119,6 +150,37 @@ information is lost and no rename is needed:
 issue's `unknown_non_blocking` is `unknown_nonblocking`; `intentionally_out_of_scope`
 is `out_of_scope`. Only `unknown_blocking` holds back convergence.
 
+## Instructions
+
+`Claim`, `HonestyCondition`, and (on the plan side) `Task` each carry an
+optional `instruction` field: verbatim operator/user-authored text on how to
+verify or implement that item. The default is `""` — empty means "no
+instruction," never fabricated or defaulted to prose. Instructions are meant to
+flow end to end: captured on a claim or honesty condition, carried onto the
+plan tasks that cover it, rendered verbatim in exports, and quoted verbatim
+into a workforce subagent's brief — no operator paraphrasing at any hop (#53).
+
+Setting or changing an instruction is content, not metadata: **adding or
+changing the instruction on an already-`confirmed` claim, honesty condition, or
+task flips its status back to `proposed`.** The user re-confirms it, exactly
+like any other proposed content — this is deliberate, not a bug, and keeps the
+anti-fabrication guarantee intact even for a field that arrives after the
+initial confirm.
+
+The CLI surface that sets instructions is planned, not yet shipped in this
+increment:
+
+- frame side: `capture --instruction "<text>"` (at creation) and
+  `interrogate <c*|h*> --instruction "<text>"` (on an existing claim or honesty
+  condition) — #53 task t4;
+- plan side: `plan task --instruction "<text>"` (at creation) and a new
+  `plan instruct <tN> --instruction "<text>"` move (on an existing task) — #53
+  task t5.
+
+`devague review` is meant to list each item's instruction alongside it once t4
+lands, so the human review loop sees instructions the same way it sees
+proposed claims and honesty conditions today.
+
 ## Convergence result
 
 `converge` returns a structured verdict (not prose-only advice). The frame CLI
@@ -135,6 +197,24 @@ A frame converges when there are confirmed `announcement` / `audience` /
 `success_signal`, a confirmed honesty condition on every spec-affecting claim,
 and no unresolved blocking vagueness or blocking hard question. `export` is gated
 on `ready_for_spec`.
+
+### Structural sharpness warnings (soft rollout)
+
+Two more deterministic warnings tighten the frame gate without changing what
+blocks convergence — planned for `convergence.py` in #53 task t7:
+
+- a confirmed spec-affecting claim carries no `instruction`;
+- the frame has no measurable `success_signal` (a deterministic structural
+  heuristic — never LLM judgment on the claim text).
+
+The plan gate gains the symmetric warning in `plan_convergence.py` (#53 task
+t8): a confirmed task carries no `instruction`.
+
+All three land as **warnings only** in this increment: they surface in
+`warnings[]` alongside the existing unconfirmed-`assumption` warning, but never
+add a blocker, so frames and plans that already converge keep converging
+unchanged. A later increment may decide whether any of them graduates to a
+blocker.
 
 ## Moves
 
@@ -168,6 +248,11 @@ explicit user `confirm` before they affect convergence. Nothing auto-confirms,
 `converge` never mutates a claim's status, and no fixed prompt sequence is
 imposed — the CLI stays a move-driven state tracker.
 
+The same guarantee extends to instructions once t4/t5 land: setting or
+changing one on an already-confirmed item demotes it back to `proposed` (see
+*Instructions* above) — content changes route through the user exactly like
+new proposals.
+
 ## Worked example
 
 `docs/examples/contract-example.json` is a real, converged frame exercising the
@@ -180,8 +265,10 @@ it round-trips losslessly and converges, so this document's model stays honest.
 
 The plan engine (`devague plan …`) is the structural peer: a Plan holds coverage
 targets derived from a converged frame, Tasks (`origin`/`status` like claims,
-plus `deps`, `covers`, `acceptance_criteria`), and PlanRisks. It reuses the same
-structured convergence result, serialized under `ready_for_plan`. See
+plus `deps`, `covers`, `acceptance_criteria`, and an optional `instruction` —
+verbatim text on how to implement/verify the task, `""` means none, v2, #53 t2;
+see *Instructions* above), and PlanRisks. It reuses the same structured
+convergence result, serialized under `ready_for_plan`. See
 `docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md`.
 
 `plan waves` emits the plan's dependency graph as deterministic, machine-readable
@@ -196,7 +283,7 @@ codexd, …) decides how — or whether — to execute it. Devague does not spaw
 subagents, manage worktrees, mark tasks done, or choose a backend.
 
 Plans carry the same persistence contract as frames. Every plan has an integer
-`schema_version` (currently `1`, `PLAN_SCHEMA_VERSION`), written on save and
+`schema_version` (currently `2`, `PLAN_SCHEMA_VERSION`), written on save and
 checked on load: `plan_store.load` **fails closed** with a clean `DevagueError`
 (exit code 1, upgrade hint) when a plan declares a `schema_version` newer than
 this devague supports. A pre-0.7.0 plan with no `schema_version` key loads
@@ -211,3 +298,6 @@ slug (so a tampered file can't silently redirect a later `save`), and parse
 `schema_version` strictly via the shared `frame.parse_schema_version` — a
 non-integer value is rejected rather than coerced. These guards are symmetric
 across the frame and plan persistence twins.
+
+> **v2 (#53 t2).** `PLAN_SCHEMA_VERSION` bumped to add `Task.instruction`. A v1
+> plan predates it and loads with every task's `instruction` defaulted to `""`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.15.0"
+version = "0.16.0"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/goldens/sharper_frame.md
+++ b/tests/goldens/sharper_frame.md
@@ -1,0 +1,43 @@
+# Announcement Frame — Sharper Golden
+
+slug: `sharper` · status: `drafting`
+
+## Announcement
+
+- we shipped the sharper method
+  - instruction: run the dogfood script end to end
+  - honesty: must be observed end to end
+
+## Audience
+
+- operators driving /think
+  - instruction: confirm by grepping skill frontmatter for the audience note
+
+## Requirements
+
+- exports render instruction blocks verbatim
+  - instruction: run `uv run devague export` and diff against the golden fixture
+  - honesty: an absent instruction renders nothing
+    - instruction: capture a claim with no instruction and assert no new bullet appears
+
+## Assumptions
+
+- the operating agent performs the exploration
+
+## Boundaries
+
+- renderer changes stay inside render slash star dot py
+
+## Non-goals
+
+- not a wizard
+
+## Decisions
+
+- sharper means instruction blocks and scope provenance
+
+## Scope exploration
+
+- `s1` — `devague render spec_md dot py`: no instruction or scope rendering existed before t6
+  - seeds: `c3`
+- `s2` — `devague render frame_md dot py`: same renderer gap as spec_md.py

--- a/tests/goldens/sharper_plan.md
+++ b/tests/goldens/sharper_plan.md
@@ -1,0 +1,19 @@
+# Build Plan — Sharper Plan Golden
+
+slug: `sharper-plan` · status: `drafting` · from frame: `sharper-plan`
+
+> we shipped the sharper plan renderer
+
+## Tasks
+
+### t1 — lay the foundation
+
+- instruction: run `uv run pytest tests/test_plan.py -v` and confirm it is green
+- covers: c1
+- acceptance:
+  - foundation lands
+
+### t2 — build on top
+
+- depends on: t1
+- covers: h1

--- a/tests/goldens/sharper_spec.md
+++ b/tests/goldens/sharper_spec.md
@@ -1,0 +1,42 @@
+# Sharper Golden
+
+> we shipped the sharper method
+> instruction: run the dogfood script end to end
+
+## Audience
+
+- operators driving /think
+  - instruction: confirm by grepping skill frontmatter for the audience note
+
+## Requirements
+
+- exports render instruction blocks verbatim
+  - instruction: run `uv run devague export` and diff against the golden fixture
+  - honesty: an absent instruction renders nothing
+    - instruction: capture a claim with no instruction and assert no new bullet appears
+
+## Honesty conditions
+
+- must be observed end to end
+
+## Scope / boundaries
+
+- renderer changes stay inside render slash star dot py
+
+## Non-goals
+
+- not a wizard
+
+## Assumptions
+
+- the operating agent performs the exploration
+
+## Scope exploration
+
+- `s1` — `devague render spec_md dot py`: no instruction or scope rendering existed before t6
+  - seeds: `c3`
+- `s2` — `devague render frame_md dot py`: same renderer gap as spec_md.py
+
+## Decisions
+
+- sharper means instruction blocks and scope provenance

--- a/tests/test_boundary_audit.py
+++ b/tests/test_boundary_audit.py
@@ -1,0 +1,47 @@
+"""t14 boundary audit: no LLM calls, no subagent spawning, no worktree management.
+
+The devague package is deterministic (#20): the CLI records and evaluates state,
+never orchestrates. This audit is the grep evidence, committed as a test so a
+future import can't drift past it. Network imports are separately guarded by
+test_offline.py; bandit runs in CI (security-checks workflow).
+
+Teaching *text* may mention worktrees or fan-out — the audit guards behavior
+(imports and process-spawning calls), not vocabulary.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# LLM/SDK clients and process-spawning machinery have no business in devague/.
+_FORBIDDEN_IMPORT = re.compile(
+    r"^\s*(?:import|from)\s+(subprocess|pty|multiprocessing|anthropic|openai)\b",
+    re.MULTILINE,
+)
+# os-level process spawning (os.system, os.popen, os.exec*, os.spawn*, os.fork).
+_FORBIDDEN_OS_CALL = re.compile(r"\bos\.(system|popen|exec\w*|spawn\w*|fork)\s*\(")
+
+
+def _package_sources() -> list[Path]:
+    files = sorted(Path("devague").rglob("*.py"))
+    assert files, "audit must run from the repo root"
+    return files
+
+
+def test_no_llm_or_process_spawning_imports() -> None:
+    offenders = [
+        f"{py}: {m.group(0).strip()}"
+        for py in _package_sources()
+        if (m := _FORBIDDEN_IMPORT.search(py.read_text(encoding="utf-8")))
+    ]
+    assert offenders == [], f"forbidden import in devague/: {offenders}"
+
+
+def test_no_os_level_process_spawning() -> None:
+    offenders = [
+        f"{py}: {m.group(0)}"
+        for py in _package_sources()
+        if (m := _FORBIDDEN_OS_CALL.search(py.read_text(encoding="utf-8")))
+    ]
+    assert offenders == [], f"process-spawning call in devague/: {offenders}"

--- a/tests/test_cli_instructions.py
+++ b/tests/test_cli_instructions.py
@@ -1,0 +1,292 @@
+"""``--instruction`` on ``capture``/``interrogate``, and ``review`` listing it.
+
+Task t4 (#53): capture/interrogate store a verbatim, optional per-item
+instruction; changing the instruction on a CONFIRMED claim or honesty
+condition flips it back to `proposed` for re-confirmation (never silently
+kept confirmed); `devague review` lists each proposed item's instruction
+alongside it.
+"""
+
+from __future__ import annotations
+
+import json
+
+from devague import store
+from devague.cli import main
+
+
+def _seed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship sharper method"])  # c1 announcement, origin=user -> confirmed
+
+
+# ---------------------------------------------------------------------------
+# capture --instruction
+# ---------------------------------------------------------------------------
+
+
+def test_capture_instruction_stored_verbatim(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(
+        [
+            "capture",
+            "--kind",
+            "requirement",
+            "must support `<id>` lookups",
+            "--instruction",
+            "verify via `devague show --json`",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["instruction"] == "verify via `devague show --json`"
+    f = store.load(store.current_slug())
+    claim = f.find_claim(payload["id"])
+    assert claim.instruction == "verify via `devague show --json`"
+
+
+def test_capture_without_instruction_defaults_empty(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["capture", "--kind", "audience", "devs", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["instruction"] == ""
+    f = store.load(store.current_slug())
+    assert f.find_claim(payload["id"]).instruction == ""
+
+
+# ---------------------------------------------------------------------------
+# interrogate --instruction — standalone, on a claim
+# ---------------------------------------------------------------------------
+
+
+def test_interrogate_instruction_standalone_on_claim(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    # c1 was auto-confirmed (origin=user) by `new` — changing its instruction
+    # must flip it back to proposed (re-confirm rule).
+    rc = main(["interrogate", "c1", "--instruction", "verify against the exported spec"])
+    assert rc == 0
+    f = store.load(store.current_slug())
+    claim = f.find_claim("c1")
+    assert claim.instruction == "verify against the exported spec"
+    assert claim.status == "proposed"
+
+
+def test_interrogate_instruction_alone_does_not_error_as_nothing_to_interrogate(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["interrogate", "c1", "--instruction", "x"])
+    assert rc == 0
+    assert "nothing to interrogate" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# interrogate --instruction — on an honesty condition id (h*)
+# ---------------------------------------------------------------------------
+
+
+def test_interrogate_instruction_on_honesty_condition_id(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    main(
+        ["interrogate", "c1", "--honesty", "must be measurable", "--origin", "user"]
+    )  # h1 confirmed
+    capsys.readouterr()
+    rc = main(["interrogate", "h1", "--instruction", "check the release notes"])
+    assert rc == 0
+    f = store.load(store.current_slug())
+    h = f.find_honesty("h1")
+    assert h.instruction == "check the release notes"
+    assert h.status == "proposed"  # was confirmed (origin=user) -> flips back
+    # The claim itself is untouched.
+    assert f.find_claim("c1").instruction == ""
+
+
+def test_interrogate_instruction_combined_with_honesty_sets_claim_not_new_honesty(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(
+        [
+            "interrogate",
+            "c1",
+            "--honesty",
+            "must be true",
+            "--instruction",
+            "verify via test",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    kinds = {a["kind"]: a for a in payload["added"]}
+    assert "honesty" in kinds and "instruction" in kinds
+    f = store.load(store.current_slug())
+    claim = f.find_claim("c1")
+    new_honesty = f.find_honesty(kinds["honesty"]["id"])
+    assert claim.instruction == "verify via test"  # set on the claim
+    assert new_honesty.instruction == ""  # NOT on the freshly-added honesty condition
+
+
+# ---------------------------------------------------------------------------
+# Re-confirm rule: confirmed -> proposed on instruction change; proposed stays
+# ---------------------------------------------------------------------------
+
+
+def test_interrogate_instruction_flip_emits_stderr_note(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["interrogate", "c1", "--instruction", "verify manually"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "c1" in err
+    assert "confirmed" in err.lower()
+    assert "proposed" in err.lower()
+
+
+def test_interrogate_instruction_on_proposed_claim_leaves_status_as_is(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2 proposed
+    capsys.readouterr()
+    rc = main(["interrogate", "c2", "--instruction", "verify with a survey"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "confirmed" not in err.lower()  # no flip note — it was already proposed
+    f = store.load(store.current_slug())
+    claim = f.find_claim("c2")
+    assert claim.status == "proposed"
+    assert claim.instruction == "verify with a survey"
+
+
+def test_interrogate_instruction_changing_twice_keeps_flipping_rule_honest(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    main(["interrogate", "c1", "--instruction", "first draft"])  # confirmed -> proposed
+    main(["confirm", "c1"])  # user re-confirms
+    capsys.readouterr()
+    rc = main(["interrogate", "c1", "--instruction", "revised draft"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "proposed" in err.lower()  # flips again
+    f = store.load(store.current_slug())
+    claim = f.find_claim("c1")
+    assert claim.instruction == "revised draft"
+    assert claim.status == "proposed"
+
+
+# ---------------------------------------------------------------------------
+# Validation: --honesty/--hard-question/--risk/--contradicts require a claim id
+# ---------------------------------------------------------------------------
+
+
+def test_interrogate_claim_only_flags_reject_honesty_id(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["interrogate", "c1", "--honesty", "must be measurable"])  # h1 proposed
+    capsys.readouterr()
+    rc = main(["interrogate", "h1", "--hard-question", "what if it's false?"])
+    assert rc == 1
+    err = capsys.readouterr().err.lower()
+    assert "honesty condition" in err
+
+
+def test_interrogate_unknown_id_with_instruction_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["interrogate", "zzz", "--instruction", "x"])
+    assert rc == 1
+    assert "no such" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# devague review lists instructions alongside their items
+# ---------------------------------------------------------------------------
+
+
+def test_review_lists_claim_instruction(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(
+        [
+            "capture",
+            "--kind",
+            "audience",
+            "devs",
+            "--origin",
+            "llm",
+            "--instruction",
+            "confirm with the PM",
+        ]
+    )  # c2 proposed, with instruction
+    capsys.readouterr()
+    assert main(["review"]) == 0
+    out = capsys.readouterr().out
+    assert "c2" in out
+    assert "confirm with the PM" in out
+
+
+def test_review_lists_honesty_instruction(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2 proposed
+    main(["interrogate", "c2", "--honesty", "must be true"])  # h1 proposed
+    main(["interrogate", "h1", "--instruction", "check with support logs"])
+    capsys.readouterr()
+    assert main(["review"]) == 0
+    out = capsys.readouterr().out
+    assert "h1" in out
+    assert "check with support logs" in out
+
+
+def test_review_item_without_instruction_renders_nothing_extra(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2, no instruction
+    capsys.readouterr()
+    assert main(["review"]) == 0
+    out = capsys.readouterr().out
+    assert "instruction" not in out.lower()
+
+
+def test_review_json_includes_instruction_fields(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(
+        [
+            "capture",
+            "--kind",
+            "audience",
+            "devs",
+            "--origin",
+            "llm",
+            "--instruction",
+            "confirm with the PM",
+        ]
+    )  # c2
+    main(["interrogate", "c2", "--honesty", "must be true"])  # h1
+    main(["interrogate", "h1", "--instruction", "check with support logs"])
+    capsys.readouterr()
+    assert main(["review", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    claim_entry = next(c for c in payload["proposed_claims"] if c["id"] == "c2")
+    assert claim_entry["instruction"] == "confirm with the PM"
+    honesty_entry = next(h for h in payload["proposed_honesty"] if h["id"] == "h1")
+    assert honesty_entry["instruction"] == "check with support logs"
+
+
+def test_review_json_instruction_empty_when_absent(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["capture", "--kind", "audience", "devs", "--origin", "llm"])  # c2, no instruction
+    capsys.readouterr()
+    assert main(["review", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    claim_entry = next(c for c in payload["proposed_claims"] if c["id"] == "c2")
+    assert claim_entry["instruction"] == ""

--- a/tests/test_cli_moves.py
+++ b/tests/test_cli_moves.py
@@ -62,9 +62,9 @@ def test_load_newer_schema_errors_cleanly(tmp_path, monkeypatch, capsys) -> None
     main(["new", "Shipped instant specs"])
     capsys.readouterr()
     p = store.path_for("shipped-instant-specs")
-    p.write_text(
-        p.read_text().replace('"schema_version": 1', '"schema_version": 99'), encoding="utf-8"
-    )
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["schema_version"] = 99  # newer than any real SCHEMA_VERSION
+    p.write_text(json.dumps(raw), encoding="utf-8")
     rc = main(["show"])
     assert rc == 1
     err = capsys.readouterr().err.lower()

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -1,0 +1,154 @@
+"""Tests for ``devague scope`` — records explored surfaces + findings (#53 t3)."""
+
+from __future__ import annotations
+
+import json
+
+from devague import store
+from devague.cli import main
+
+
+def _seed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship sharper method", "--title", "sharper-method"])
+
+
+def test_scope_records_entry_round_trip(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    rc = main(["scope", "devague/frame.py", "--finding", "claim model lives here"])
+    assert rc == 0
+    frame = store.load(slug)
+    assert len(frame.scope_entries) == 1
+    entry = frame.scope_entries[0]
+    assert entry.id == "s1"
+    assert entry.surface == "devague/frame.py"
+    assert entry.finding == "claim model lives here"
+    assert entry.seeds == []
+
+
+def test_scope_records_entry_with_seeds(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    main(["capture", "--kind", "requirement", "add a scope move"])
+    rc = main(
+        [
+            "scope",
+            "devague/cli/_commands/park.py",
+            "--finding",
+            "closest peer in shape",
+            "--seeds",
+            "c1",
+        ]
+    )
+    assert rc == 0
+    frame = store.load(slug)
+    assert frame.scope_entries[0].seeds == ["c1"]
+
+
+def test_scope_json_shape_on_record(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["scope", "docs/spec-contract.md", "--finding", "schema contract", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "id": "s1",
+        "surface": "docs/spec-contract.md",
+        "finding": "schema contract",
+        "seeds": [],
+    }
+
+
+def test_scope_list_json_shape(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["scope", "a.py", "--finding", "first"])
+    main(["scope", "b.py", "--finding", "second"])
+    capsys.readouterr()
+    rc = main(["scope", "--list", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scope_entries"][0]["id"] == "s1"
+    assert payload["scope_entries"][1]["id"] == "s2"
+    assert [e["surface"] for e in payload["scope_entries"]] == ["a.py", "b.py"]
+
+
+def test_scope_bare_invocation_lists(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["scope", "a.py", "--finding", "first"])
+    capsys.readouterr()
+    rc = main(["scope"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "s1" in out and "a.py" in out and "first" in out
+
+
+def test_scope_bare_invocation_no_entries(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["scope"])
+    assert rc == 0
+    assert "no scope entries yet" in capsys.readouterr().out
+
+
+def test_scope_unknown_seed_id_refused_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    rc = main(["scope", "devague/frame.py", "--finding", "bogus link", "--seeds", "c99"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unknown seed claim id" in err
+    assert "hint:" in err
+    # Transactional: nothing was recorded.
+    frame = store.load(store.current_slug())
+    assert frame.scope_entries == []
+
+
+def test_scope_missing_finding_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    rc = main(["scope", "devague/frame.py"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--finding" in err
+    frame = store.load(store.current_slug())
+    assert frame.scope_entries == []
+
+
+def test_scope_provenance_text_stored_verbatim(tmp_path, monkeypatch) -> None:
+    _seed(monkeypatch, tmp_path)
+    slug = store.current_slug()
+    surface = "devague/cli/_commands/park.py + question.py"
+    finding = "closest peers in shape — cite the file, not a generic disclaimer"
+    main(["scope", surface, "--finding", finding])
+    frame = store.load(slug)
+    assert frame.scope_entries[0].surface == surface
+    assert frame.scope_entries[0].finding == finding
+
+
+def test_scope_frame_flag_targets_named_frame(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "First idea", "--title", "first-idea"])
+    capsys.readouterr()
+    main(["new", "Second idea", "--title", "second-idea"])
+    capsys.readouterr()
+    rc = main(["scope", "docs/", "--finding", "docs surface", "--frame", "first-idea"])
+    assert rc == 0
+    assert store.load("first-idea").scope_entries[0].surface == "docs/"
+    assert store.load("second-idea").scope_entries == []
+
+
+def test_scope_deterministic_no_subprocess_or_llm(tmp_path, monkeypatch) -> None:
+    # Guard against accidental scope creep: recording must never shell out or
+    # touch the filesystem beyond the frame store itself.
+    import subprocess
+
+    _seed(monkeypatch, tmp_path)
+    called = {"n": 0}
+    real_run = subprocess.run
+
+    def _guard(*args, **kwargs):
+        called["n"] += 1
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _guard)
+    main(["scope", "devague/frame.py", "--finding", "no subprocess used"])
+    assert called["n"] == 0

--- a/tests/test_convergence_sharper.py
+++ b/tests/test_convergence_sharper.py
@@ -1,0 +1,225 @@
+"""Deterministic structural-sharpness warnings on the frame gate (#53 t7).
+
+These pin the two documented rules added in t7 — both **warning-only** (soft
+rollout per the resolved parked-v2 decision: structural checks land as warnings
+first, never as blockers). Nothing here may flip ``ready_for_spec``.
+
+- S1 (instruction present): a *confirmed spec-affecting* claim whose
+  ``instruction`` is empty draws a per-claim warning naming its id.
+- S2 (measurable success signal): if a frame has at least one confirmed
+  ``success_signal`` claim but none of them contains a measurable token
+  (a numeral, ``%``, or a comparator ``<`` / ``>`` / ``≤`` / ``≥``), a single
+  warning is drawn.
+
+The rules are pure predicates over frame state — never LLM judgment (h6). The
+false-positive edges each rule is known to over-fire on are pinned below so the
+soft-rollout story stays honest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from devague.convergence import evaluate
+from devague.frame import SPEC_AFFECTING_KINDS, Frame
+
+# The six kinds a bare `_full_frame` needs to clear every *blocker* (so any
+# remaining signal in `.warnings` is a sharpness warning, not a gate gap).
+_REQUIRED_KINDS = (
+    "announcement",
+    "audience",
+    "after_state",
+    "before_state",
+    "boundary",
+    "success_signal",
+)
+
+
+def _full_frame(
+    *, success_text: str = "success_signal text", with_instructions: bool = False
+) -> Frame:
+    """A frame that clears every convergence blocker (mirrors test_convergence).
+
+    ``success_text`` overrides the success_signal claim's text so S2's
+    measurability predicate can be exercised. ``with_instructions`` attaches a
+    verbatim instruction to every spec-affecting claim so S1 stays silent.
+    """
+    f = Frame(slug="s", title="t")
+    for kind in _REQUIRED_KINDS:
+        text = success_text if kind == "success_signal" else f"{kind} text"
+        c = f.add_claim(kind, text, origin="user")  # user -> confirmed
+        f.add_honesty(c, "must hold", origin="user")  # user -> confirmed
+        if with_instructions:
+            c.instruction = f"verify {kind}"
+    return f
+
+
+# --- baseline: warnings never move the gate ----------------------------------
+
+
+def test_pre_change_converging_frame_still_converges_with_warnings() -> None:
+    """A frame that converged before t7 still converges — the new signals are
+    warnings, so ``ready`` stays True and blockers/next-moves are untouched."""
+    res = evaluate(_full_frame())
+    assert res.ready is True
+    assert res.blockers == []
+    assert res.required_next_moves == []  # derived from blockers only
+    assert res.warnings  # but sharpness warnings are surfaced
+
+
+# --- S1: instruction present on confirmed spec-affecting claims ---------------
+
+
+def test_s1_confirmed_spec_affecting_claim_without_instruction_warns() -> None:
+    res = evaluate(_full_frame())
+    # Every required kind is spec-affecting and instruction-less → one warning each.
+    for kind in _REQUIRED_KINDS:
+        assert kind in SPEC_AFFECTING_KINDS
+    instruction_warnings = [w for w in res.warnings if "instruction" in w]
+    # One per spec-affecting confirmed claim (all six).
+    assert len(instruction_warnings) == len(_REQUIRED_KINDS)
+    # Each names its claim id and the fixing move.
+    assert all("--instruction" in w for w in instruction_warnings)
+
+
+def test_s1_names_the_claim_id() -> None:
+    f = _full_frame()
+    boundary = next(c for c in f.claims if c.kind == "boundary")
+    res = evaluate(f)
+    assert any(boundary.id in w and "instruction" in w for w in res.warnings)
+
+
+def test_s1_silent_when_instruction_present() -> None:
+    res = evaluate(_full_frame(with_instructions=True))
+    assert res.ready is True
+    assert not any("instruction" in w for w in res.warnings)
+
+
+def test_s1_ignores_whitespace_only_instruction() -> None:
+    """A whitespace-only instruction is 'no instruction' — the warning still fires."""
+    f = _full_frame(with_instructions=True)
+    boundary = next(c for c in f.claims if c.kind == "boundary")
+    boundary.instruction = "   \n  "
+    res = evaluate(f)
+    assert any(boundary.id in w and "instruction" in w for w in res.warnings)
+
+
+def test_s1_only_confirmed_claims_no_double_signal_on_proposed() -> None:
+    """A still-*proposed* spec-affecting claim is already a blocker; S1 must not
+    also warn on it (no double-signalling)."""
+    f = _full_frame()
+    proposed = f.add_claim("requirement", "must round-trip", origin="llm")  # proposed
+    res = evaluate(f)
+    # It IS a blocker...
+    assert any(proposed.id in b and "proposed" in b for b in res.blockers)
+    # ...but NOT an S1 instruction warning.
+    assert not any(proposed.id in w and "instruction" in w for w in res.warnings)
+
+
+def test_s1_ignores_descriptive_and_assumption_kinds() -> None:
+    """Descriptive/soft kinds are not spec-affecting → no instruction warning,
+    even when confirmed and instruction-less."""
+    f = _full_frame(with_instructions=True)
+    ng = f.add_claim("non_goal", "not a PRD generator", origin="user")
+    dec = f.add_claim("decision", "keep the vocabulary", origin="user")
+    asm = f.add_claim("assumption", "frames stay small", origin="user")
+    res = evaluate(f)
+    for c in (ng, dec, asm):
+        assert not any(c.id in w and "instruction" in w for w in res.warnings)
+
+
+# --- S2: measurable success signal -------------------------------------------
+
+
+def test_s2_warns_when_no_success_signal_is_measurable() -> None:
+    # Default success text "success_signal text" carries no measurable token.
+    res = evaluate(_full_frame(with_instructions=True))
+    assert res.ready is True
+    assert any("measurable" in w and "success_signal" in w for w in res.warnings)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "converge in under 3 seconds",  # numeral
+        "95% of runs converge",  # percent (and numeral)
+        "resolves in < 200 ms",  # comparator + numeral
+        "at least 2 reviewers approve",  # numeral
+        "latency ≤ 5s",  # unicode comparator
+    ],
+)
+def test_s2_silent_for_measurable_signal(text: str) -> None:
+    res = evaluate(_full_frame(success_text=text, with_instructions=True))
+    assert not any("measurable" in w for w in res.warnings)
+
+
+def test_s2_not_fired_when_no_success_signal_claim_exists() -> None:
+    """When there's no confirmed success_signal at all, that's the existing
+    *blocker*'s job — S2 must not pile on a measurability warning."""
+    f = Frame(slug="s", title="t")
+    for kind in ("announcement", "audience", "after_state", "before_state", "boundary"):
+        c = f.add_claim(kind, f"{kind} text", origin="user")
+        f.add_honesty(c, "must hold", origin="user")
+        c.instruction = "verify"
+    res = evaluate(f)
+    assert not res.ready  # missing success_signal is a blocker
+    assert any("success_signal" in b for b in res.blockers)
+    assert not any("measurable" in w for w in res.warnings)
+
+
+def test_s2_measurable_only_needs_one_of_several_success_signals() -> None:
+    """A frame with several success_signal claims stays silent if *any* is measurable."""
+    f = _full_frame(success_text="the spec reads clearly", with_instructions=True)
+    c = f.add_claim("success_signal", "95% of exports pass lint", origin="user")
+    f.add_honesty(c, "must hold", origin="user")
+    c.instruction = "verify"
+    res = evaluate(f)
+    assert not any("measurable" in w for w in res.warnings)
+
+
+# --- known false-positive edges (pinned to keep the soft-rollout honest) ------
+
+
+def test_s2_false_positive_binary_checkable_signal_still_warns() -> None:
+    """Documented S2 false positive: a perfectly checkable *binary* success
+    signal worded without a numeral (e.g. 'the exported spec shows scope
+    provenance') trips the warning. Warning-only, so harmless — pinned here so
+    the false-positive story is visible in the suite."""
+    res = evaluate(
+        _full_frame(
+            success_text="the exported spec shows scope provenance",
+            with_instructions=True,
+        )
+    )
+    assert any("measurable" in w for w in res.warnings)
+
+
+def test_s1_false_positive_self_contained_claim_still_nudged() -> None:
+    """Documented S1 false positive: a self-evident spec-affecting claim that
+    needs no separate verification instruction is still nudged for one."""
+    res = evaluate(_full_frame())  # no instructions anywhere
+    assert any("instruction" in w for w in res.warnings)
+
+
+# --- structural invariants ----------------------------------------------------
+
+
+def test_sharpness_warnings_never_touch_blockers_or_next_moves() -> None:
+    f = _full_frame()  # converges, but with both S1 and S2 warnings
+    res = evaluate(f)
+    assert res.warnings
+    assert res.blockers == []
+    assert res.required_next_moves == []
+    # warnings and blockers are distinct list objects (no aliasing).
+    assert res.warnings is not res.blockers
+
+
+def test_assumption_and_sharpness_warnings_coexist() -> None:
+    """The pre-existing unconfirmed-assumption warning still fires alongside the
+    new sharpness warnings."""
+    f = _full_frame()
+    f.add_claim("assumption", "frames stay small", origin="llm")  # proposed
+    res = evaluate(f)
+    assert any("assumption" in w for w in res.warnings)
+    assert any("instruction" in w for w in res.warnings)
+    assert any("measurable" in w for w in res.warnings)

--- a/tests/test_e2e_sharper_method.py
+++ b/tests/test_e2e_sharper_method.py
@@ -1,0 +1,209 @@
+"""t14: one real idea runs scope -> frame -> sharper spec -> plan -> fanout brief.
+
+The dogfooded end-to-end run of the sharper method (#53) on the shipped surface
+only. The idea is real: "devague ships an unpark move" (issue #57, found while
+dogfooding the multi-repo frame — a parked blocking vagueness cannot be
+resolved through moves today). Covers c1/h1 (the guided arc exists end to end),
+c2/h7 (driven through the public CLI surface), c3/h8 (the sharper artifacts
+render instructions + scope provenance).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from devague import store
+from devague.cli import main
+
+
+def _json_out(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_e2e_scope_frame_spec_plan_fanout(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    # --- scope -> frame -----------------------------------------------------
+    assert (
+        main(
+            [
+                "new",
+                "devague ships an unpark move: a parked blocking vagueness "
+                "can be resolved through a first-class move",
+                "--title",
+                "unpark move",
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "scope",
+                "devague/frame.py add_vagueness",
+                "--finding",
+                "park only appends; no move edits or removes a vagueness once parked",
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "scope",
+                "devague/convergence.py blocker hint",
+                "--finding",
+                "the resolve hint names moves that cannot clear a blocking park",
+                "--seeds",
+                "c1",
+            ]
+        )
+        == 0
+    )
+
+    # user-origin captures auto-confirm; two carry per-item instructions
+    assert main(["capture", "--kind", "audience", "operators driving frames through moves"]) == 0
+    assert (
+        main(
+            [
+                "capture",
+                "--kind",
+                "after_state",
+                "a blocking park can be resolved via a move; the frame "
+                "converges without hand-editing state",
+                "--instruction",
+                "park a blocking item, resolve it via the move, assert converge passes",
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "capture",
+                "--kind",
+                "why_it_matters",
+                "hand-editing .devague state is forbidden; a stale blocking "
+                "park otherwise blocks forever",
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "capture",
+                "--kind",
+                "boundary",
+                "no bulk edit of vagueness text; only kind and resolution transitions",
+                "--instruction",
+                "attempt a text edit through the move and assert it is refused",
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "capture",
+                "--kind",
+                "success_signal",
+                "1 previously-blocked frame converges after the unpark move",
+            ]
+        )
+        == 0
+    )
+
+    frame = store.load(store.current_slug())
+    claim_ids = [c.id for c in frame.claims]
+    for cid in claim_ids:
+        assert main(["interrogate", cid, "--honesty", f"holds and is testable for {cid}"]) == 0
+    frame = store.load(store.current_slug())
+    honesty_ids = [h.id for c in frame.claims for h in c.honesty_conditions]
+    assert main(["confirm", *honesty_ids]) == 0
+
+    # --- converge: gate passes; sharpness warnings (t7) fire, never block ---
+    capsys.readouterr()
+    assert main(["converge", "--json"]) == 0
+    verdict = _json_out(capsys)
+    assert verdict["ready_for_spec"] is True
+    assert any("instruction" in w for w in verdict["warnings"])  # S1 on instruction-less claims
+
+    # --- sharper spec export (t6): instruction blocks + scope provenance ----
+    assert main(["export"]) == 0
+    spec_files = list(Path("docs/specs").glob("*-unpark-move.md"))
+    assert len(spec_files) == 1
+    spec_md = spec_files[0].read_text(encoding="utf-8")
+    assert "instruction: park a blocking item" in spec_md  # verbatim, not paraphrased
+    assert "Scope exploration" in spec_md
+    assert "devague/frame.py add_vagueness" in spec_md  # provenance cites the surface
+
+    # --- plan: tasks with instructions cover every target -------------------
+    assert main(["plan", "new", "--frame", "unpark-move"]) == 0
+    capsys.readouterr()
+    assert main(["plan", "show", "--json"]) == 0
+    targets = [t["id"] for t in _json_out(capsys)["targets"]]
+    mid = len(targets) // 2
+    assert (
+        main(
+            [
+                "plan",
+                "task",
+                "add the unpark transition to the frame model",
+                "--accept",
+                "a blocking vagueness resolves and converge passes",
+                "--instruction",
+                "test-first against frame.py; keep the fail-closed schema",
+                *[a for t in targets[:mid] for a in ("--covers", t)],
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "plan",
+                "task",
+                "expose the unpark move on the CLI with teaching",
+                "--accept",
+                "unpark appears in learn and explain output",
+                "--dep",
+                "t1",
+                "--instruction",
+                "register like scope; update learn MOVES",
+                *[a for t in targets[mid:] for a in ("--covers", t)],
+            ]
+        )
+        == 0
+    )
+
+    # the instruct move flips a confirmed task back to proposed (t5), then re-confirm
+    assert main(["plan", "instruct", "t1", "sharper guidance, still verbatim"]) == 0
+    plan_state = json.loads(Path(".devague/plans/unpark-move.json").read_text(encoding="utf-8"))
+    t1 = next(t for t in plan_state["tasks"] if t["id"] == "t1")
+    assert t1["status"] == "proposed"
+    assert main(["plan", "confirm", "t1"]) == 0
+
+    capsys.readouterr()
+    assert main(["plan", "converge", "--json"]) == 0
+    plan_verdict = _json_out(capsys)
+    assert plan_verdict["ready_for_plan"] is True
+
+    # --- sharper plan export (t9) -------------------------------------------
+    assert main(["plan", "export"]) == 0
+    plan_files = list(Path("docs/plans").glob("*-unpark-move.md"))
+    assert len(plan_files) == 1
+    plan_md = plan_files[0].read_text(encoding="utf-8")
+    assert "- instruction: sharper guidance, still verbatim" in plan_md
+
+    # --- fanout brief (t9 payload): self-contained, verbatim ----------------
+    capsys.readouterr()
+    assert main(["plan", "waves", "--json"]) == 0
+    payload = _json_out(capsys)
+    assert payload["waves"] == [["t1"], ["t2"]]
+    brief = payload["tasks"]["t1"]
+    assert brief["summary"] == "add the unpark transition to the frame model"
+    assert brief["instruction"] == "sharper guidance, still verbatim"
+    assert brief["acceptance_criteria"] == ["a blocking vagueness resolves and converge passes"]
+    assert set(brief["covers"]) == set(targets[:mid])

--- a/tests/test_frame_schema_v2.py
+++ b/tests/test_frame_schema_v2.py
@@ -1,0 +1,149 @@
+"""Schema v2: scope entries + per-item instruction fields (#53 t1).
+
+Covers c10 (per-item instruction), h3 (instructions round-trip verbatim,
+absent instruction renders nothing / defaults empty), c4 + h9 (a scope survey
+stage exists as first-class state with provenance to claims).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devague import store
+from devague.frame import (
+    SCHEMA_VERSION,
+    Claim,
+    Frame,
+    HonestyCondition,
+    ScopeEntry,
+    from_dict,
+    to_dict,
+)
+
+
+def test_schema_version_bumped_exactly_once() -> None:
+    assert SCHEMA_VERSION == 2
+
+
+def test_claim_and_honesty_instruction_default_empty() -> None:
+    f = Frame(slug="s", title="t")
+    c = f.add_claim("announcement", "we shipped X", origin="user")
+    h = f.add_honesty(c, "must be measurable", origin="llm")
+    assert c.instruction == ""
+    assert h.instruction == ""
+
+
+def test_claim_and_honesty_instruction_settable_verbatim() -> None:
+    c = Claim(id="c1", kind="requirement", text="x", instruction="verify via `pytest -k x`")
+    h = HonestyCondition(id="h1", text="y", instruction="check the CLI --json output")
+    assert c.instruction == "verify via `pytest -k x`"
+    assert h.instruction == "check the CLI --json output"
+
+
+def test_add_scope_entry_ids_and_defaults() -> None:
+    f = Frame(slug="s", title="t")
+    e1 = f.add_scope_entry("existing frame.py", "no instruction field today")
+    e2 = f.add_scope_entry("existing store.py", "schema_version fails closed already")
+    assert isinstance(e1, ScopeEntry)
+    assert (e1.id, e2.id) == ("s1", "s2")
+    assert e1.seeds == []
+    assert f.scope_entries == [e1, e2]
+
+
+def test_add_scope_entry_with_seeds_referencing_existing_claims() -> None:
+    f = Frame(slug="s", title="t")
+    c = f.add_claim("requirement", "must persist instructions", origin="user")
+    e = f.add_scope_entry("survey of store.py", "needs instruction field", seeds=[c.id])
+    assert e.seeds == ["c1"]
+
+
+def test_add_scope_entry_rejects_unknown_seed_id() -> None:
+    f = Frame(slug="s", title="t")
+    with pytest.raises(ValueError):
+        f.add_scope_entry("survey", "finding", seeds=["c999"])
+
+
+def test_add_scope_entry_rejects_unknown_seed_id_among_valid_ones() -> None:
+    f = Frame(slug="s", title="t")
+    c = f.add_claim("requirement", "must persist instructions", origin="user")
+    with pytest.raises(ValueError):
+        f.add_scope_entry("survey", "finding", seeds=[c.id, "c999"])
+
+
+def test_roundtrip_scope_entries_and_instructions_via_dict() -> None:
+    f = Frame(slug="s", title="t")
+    c = f.add_claim("requirement", "instructions round-trip", origin="user")
+    c.instruction = "capture, store, export renders them verbatim"
+    h = f.add_honesty(c, "cond", origin="user")
+    h.instruction = "check export output contains the instruction text"
+    f.add_scope_entry("existing frame.py", "no instruction field today", seeds=[c.id])
+
+    f2 = from_dict(to_dict(f))
+
+    assert to_dict(f2) == to_dict(f)
+    assert f2.claims[0].instruction == "capture, store, export renders them verbatim"
+    assert f2.claims[0].honesty_conditions[0].instruction == (
+        "check export output contains the instruction text"
+    )
+    assert f2.scope_entries[0].surface == "existing frame.py"
+    assert f2.scope_entries[0].finding == "no instruction field today"
+    assert f2.scope_entries[0].seeds == [c.id]
+
+
+def test_roundtrip_scope_entries_and_instructions_via_store(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = Frame(slug="demo", title="Demo")
+    c = f.add_claim("requirement", "instructions round-trip", origin="user")
+    c.instruction = "verify via the export renderer"
+    f.add_scope_entry("survey", "finding", seeds=[c.id])
+    store.save(f)
+    assert to_dict(store.load("demo")) == to_dict(f)
+
+
+def test_legacy_v1_dict_loads_with_empty_scope_and_instruction_defaults() -> None:
+    legacy = {
+        "slug": "s",
+        "title": "t",
+        "schema_version": 1,
+        "claims": [
+            {
+                "id": "c1",
+                "kind": "requirement",
+                "text": "x",
+                "origin": "user",
+                "status": "confirmed",
+            }
+        ],
+        "open_vagueness": [],
+    }
+    f = from_dict(legacy)
+    assert f.claims[0].instruction == ""
+    assert f.scope_entries == []
+
+
+def test_legacy_v1_frame_without_schema_version_loads_via_store(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.FRAMES_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {"slug": "demo", "title": "Demo", "claims": [], "open_vagueness": []}
+    store.path_for("demo").write_text(json.dumps(legacy), encoding="utf-8")
+    loaded = store.load("demo")
+    assert loaded.schema_version == SCHEMA_VERSION
+    assert loaded.scope_entries == []
+
+
+def test_load_rejects_newer_schema_version_still_fails_closed(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.save(Frame(slug="demo", title="Demo"))
+    p = store.path_for("demo")
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["schema_version"] = SCHEMA_VERSION + 1
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        store.load("demo")
+
+
+def test_scope_entry_seeds_default_to_empty_list() -> None:
+    e = ScopeEntry(id="s1", surface="a", finding="b")
+    assert e.seeds == []

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -76,10 +76,42 @@ def test_plan_carries_schema_version() -> None:
     assert from_dict(to_dict(p)).schema_version == PLAN_SCHEMA_VERSION
 
 
+def test_plan_schema_version_bumped_to_2_for_instruction_field() -> None:
+    # #53 t2: the instruction field bumps the persisted plan shape exactly once.
+    assert PLAN_SCHEMA_VERSION == 2
+
+
 def test_legacy_plan_without_schema_version_loads() -> None:
     # A pre-0.7.0 plan has no schema_version key — it must still load.
     p = from_dict({"slug": "s", "title": "t", "frame_slug": "s", "tasks": []})
     assert p.schema_version == PLAN_SCHEMA_VERSION
+
+
+def test_task_instruction_defaults_empty() -> None:
+    p = _plan()
+    t = p.add_task("x")
+    assert t.instruction == ""
+
+
+def test_task_instruction_roundtrips_verbatim() -> None:
+    p = _plan()
+    t = p.add_task("x")
+    t.instruction = "run pytest -k foo then check the diff"
+    restored = from_dict(to_dict(p))
+    assert restored.find_task("t1").instruction == "run pytest -k foo then check the diff"
+
+
+def test_legacy_v1_task_dict_without_instruction_loads_with_empty_default() -> None:
+    # A schema_version-1 plan's task dicts predate the instruction field entirely.
+    legacy = {
+        "slug": "s",
+        "title": "t",
+        "frame_slug": "s",
+        "schema_version": 1,
+        "tasks": [{"id": "t1", "summary": "x"}],
+    }
+    p = from_dict(legacy)
+    assert p.find_task("t1").instruction == ""
 
 
 def test_dataclasses_validate_enums() -> None:
@@ -117,6 +149,7 @@ def test_roundtrip_preserves_nested_fields() -> None:
     p.add_acceptance(t, "works")
     p.add_dep(t, "t9")
     p.add_cover(t, "h2")
+    t.instruction = "verify against acceptance criteria before merge"
     p.add_risk("scope?", "unknown_blocking", task_id="t1")
     p.targets.append(targets_from_frame(_seed_frame())[0])
     restored = from_dict(to_dict(p))

--- a/tests/test_plan_cli_instructions.py
+++ b/tests/test_plan_cli_instructions.py
@@ -1,0 +1,177 @@
+"""Tests for #53 t5: instruction flags on plan moves.
+
+Covers ``plan task --instruction`` (stores verbatim on a new task), the new
+``plan instruct <tN> "<text>"`` move (adds/updates an instruction on an
+existing task), the re-confirm rule (setting/changing an instruction on a
+CONFIRMED task flips it back to 'proposed'), and that ``plan show --json``
+carries each task's instruction.
+"""
+
+from __future__ import annotations
+
+import json
+
+from devague import plan_store, store
+from devague.cli import main
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+
+
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame that passes the frame gate; return its slug."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship instructions"])  # c1 announcement
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _seeded_plan(monkeypatch, tmp_path, capsys) -> str:
+    """A plan with no tasks yet, seeded from a converged frame."""
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    return slug
+
+
+# ── plan task --instruction ──────────────────────────────────────────────────
+def test_task_instruction_stored_verbatim(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "task", "core", "--instruction", "run the `pytest` suite", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["instruction"] == "run the `pytest` suite"
+    task = plan_store.load(slug).find_task(payload["id"])
+    assert task.instruction == "run the `pytest` suite"
+
+
+def test_task_without_instruction_defaults_empty(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])
+    capsys.readouterr()
+    task = plan_store.load(slug).tasks[0]
+    assert task.instruction == ""
+
+
+# ── instruct: add / update on an existing task ───────────────────────────────
+def test_instruct_adds_instruction_to_existing_proposed_task(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "speculative", "--origin", "llm"])  # proposed
+    capsys.readouterr()
+    rc = main(["plan", "instruct", "t1", "verify via `pytest`", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["id"] == "t1"
+    assert payload["instruction"] == "verify via `pytest`"
+    assert payload["status"] == "proposed"  # was never confirmed, so unchanged
+    assert payload["flipped"] is False
+    task = plan_store.load(slug).find_task("t1")
+    assert task.instruction == "verify via `pytest`"
+    assert task.status == "proposed"
+
+
+def test_instruct_updates_existing_instruction(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(
+        [
+            "plan",
+            "task",
+            "speculative",
+            "--origin",
+            "llm",
+            "--instruction",
+            "first draft",
+        ]
+    )
+    capsys.readouterr()
+    rc = main(["plan", "instruct", "t1", "second draft", "--json"])
+    assert rc == 0
+    task = plan_store.load(slug).find_task("t1")
+    assert task.instruction == "second draft"
+
+
+def test_instruct_unknown_task_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seeded_plan(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "instruct", "tX", "text"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no such task" in err
+    assert "hint:" in err
+
+
+# ── re-confirm rule ───────────────────────────────────────────────────────────
+def test_instruct_flips_confirmed_task_to_proposed(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])  # origin=user -> confirmed by default
+    capsys.readouterr()
+    assert plan_store.load(slug).find_task("t1").status == "confirmed"
+    rc = main(["plan", "instruct", "t1", "how to verify", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "proposed"
+    assert payload["flipped"] is True
+    task = plan_store.load(slug).find_task("t1")
+    assert task.status == "proposed"
+    assert task.instruction == "how to verify"
+
+
+def test_instruct_flip_emits_stderr_note_in_text_mode(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])  # confirmed
+    capsys.readouterr()
+    rc = main(["plan", "instruct", "t1", "how to verify"])  # text mode
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "proposed" in err
+    assert plan_store.load(slug).find_task("t1").status == "proposed"
+
+
+def test_instruct_on_proposed_task_no_flip_note(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "speculative", "--origin", "llm"])  # proposed
+    capsys.readouterr()
+    rc = main(["plan", "instruct", "t1", "how to verify"])
+    assert rc == 0
+    out = capsys.readouterr()
+    assert out.err == ""  # no flip note; status was already proposed
+    assert plan_store.load(slug).find_task("t1").status == "proposed"
+
+
+def test_instruct_flips_confirmed_task_json_note_only_relevant_fields(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """A rejected task is untouched by the flip rule (only confirmed -> proposed)."""
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])  # confirmed
+    main(["plan", "reject", "t1"])
+    capsys.readouterr()
+    rc = main(["plan", "instruct", "t1", "how to verify", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "rejected"
+    assert payload["flipped"] is False
+    assert plan_store.load(slug).find_task("t1").status == "rejected"
+
+
+# ── plan show --json carries instructions ────────────────────────────────────
+def test_show_json_includes_task_instruction(tmp_path, monkeypatch, capsys) -> None:
+    _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core", "--instruction", "do the thing"])
+    capsys.readouterr()
+    rc = main(["plan", "show", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tasks"][0]["instruction"] == "do the thing"
+
+
+# ── discoverability ───────────────────────────────────────────────────────────
+def test_instruct_registered_in_learn_and_explain(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "learn", "--json"]) == 0
+    moves = json.loads(capsys.readouterr().out)["moves"]
+    assert "instruct" in moves
+    assert main(["plan", "explain", "instruct", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["move"] == "instruct"

--- a/tests/test_plan_convergence.py
+++ b/tests/test_plan_convergence.py
@@ -23,6 +23,7 @@ def _plan_with_tasks(
 
     ids are t1.. in stored order; targets are auto-created to keep the plan
     otherwise convergence-clean (each confirmed task covers its own target).
+    Confirmed tasks automatically get a default instruction to avoid TDD warnings.
     """
     p = Plan(slug="demo", title="Demo", frame_slug="demo")
     for i, (summary, deps, status, acceptance) in enumerate(specs, start=1):
@@ -33,6 +34,8 @@ def _plan_with_tasks(
             deps=list(deps),
             acceptance_criteria=list(acceptance),
         )
+        if status == "confirmed":
+            t.instruction = f"implement {summary}"
         p.tasks.append(t)
         if status == "confirmed":
             tgt = CoverageTarget(id=f"c{i}", kind="requirement", text=summary)
@@ -42,10 +45,11 @@ def _plan_with_tasks(
 
 
 def _converging() -> Plan:
-    """Minimal plan that is fully converged: one confirmed task, one target, criteria."""
+    """Minimal plan that is fully converged: one task, target, criteria, instruction."""
     p = Plan(slug="demo", title="Demo", frame_slug="demo")
     p.targets = [CoverageTarget(id="c1", kind="announcement", text="shipped")]
     t = p.add_task("do the thing")  # confirmed
+    t.instruction = "implement the feature"
     p.add_acceptance(t, "it works")
     p.add_cover(t, "c1")
     return p

--- a/tests/test_plan_convergence_sharper.py
+++ b/tests/test_plan_convergence_sharper.py
@@ -1,0 +1,190 @@
+"""Tests for the instruction warning in plan convergence (#53 t8).
+
+These tests cover:
+  - warning_missing_instruction: confirmed tasks without an instruction
+  - interaction with existing convergence state
+"""
+
+from __future__ import annotations
+
+from devague.plan import CoverageTarget, Plan
+from devague.plan_convergence import evaluate
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _converging_with_instruction() -> Plan:
+    """Minimal plan that is fully converged: one confirmed task with instruction."""
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.targets = [CoverageTarget(id="c1", kind="announcement", text="shipped")]
+    t = p.add_task("do the thing")  # confirmed
+    t.instruction = "implement feature X"  # has instruction
+    p.add_acceptance(t, "it works")
+    p.add_cover(t, "c1")
+    return p
+
+
+def _converging_without_instruction() -> Plan:
+    """Minimal plan that is fully converged except for missing instruction on task."""
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.targets = [CoverageTarget(id="c1", kind="announcement", text="shipped")]
+    t = p.add_task("do the thing")  # confirmed
+    # instruction defaults to "" — no instruction
+    p.add_acceptance(t, "it works")
+    p.add_cover(t, "c1")
+    return p
+
+
+# ── warning: missing instruction ──────────────────────────────────────────────
+
+
+def test_no_warning_when_confirmed_task_has_instruction() -> None:
+    """A converged plan with instruction on every confirmed task has no instruction warnings."""
+    res = evaluate(_converging_with_instruction())
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert (
+        instruction_warnings == []
+    ), f"should have no instruction warnings, got: {instruction_warnings}"
+
+
+def test_warning_when_confirmed_task_has_no_instruction() -> None:
+    """A confirmed task with empty instruction emits a non-blocking warning.
+
+    The warning does NOT flip ready_for_plan or appear in blockers — it is purely
+    advisory.
+    """
+    res = evaluate(_converging_without_instruction())
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert instruction_warnings, f"expected instruction warning, got: {res.warnings}"
+    # Verify the warning references the task id and suggests the fix move
+    assert any(
+        "t1" in w for w in instruction_warnings
+    ), f"warning should mention t1: {instruction_warnings}"
+    assert any(
+        "instruct" in w.lower() for w in instruction_warnings
+    ), f"warning should suggest instruct move: {instruction_warnings}"
+
+
+def test_instruction_warning_does_not_affect_ready_for_plan() -> None:
+    """A confirmed task's missing instruction warning must NOT flip ready_for_plan.
+
+    A converged plan (all targets covered, all tasks have acceptance criteria)
+    that is missing an instruction should still converge; the warning fires but
+    does not independently affect ready_for_plan.
+    """
+    p = _converging_without_instruction()
+    res = evaluate(p)
+    # The plan converges (all targets covered, all tasks have criteria)
+    assert res.ready is True, f"expected convergence; blockers: {res.blockers}"
+    # But we still get the warning
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert instruction_warnings, "expected instruction warning even on converged plan"
+
+
+def test_no_warning_for_proposed_task_without_instruction() -> None:
+    """Proposed tasks without instruction do NOT trigger the instruction warning.
+
+    Proposed tasks are not yet confirmed; the instruction warning is limited to
+    confirmed tasks only.
+    """
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.add_task("speculative", origin="llm")  # proposed, no instruction
+    res = evaluate(p)
+    # The warning must NOT mention t1 for the instruction reason.
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower() and "t1" in w]
+    assert (
+        instruction_warnings == []
+    ), f"instruction warning should not fire for proposed tasks: {instruction_warnings}"
+
+
+def test_no_warning_for_rejected_task_without_instruction() -> None:
+    """Rejected tasks without instruction do NOT trigger the instruction warning."""
+    p = _converging_with_instruction()
+    t = p.add_task("dropped")
+    p.set_status(t.id, "rejected")
+    # t2 is rejected and has no instruction — no warning
+    res = evaluate(p)
+    instruction_warnings = [w for w in res.warnings if "t2" in w and "instruction" in w.lower()]
+    assert (
+        instruction_warnings == []
+    ), f"instruction warning should not fire for rejected tasks: {instruction_warnings}"
+
+
+def test_multiple_confirmed_tasks_missing_instruction() -> None:
+    """Multiple confirmed tasks without instruction all get warnings."""
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.targets = [
+        CoverageTarget(id="c1", kind="requirement", text="req 1"),
+        CoverageTarget(id="c2", kind="requirement", text="req 2"),
+    ]
+    t1 = p.add_task("task 1")  # no instruction
+    p.add_acceptance(t1, "ok")
+    p.add_cover(t1, "c1")
+    t2 = p.add_task("task 2")  # no instruction
+    p.add_acceptance(t2, "ok")
+    p.add_cover(t2, "c2")
+    res = evaluate(p)
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert (
+        len(instruction_warnings) == 2
+    ), f"expected 2 instruction warnings, got: {instruction_warnings}"
+    assert any("t1" in w for w in instruction_warnings)
+    assert any("t2" in w for w in instruction_warnings)
+
+
+def test_mixed_tasks_with_and_without_instruction() -> None:
+    """Some tasks have instructions, some don't — only the missing ones warn."""
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.targets = [
+        CoverageTarget(id="c1", kind="requirement", text="req 1"),
+        CoverageTarget(id="c2", kind="requirement", text="req 2"),
+    ]
+    t1 = p.add_task("task 1")
+    t1.instruction = "do this"  # has instruction
+    p.add_acceptance(t1, "ok")
+    p.add_cover(t1, "c1")
+    t2 = p.add_task("task 2")
+    # no instruction
+    p.add_acceptance(t2, "ok")
+    p.add_cover(t2, "c2")
+    res = evaluate(p)
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert (
+        len(instruction_warnings) == 1
+    ), f"expected 1 instruction warning, got: {instruction_warnings}"
+    assert any("t2" in w for w in instruction_warnings)
+    assert not any("t1" in w for w in instruction_warnings)
+
+
+def test_converging_plan_with_all_instructions_has_no_instruction_warnings() -> None:
+    """All-instruction converged plan has no instruction warnings."""
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    p.targets = [
+        CoverageTarget(id="c1", kind="requirement", text="req 1"),
+        CoverageTarget(id="c2", kind="requirement", text="req 2"),
+    ]
+    t1 = p.add_task("task 1")
+    t1.instruction = "implement feature A"
+    p.add_acceptance(t1, "works")
+    p.add_cover(t1, "c1")
+    t2 = p.add_task("task 2")
+    t2.instruction = "implement feature B"
+    p.add_acceptance(t2, "works")
+    p.add_cover(t2, "c2")
+    res = evaluate(p)
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert (
+        instruction_warnings == []
+    ), f"should have no instruction warnings, got: {instruction_warnings}"
+    assert res.ready is True
+
+
+def test_instruction_warning_includes_suggested_fix() -> None:
+    """The instruction warning includes the exact suggested fix move."""
+    res = evaluate(_converging_without_instruction())
+    instruction_warnings = [w for w in res.warnings if "instruction" in w.lower()]
+    assert instruction_warnings, "should have instruction warning"
+    # The warning should suggest the devague plan instruct move with backticks
+    assert any(
+        "`devague plan instruct" in w for w in instruction_warnings
+    ), f"warning should include exact fix move with backticks: {instruction_warnings}"

--- a/tests/test_plan_render_sharper.py
+++ b/tests/test_plan_render_sharper.py
@@ -1,0 +1,214 @@
+"""Sharper plan renderer + enriched waves payload (#53 t9).
+
+Covers c12 (plan-md renders a task's instruction verbatim), c11 (sharper exports —
+the plan-md peer of t6's spec-md/frame-md instruction blocks), h3 (an absent
+instruction renders nothing — never fabricated filler), c8 (a subagent brief needs
+no external context — ``plan waves --json`` now carries summary/instruction/
+acceptance/covers per task), and h12 (checkable on artifacts alone).
+
+``render/plan_md.py`` gained a per-task ``- instruction: <verbatim text>`` bullet —
+the plan-md idiom mirroring t6's nested ``- instruction:`` bullet in spec_md.py /
+frame_md.py, adapted to a task (a heading, not a claim bullet): the instruction
+renders as the first body bullet, immediately under the task heading, before
+``depends on`` / ``covers`` / ``acceptance``. Absent entirely when the task carries
+none. ``devague plan waves --json`` gained a top-level ``"tasks"`` key — an object
+keyed by task id with ``{summary, instruction, acceptance_criteria, covers}`` for
+every active (non-rejected) task appearing in ``waves`` — while keeping the existing
+``plan`` and ``waves`` keys byte-compatible.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from devague import plan_store, store
+from devague.cli import main
+from devague.frame import Frame
+from devague.plan import Plan
+from devague.render.plan_md import render_plan
+from tests.test_render import assert_markdownlint_clean
+
+GOLDENS = Path(__file__).parent / "goldens"
+
+
+def _bare_frame() -> Frame:
+    f = Frame(slug="demo", title="Demo")
+    f.add_claim("announcement", "We shipped the plan engine", origin="user")
+    return f
+
+
+def _bare_plan() -> Plan:
+    """A plan with no task instructions — the pre-t9 shape."""
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    t1 = p.add_task("foundation")
+    p.add_acceptance(t1, "core lands")
+    p.add_cover(t1, "c1")
+    t2 = p.add_task("on top")
+    p.add_dep(t2, "t1")
+    p.add_cover(t2, "h1")
+    return p
+
+
+# Captured from the renderer before t9 (git show HEAD:devague/render/plan_md.py
+# against `_bare_plan()` / `_bare_frame()`) — locks in that the no-instruction path
+# stays byte-identical.
+_BARE_PLAN_BASELINE = (
+    "# Build Plan — Demo\n"
+    "\n"
+    "slug: `demo` · status: `drafting` · from frame: `demo`\n"
+    "\n"
+    "> We shipped the plan engine\n"
+    "\n"
+    "## Tasks\n"
+    "\n"
+    "### t1 — foundation\n"
+    "\n"
+    "- covers: c1\n"
+    "- acceptance:\n"
+    "  - core lands\n"
+    "\n"
+    "### t2 — on top\n"
+    "\n"
+    "- depends on: t1\n"
+    "- covers: h1\n"
+)
+
+
+def test_no_instruction_plan_md_byte_identical_to_baseline() -> None:
+    assert render_plan(_bare_plan(), _bare_frame()) == _BARE_PLAN_BASELINE
+
+
+def _sharper_frame() -> Frame:
+    f = Frame(slug="sharper-plan", title="Sharper Plan Golden")
+    f.add_claim("announcement", "we shipped the sharper plan renderer", origin="user")
+    return f
+
+
+def _sharper_plan() -> Plan:
+    """A plan exercising a task instruction (t1) and a task with none (t2)."""
+    p = Plan(slug="sharper-plan", title="Sharper Plan Golden", frame_slug="sharper-plan")
+    t1 = p.add_task("lay the foundation")
+    t1.instruction = "run `uv run pytest tests/test_plan.py -v` and confirm it is green"
+    p.add_acceptance(t1, "foundation lands")
+    p.add_cover(t1, "c1")
+    t2 = p.add_task("build on top")
+    p.add_dep(t2, "t1")
+    p.add_cover(t2, "h1")
+    # t2 carries no instruction — must render nothing.
+    return p
+
+
+def test_task_instruction_rendered_verbatim() -> None:
+    out = render_plan(_sharper_plan(), _sharper_frame())
+    assert "- instruction: run `uv run pytest tests/test_plan.py -v` and confirm it is green" in out
+
+
+def test_task_without_instruction_has_no_instruction_line() -> None:
+    out = render_plan(_sharper_plan(), _sharper_frame())
+    lines = out.splitlines()
+    idx = lines.index("### t2 — build on top")
+    # t2's body starts on the next non-blank line; it must not be an instruction bullet.
+    body_start = idx + 2  # skip the heading and the blank line after it
+    assert not lines[body_start].strip().startswith("- instruction:")
+
+
+def test_instruction_precedes_depends_covers_acceptance() -> None:
+    out = render_plan(_sharper_plan(), _sharper_frame())
+    lines = out.splitlines()
+    idx = lines.index("### t1 — lay the foundation")
+    assert lines[idx + 2].startswith("- instruction:")
+    assert lines[idx + 3] == "- covers: c1"
+    assert lines[idx + 4] == "- acceptance:"
+
+
+def test_sharper_plan_md_is_markdownlint_clean() -> None:
+    assert_markdownlint_clean(render_plan(_sharper_plan(), _sharper_frame()))
+
+
+def test_golden_plan_md() -> None:
+    expected = (GOLDENS / "sharper_plan.md").read_text(encoding="utf-8")
+    assert render_plan(_sharper_plan(), _sharper_frame()) == expected
+
+
+# ── waves --json enriched payload (#53 t9, c8/c11/h12) ───────────────────────────
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+_ALL_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the sharper plan renderer"])  # c1 announcement
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def test_waves_json_carries_tasks_payload(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(
+        [
+            "plan",
+            "task",
+            "Build everything",
+            "--accept",
+            "all targets satisfied",
+            "--instruction",
+            "run the full suite and diff the export",
+            *[flag for tid in _ALL_TARGETS for flag in ("--covers", tid)],
+        ]
+    )
+    capsys.readouterr()
+    assert main(["plan", "waves", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    # Existing keys stay byte-compatible.
+    assert payload["plan"] == slug
+    assert payload["waves"] == [["t1"]]
+    # New "tasks" key: every field verbatim for the task in the waves.
+    assert payload["tasks"] == {
+        "t1": {
+            "summary": "Build everything",
+            "instruction": "run the full suite and diff the export",
+            "acceptance_criteria": ["all targets satisfied"],
+            "covers": _ALL_TARGETS,
+        }
+    }
+
+
+def test_waves_json_tasks_without_instruction_is_empty_string(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "no instruction here"])
+    capsys.readouterr()
+    assert main(["plan", "waves", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tasks"]["t1"]["instruction"] == ""
+
+
+def test_waves_json_tasks_excludes_rejected(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "task 1"])
+    main(["plan", "task", "task 2"])
+    main(["plan", "reject", "t2"])
+    capsys.readouterr()
+    assert main(["plan", "waves", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload["tasks"].keys()) == {"t1"}
+    assert "t2" not in payload["tasks"]
+
+
+def test_waves_does_not_mutate_plan_state(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "task 1", "--instruction", "do it"])
+    capsys.readouterr()
+    before = plan_store.path_for(slug).read_text(encoding="utf-8")
+    assert main(["plan", "waves", "--json"]) == 0
+    assert plan_store.path_for(slug).read_text(encoding="utf-8") == before

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -96,6 +96,35 @@ def test_load_legacy_plan_without_schema_version(tmp_path, monkeypatch) -> None:
     assert plan_store.load("demo").schema_version == PLAN_SCHEMA_VERSION
 
 
+def test_load_v1_plan_with_tasks_but_no_instruction_field(tmp_path, monkeypatch) -> None:
+    # #53 t2: a pre-existing (schema_version 1) plan predates the instruction field
+    # on Task entirely — it must still load, with instruction defaulting to "".
+    monkeypatch.chdir(tmp_path)
+    plan_store.PLANS_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "slug": "demo",
+        "title": "Demo",
+        "frame_slug": "demo",
+        "schema_version": 1,
+        "tasks": [{"id": "t1", "summary": "first task"}],
+    }
+    plan_store.path_for("demo").write_text(json.dumps(legacy), encoding="utf-8")
+    loaded = plan_store.load("demo")
+    # A declared v1 stays 1 (not silently upgraded); loading itself must not error,
+    # and the new field defaults to "" for a task dict that predates it.
+    assert loaded.schema_version == 1
+    assert loaded.find_task("t1").instruction == ""
+
+
+def test_save_load_roundtrips_task_instruction_verbatim(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    p = _plan()
+    p.find_task("t1").instruction = "write the failing test before the fix"
+    plan_store.save(p)
+    loaded = plan_store.load("demo")
+    assert loaded.find_task("t1").instruction == "write the failing test before the fix"
+
+
 def test_load_rejects_slug_mismatch(tmp_path, monkeypatch) -> None:
     # A file under demo.json whose internal slug is a *different* valid slug must
     # be rejected, so a later save() can't be redirected onto another plan.

--- a/tests/test_render_sharper.py
+++ b/tests/test_render_sharper.py
@@ -1,0 +1,240 @@
+"""Sharper frame renderers: per-item instruction blocks + scope provenance (#53 t6).
+
+Covers c11 (sharper exports), h4 (sharper's definition is decision c14, confirmed
+by the user before any renderer change lands), c8 + h12 (exported spec shows scope
+provenance and renders instructions verbatim, checkable on artifacts alone), c3
+(every claim/honesty condition can carry its own instruction and exports read
+sharp), and h2/h3 (instructions and scope findings round-trip verbatim; an item
+without one renders nothing — never fabricated filler).
+
+``render/spec_md.py`` and ``render/frame_md.py`` gained: (1) a nested
+``- instruction: <verbatim text>`` bullet under any claim or honesty condition
+that carries one — absent entirely when the item has none; and (2) a
+``## Scope exploration`` section listing each ``frame.scope_entries`` record
+(id, surface, finding, seeded claim ids) — omitted entirely when there are none.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from devague.frame import Frame
+from devague.render.frame_md import render_frame
+from devague.render.spec_md import render_spec
+from tests.test_render import assert_markdownlint_clean
+
+GOLDENS = Path(__file__).parent / "goldens"
+
+
+def _bare_frame() -> Frame:
+    """A frame with no instructions and no scope entries — the pre-t6 shape.
+
+    Used to pin that an item without an instruction (and a frame without scope
+    entries) renders byte-identically to the renderer before this change.
+    """
+    f = Frame(slug="r", title="Rich Feature")
+    ann = f.add_claim("announcement", "Shipped", origin="user")
+    f.add_honesty(ann, "must be honest", origin="user")
+    f.add_claim("boundary", "scope is X only", origin="user")
+    f.add_claim("non_goal", "does not call an LLM", origin="user")
+    f.add_claim("non_goal", "no external services", origin="user")
+    f.add_claim("assumption", "frames fit in memory", origin="user")
+    f.add_claim("decision", "batch is transactional", origin="user")
+    req = f.add_claim("requirement", "review lists proposed items", origin="user")
+    f.add_honesty(req, "review never mutates state", origin="user")
+    return f
+
+
+# Captured from the renderer before t6 (git show HEAD:devague/render/spec_md.py /
+# frame_md.py against `_bare_frame()`) — locks in that the no-instruction,
+# no-scope-entries path stays byte-identical.
+_BARE_SPEC_BASELINE = (
+    "# Rich Feature\n"
+    "\n"
+    "> Shipped\n"
+    "\n"
+    "## Requirements\n"
+    "\n"
+    "- review lists proposed items\n"
+    "  - honesty: review never mutates state\n"
+    "\n"
+    "## Honesty conditions\n"
+    "\n"
+    "- must be honest\n"
+    "\n"
+    "## Scope / boundaries\n"
+    "\n"
+    "- scope is X only\n"
+    "\n"
+    "## Non-goals\n"
+    "\n"
+    "- does not call an LLM\n"
+    "- no external services\n"
+    "\n"
+    "## Assumptions\n"
+    "\n"
+    "- frames fit in memory\n"
+    "\n"
+    "## Decisions\n"
+    "\n"
+    "- batch is transactional\n"
+)
+
+_BARE_FRAME_BASELINE = (
+    "# Announcement Frame — Rich Feature\n"
+    "\n"
+    "slug: `r` · status: `drafting`\n"
+    "\n"
+    "## Announcement\n"
+    "\n"
+    "- Shipped\n"
+    "  - honesty: must be honest\n"
+    "\n"
+    "## Requirements\n"
+    "\n"
+    "- review lists proposed items\n"
+    "  - honesty: review never mutates state\n"
+    "\n"
+    "## Assumptions\n"
+    "\n"
+    "- frames fit in memory\n"
+    "\n"
+    "## Boundaries\n"
+    "\n"
+    "- scope is X only\n"
+    "\n"
+    "## Non-goals\n"
+    "\n"
+    "- does not call an LLM\n"
+    "- no external services\n"
+    "\n"
+    "## Decisions\n"
+    "\n"
+    "- batch is transactional\n"
+)
+
+
+def test_no_instruction_no_scope_spec_md_byte_identical_to_baseline() -> None:
+    assert render_spec(_bare_frame()) == _BARE_SPEC_BASELINE
+
+
+def test_no_instruction_no_scope_frame_md_byte_identical_to_baseline() -> None:
+    assert render_frame(_bare_frame()) == _BARE_FRAME_BASELINE
+
+
+def _sharper_frame() -> Frame:
+    """A frame exercising per-item instructions (claim + honesty) and scope entries."""
+    f = Frame(slug="sharper", title="Sharper Golden")
+    ann = f.add_claim("announcement", "we shipped the sharper method", origin="user")
+    ann.instruction = "run the dogfood script end to end"
+    f.add_honesty(ann, "must be observed end to end", origin="user")
+
+    aud = f.add_claim("audience", "operators driving /think", origin="user")
+    aud.instruction = "confirm by grepping skill frontmatter for the audience note"
+
+    req = f.add_claim("requirement", "exports render instruction blocks verbatim", origin="user")
+    req.instruction = "run `uv run devague export` and diff against the golden fixture"
+    h = f.add_honesty(req, "an absent instruction renders nothing", origin="user")
+    h.instruction = "capture a claim with no instruction and assert no new bullet appears"
+
+    f.add_claim("boundary", "renderer changes stay inside render slash star dot py", origin="user")
+    f.add_claim("non_goal", "not a wizard", origin="user")
+    f.add_claim("assumption", "the operating agent performs the exploration", origin="user")
+    f.add_claim(
+        "decision",
+        "sharper means instruction blocks and scope provenance",
+        origin="user",
+    )
+
+    f.add_scope_entry(
+        "devague render spec_md dot py",
+        "no instruction or scope rendering existed before t6",
+        seeds=[req.id],
+    )
+    f.add_scope_entry("devague render frame_md dot py", "same renderer gap as spec_md.py")
+    return f
+
+
+def test_claim_instruction_rendered_verbatim_in_spec_md() -> None:
+    out = render_spec(_sharper_frame())
+    assert "  - instruction: run `uv run devague export` and diff against the golden fixture" in out
+
+
+def test_honesty_instruction_rendered_verbatim_in_spec_md() -> None:
+    out = render_spec(_sharper_frame())
+    assert (
+        "    - instruction: capture a claim with no instruction and assert no new bullet appears"
+        in out
+    )
+
+
+def test_claim_without_instruction_has_no_instruction_line_in_spec_md() -> None:
+    out = render_spec(_sharper_frame())
+    lines = out.splitlines()
+    idx = lines.index("- not a wizard")
+    # The non_goal claim carries no instruction — the following line must not be one.
+    assert not lines[idx + 1].strip().startswith("- instruction:")
+
+
+def test_claim_instruction_rendered_verbatim_in_frame_md() -> None:
+    out = render_frame(_sharper_frame())
+    assert "  - instruction: confirm by grepping skill frontmatter for the audience note" in out
+
+
+def test_honesty_instruction_rendered_verbatim_in_frame_md() -> None:
+    out = render_frame(_sharper_frame())
+    assert (
+        "    - instruction: capture a claim with no instruction and assert no new bullet appears"
+        in out
+    )
+
+
+def test_scope_section_present_in_spec_md_when_entries_exist() -> None:
+    out = render_spec(_sharper_frame())
+    assert "## Scope exploration" in out
+    assert "`s1`" in out and "devague render spec_md dot py" in out
+    assert "no instruction or scope rendering existed before t6" in out
+    assert "seeds: `c3`" in out  # req is the third claim added -> c3
+    assert "`s2`" in out and "devague render frame_md dot py" in out
+
+
+def test_scope_section_present_in_frame_md_when_entries_exist() -> None:
+    out = render_frame(_sharper_frame())
+    assert "## Scope exploration" in out
+    assert "`s1`" in out and "seeds: `c3`" in out
+
+
+def test_scope_section_absent_in_spec_md_when_no_entries() -> None:
+    out = render_spec(_bare_frame())
+    assert "## Scope exploration" not in out
+
+
+def test_scope_section_absent_in_frame_md_when_no_entries() -> None:
+    out = render_frame(_bare_frame())
+    assert "## Scope exploration" not in out
+
+
+def test_scope_entry_without_seeds_omits_seeds_line() -> None:
+    out = render_spec(_sharper_frame())
+    # s2 carries no seeds -> no "seeds:" line directly under its bullet.
+    lines = out.splitlines()
+    idx = next(i for i, ln in enumerate(lines) if ln.startswith("- `s2`"))
+    assert idx + 1 == len(lines) or not lines[idx + 1].strip().startswith("- seeds:")
+
+
+def test_sharper_spec_md_is_markdownlint_clean() -> None:
+    assert_markdownlint_clean(render_spec(_sharper_frame()))
+
+
+def test_sharper_frame_md_is_markdownlint_clean() -> None:
+    assert_markdownlint_clean(render_frame(_sharper_frame()))
+
+
+def test_golden_spec_md() -> None:
+    expected = (GOLDENS / "sharper_spec.md").read_text(encoding="utf-8")
+    assert render_spec(_sharper_frame()) == expected
+
+
+def test_golden_frame_md() -> None:
+    expected = (GOLDENS / "sharper_frame.md").read_text(encoding="utf-8")
+    assert render_frame(_sharper_frame()) == expected

--- a/tests/test_teaching_scope.py
+++ b/tests/test_teaching_scope.py
@@ -1,0 +1,145 @@
+"""Tests for the teaching surface covering the scope stage + `question` move.
+
+`devague learn` gains the scope-exploration lead-in (optional-but-recommended
+— the recorded non-goal is that it never becomes a mandatory first stage), and
+`devague explain` gains coverage for every frame-side move it was missing
+(`scope`, `question`, `review`) — #53 t10, covers c9.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devague.cli import main
+
+
+# ── learn: the scope stage is taught as optional-but-recommended ───────────
+def test_learn_mentions_scope_stage(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["learn"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "scope" in out
+    # The real, shipped command syntax — not "planned" / "not yet" wording.
+    assert "devague scope" in out
+    assert "--finding" in out
+    assert "--seeds" in out
+
+
+def test_learn_presents_scope_as_optional_by_size(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["learn"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    # Optional-but-recommended framing, citing the recorded non-goal (c7):
+    # small ideas may skip it — never a mandatory first stage.
+    assert "optional" in out
+    assert "skip" in out
+    assert "not a mandatory" in out
+
+
+def test_learn_keeps_ten_stage_arc_unchanged(capsys: pytest.CaptureFixture[str]) -> None:
+    # Scope is a lead-in, not one of the ten numbered stages — the existing
+    # guided-arc contract (test_cli_affordances.py) must stay pinned.
+    rc = main(["learn", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["stages"]) == 10
+    assert payload["stages"][0]["name"] == "Announcement"
+
+
+def test_learn_json_includes_scope_stage_section(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["learn", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "scope_stage" in payload
+    section = payload["scope_stage"]
+    assert "scope" in json.dumps(section).lower()
+    assert any("optional" in str(v).lower() for v in section.values())
+
+
+def test_learn_mentions_instruction_flags_and_plan_handoff(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["learn"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "--instruction" in out
+    # The plan-side handoff moves (#53 t5).
+    assert "plan task" in out
+    assert "plan instruct" in out
+
+
+def test_learn_json_includes_instruction_flags_note(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["learn", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "instruction_flags" in payload
+    assert "--instruction" in payload["instruction_flags"]
+
+
+def test_learn_existing_assertions_still_hold(capsys: pytest.CaptureFixture[str]) -> None:
+    # Guard against regressing the pre-existing learn contract while adding
+    # the scope lead-in (test_cli_affordances.py pins the rest).
+    rc = main(["learn"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "what's the announcement?" in out
+    assert "not a mandatory conversation order" in out
+
+
+# ── explain: scope, question, and review now resolve ────────────────────────
+def test_explain_scope_works(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "scope"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "scope" in out
+
+
+def test_explain_question_works(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "question"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "question" in out
+
+
+def test_explain_review_works(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "review"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "review" in out
+
+
+def test_explain_scope_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "scope", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["move"] == "scope"
+    assert payload["description"]
+
+
+def test_explain_question_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "question", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["move"] == "question"
+    assert payload["description"]
+
+
+def test_explain_unknown_move_error_path_unchanged(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["explain", "not-a-real-move"])
+    assert rc == 1
+    err = capsys.readouterr().err.lower()
+    assert "unknown move" in err
+    assert "hint:" in err
+    assert "traceback" not in err
+
+
+def test_learn_moves_list_now_includes_scope_question_review(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["learn", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    for name in ("scope", "question", "review"):
+        assert name in payload["moves"]

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.13.0"
+version = "0.16.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

**The sharper end-to-end method ships (0.16.0)** — the full #53 build plan
(t1–t14), executed as a devague-orchestrated workforce fan-out: 5 dependency
waves from `devague plan waves`, one agent per task in an isolated worktree,
every merge TDD-gated (full suite green before **and** after), no human in the
per-task loop per the approved implementation split plan.

- **`devague scope`** — records explored surfaces as first-class `ScopeEntry`
  state (surface, finding, `--seeds` claim links; unknown ids refused);
  `scope --list [--json]` reads them back. (t1, t3)
- **Per-item instructions** — verbatim `instruction` text on claims, honesty
  conditions, and plan tasks (`capture --instruction`,
  `interrogate <c*|h*> --instruction`, `plan task --instruction`,
  new `plan instruct <tN>`); changing one on a confirmed item flips it back to
  `proposed` for re-confirmation. (t2, t4, t5)
- **Sharper exports** — instruction blocks + scope-provenance sections in
  spec/frame/plan markdown, golden-file tested; absent instructions render
  nothing. (t6, t9)
- **Enriched `waves --json`** — top-level `tasks` object
  (`summary`/`instruction`/`acceptance_criteria`/`covers` per id): a
  self-contained subagent brief; existing keys unchanged. The
  assign-to-workforce skill + split-plan script now brief verbatim from it —
  the operator-paraphrase step is gone. (t9, t13)
- **Structural sharpness warnings** (soft rollout, warnings-only, documented
  deterministic predicates): instruction-less spec-affecting claims,
  non-measurable success signals, instruction-less confirmed tasks. (t7, t8)
- **Teaching**: `learn` presents the optional scope stage; `explain scope` /
  `explain question` fixed; /think, /spec-to-plan, /scope SKILL.md teach the
  shipped surface (verified live by the doc agent). (t10, t11, t12)
- **Dogfooded e2e + boundary audit as committed tests** — a real idea (#57's
  unpark move) runs scope → frame → sharper spec → plan → fanout brief on the
  shipped surface; the audit pins no LLM imports / no process spawning in the
  package (#20). (t14)

Both schemas bump 1 → 2, fail-closed, with empty-default hydration of v1
files.

## Evidence

- Tests: 290 (baseline) → **418 passed**; every wave merge gated both sides.
- `bandit -r devague/`: no issues identified. flake8/black/isort: clean.
- `markdownlint-cli2` clean on CHANGELOG + the three updated docs.
- Enriched-payload contract verified live against the documented shape.

## Notes

- Merge order: independent of #56 (multi-repo spec+plan, 0.15.1); whichever
  merges second keeps the version monotonic (0.15.1 < 0.16.0).
- This unblocks the multi-repo plan's r1 precondition (#56): its t1/t3 ride
  the instruction fields + enriched waves payload shipped here.

- devague (Claude)
