### PR TITLE
fix(export): markdownlint-safe specs and plans (MD026/MD034) (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-07-10
+
+### Fixed
+
+- **`devague export` / `devague plan export` now emit markdownlint-safe markdown (#64).** Both renderers interpolate free-form claim/task/honesty prose straight into headings, blockquotes, and bullets, which tripped markdownlint's MD026 (no-trailing-punctuation) whenever a heading came from a sentence (the announcement, a task summary) and MD034 (no-bare-urls) whenever prose carried a bare `http(s)://` URL. Downstream repos (league-of-agents-platform) were hand-fixing every export before committing it. New shared helper `devague/render/_md_safety.py`: `heading_safe()` strips trailing punctuation from the `#`/`###` line only (blockquote/body copy keeps the sentence verbatim); `autolink_urls()` wraps a bare URL in `<...>` unless it is already inside `<>`, already the destination of a `[text](url)` link, or inside a code span. Both rules are pinned empirically against markdownlint-cli2 v0.21.0 (markdownlint v0.40.0). Rendering only — Frame/Plan JSON keeps the original text verbatim. New `tests/test_md_safety.py` (unit), hostile-input cases added to `tests/test_render.py` / `tests/test_render_plan.py`, and `tests/test_export_markdownlint_integration.py` (drives the real CLI end to end and shells out to `markdownlint-cli2`, skipping cleanly when it is not on PATH). Closes #64.
+
 ## [0.17.0] - 2026-07-09
 
 Skills release plus one correctness fix. No new CLI verbs and no new CLI docs;

--- a/devague/render/_md_safety.py
+++ b/devague/render/_md_safety.py
@@ -1,0 +1,104 @@
+"""Shared rendering-time markdown-safety helpers for the export renderers (#64).
+
+``devague export`` (spec-md, ``docs/specs/*.md``) and ``devague plan export``
+(plan-md, ``docs/plans/*.md``) both interpolate free-form claim/task/honesty
+prose straight into markdown — headings, blockquotes, and bullets. Prose
+written as a sentence ("Ship the feature.") trips markdownlint's MD026
+(no-trailing-punctuation) when it lands in a heading, and a URL written bare
+("see https://example.com") trips MD034 (no-bare-urls) wherever it lands.
+Downstream repos that commit exported specs/plans and gate PRs on
+markdownlint were hand-fixing every export until this landed.
+
+Both functions are applied **only** at render time — the underlying Frame/Plan
+JSON keeps the original text verbatim (rendering never mutates state).
+
+The exact rules here are pinned against markdownlint-cli2 v0.21.0
+(markdownlint v0.40.0) behavior, verified empirically, not just read from docs.
+"""
+
+from __future__ import annotations
+
+import re
+
+# markdownlint's MD026 default punctuation set is "all punctuation minus '?'"
+# (ASCII + full-width) — see markdownlint's `allPunctuationNoQuestion` helper
+# (`allPunctuation.replace(/[?？]/gu, "")`, where `allPunctuation` is
+# ".,;:!?。，；：！？"). '?' is intentionally excluded — a heading ending in '?'
+# is not flagged, so it is never stripped here.
+_HEADING_TRAILING_PUNCT_RE = re.compile(r"\s*[.,;:!。，；：！]+$")
+
+# A bare http(s) URL, not already the destination of a markdown link
+# ("...](url)") and not already inside "<...>" — both excluded via a
+# fixed-width negative lookbehind. The character class stops at whitespace,
+# angle brackets, and parens so a match never swallows surrounding markdown
+# syntax.
+_BARE_URL_RE = re.compile(r"(?<!<)(?<!\]\()https?://[^\s<>()]+")
+
+# Trailing characters GFM's autolink-literal extension (the thing MD034 is
+# built on) does not treat as part of the URL — kept *outside* the "<...>"
+# wrap so the rendered text tokenizes the same way markdownlint itself would.
+_URL_TRAILING_PUNCT = ".,;:!?'\""
+
+# Code spans (`...`) are left untouched — a URL inside backticks is literal
+# text, never a markdownlint "bare URL", and rewriting it would change
+# rendered content markdownlint never asked us to change.
+_CODE_SPAN_RE = re.compile(r"`[^`]*`")
+
+
+def _strip_url_trailing_punct(url: str) -> tuple[str, str]:
+    """Split a matched URL into ``(url, trailing)`` the way GFM's
+    autolink-literal extension would: trailing sentence punctuation, and an
+    unmatched closing paren, are not part of the URL.
+    """
+    trail = ""
+    while url:
+        ch = url[-1]
+        if ch in _URL_TRAILING_PUNCT:
+            trail = ch + trail
+            url = url[:-1]
+        elif ch == ")" and url.count("(") < url.count(")"):
+            trail = ch + trail
+            url = url[:-1]
+        else:
+            break
+    return url, trail
+
+
+def _autolink_segment(segment: str) -> str:
+    def _wrap(match: "re.Match[str]") -> str:
+        url, trail = _strip_url_trailing_punct(match.group(0))
+        return f"<{url}>{trail}"
+
+    return _BARE_URL_RE.sub(_wrap, segment)
+
+
+def autolink_urls(text: str) -> str:
+    """Wrap bare ``http(s)://`` URLs in ``<...>`` (MD034).
+
+    Skips a URL that is already inside ``<>``, already the destination of a
+    ``[text](url)`` markdown link, or already inside a code span. Plain
+    parens with no preceding ``[text]`` do **not** protect a bare URL —
+    markdownlint still flags those, and so do we.
+    """
+    if "https://" not in text and "http://" not in text:
+        return text
+    parts: list[str] = []
+    last = 0
+    for m in _CODE_SPAN_RE.finditer(text):
+        parts.append(_autolink_segment(text[last : m.start()]))
+        parts.append(m.group(0))  # code span: verbatim, never rewritten
+        last = m.end()
+    parts.append(_autolink_segment(text[last:]))
+    return "".join(parts)
+
+
+def heading_safe(text: str) -> str:
+    """Render-only heading text: URLs autolinked first (MD034), then any
+    trailing punctuation markdownlint's MD026 flags is stripped.
+
+    URLs must be wrapped before the punctuation strip runs — a heading ending
+    in a bare URL still needs MD034's fix, and once wrapped, a trailing
+    sentence '.' immediately after the closing '>' still trips MD026 (pinned
+    empirically against markdownlint-cli2: ``# Ship <url>.`` still errors).
+    """
+    return _HEADING_TRAILING_PUNCT_RE.sub("", autolink_urls(text))

--- a/devague/render/plan_md.py
+++ b/devague/render/plan_md.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from devague.frame import Frame
 from devague.plan import Plan, Task
+from devague.render._md_safety import autolink_urls, heading_safe
 
 
 def _topo_order(tasks: list[Task]) -> list[Task]:
@@ -58,15 +59,15 @@ def _task_lines(task: Task) -> list[str]:
         # t9), mirroring t6's nested ``- instruction:`` bullet in spec_md.py /
         # frame_md.py. A task is a heading rather than a claim bullet, so the
         # instruction renders as the first body bullet, immediately under it.
-        body.append(f"- instruction: {task.instruction}")
+        body.append(f"- instruction: {autolink_urls(task.instruction)}")
     if task.deps:
         body.append(f"- depends on: {', '.join(task.deps)}")
     if task.covers:
         body.append(f"- covers: {', '.join(task.covers)}")
     if task.acceptance_criteria:
         body.append("- acceptance:")
-        body.extend(f"  - {a}" for a in task.acceptance_criteria)
-    lines = [f"### {task.id} — {task.summary}{mark}"]
+        body.extend(f"  - {autolink_urls(a)}" for a in task.acceptance_criteria)
+    lines = [f"### {task.id} — {heading_safe(task.summary)}{mark}"]
     if body:
         # Blank line between the heading and its list (MD022/MD032).
         lines += ["", *body]
@@ -76,14 +77,14 @@ def _task_lines(task: Task) -> list[str]:
 
 def render_plan(plan: Plan, frame: Optional[Frame]) -> str:
     out = [
-        f"# Build Plan — {plan.title}",
+        f"# Build Plan — {heading_safe(plan.title)}",
         "",
         f"slug: `{plan.slug}` · status: `{plan.status}` · from frame: `{plan.frame_slug}`",
         "",
     ]
     ann = _announcement(frame)
     if ann:
-        out += ["> " + ann, ""]
+        out += ["> " + autolink_urls(ann), ""]
 
     tasks = [t for t in plan.tasks if t.status != "rejected"]
     if tasks:
@@ -95,7 +96,7 @@ def render_plan(plan: Plan, frame: Optional[Frame]) -> str:
         out += ["## Risks", ""]
         for r in plan.risks:
             suffix = f" (task {r.task_id})" if r.task_id else ""
-            out.append(f"- [{r.kind}] {r.text}{suffix}")
+            out.append(f"- [{r.kind}] {autolink_urls(r.text)}{suffix}")
         out.append("")
 
     return "\n".join(out).rstrip() + "\n"

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from devague.frame import Claim, Frame, HonestyCondition
+from devague.render._md_safety import autolink_urls, heading_safe
 
 
 def _claims(frame: Frame, kind: str) -> list[Claim]:
@@ -14,13 +15,13 @@ def _instruction_lines(instruction: str, indent: str = "  ") -> list[str]:
     when the item carries no instruction — never fabricated filler (#53 t1/t6,
     c10/h3).
     """
-    return [f"{indent}- instruction: {instruction}"] if instruction else []
+    return [f"{indent}- instruction: {autolink_urls(instruction)}"] if instruction else []
 
 
 def _claim_bullets(claims: list[Claim], prefix: str = "") -> list[str]:
     out: list[str] = []
     for c in claims:
-        out.append(f"- {prefix}{c.text}")
+        out.append(f"- {prefix}{autolink_urls(c.text)}")
         out += _instruction_lines(c.instruction)
     return out
 
@@ -32,7 +33,7 @@ def _text_section(heading: str, texts: list[str]) -> list[str]:
     """
     if not texts:
         return []
-    return [f"## {heading}", "", *[f"- {t}" for t in texts], ""]
+    return [f"## {heading}", "", *[f"- {autolink_urls(t)}" for t in texts], ""]
 
 
 def _claim_section(heading: str, claims: list[Claim]) -> list[str]:
@@ -62,12 +63,12 @@ def _requirements_block(frame: Frame) -> list[str]:
         return []
     out = ["## Requirements", ""]
     for c in reqs:
-        out.append(f"- {c.text}")
+        out.append(f"- {autolink_urls(c.text)}")
         out += _instruction_lines(c.instruction)
         for h in c.honesty_conditions:
             if h.status != "confirmed":
                 continue
-            out.append(f"  - honesty: {h.text}")
+            out.append(f"  - honesty: {autolink_urls(h.text)}")
             out += _instruction_lines(h.instruction, indent="    ")
     return out + [""]
 
@@ -95,14 +96,14 @@ def _honesty_section(heading: str, honesties: list[HonestyCondition]) -> list[st
         return []
     out = [f"## {heading}", ""]
     for h in honesties:
-        out.append(f"- {h.text}")
+        out.append(f"- {autolink_urls(h.text)}")
         out += _instruction_lines(h.instruction)
     return out + [""]
 
 
 def _hard_questions(frame: Frame) -> list[str]:
     hqs = [q for c in frame.claims for q in c.hard_questions]
-    bullets = [f"- {q.text}" + (" (blocking)" if q.blocking else "") for q in hqs]
+    bullets = [f"- {autolink_urls(q.text)}" + (" (blocking)" if q.blocking else "") for q in hqs]
     return ["## Hard questions", "", *bullets, ""] if hqs else []
 
 
@@ -119,20 +120,20 @@ def _scope_section(frame: Frame) -> list[str]:
         return []
     out = ["## Scope exploration", ""]
     for e in frame.scope_entries:
-        out.append(f"- `{e.id}` — `{e.surface}`: {e.finding}")
+        out.append(f"- `{e.id}` — `{e.surface}`: {autolink_urls(e.finding)}")
         if e.seeds:
             out.append(f"  - seeds: {', '.join(f'`{s}`' for s in e.seeds)}")
     return out + [""]
 
 
 def render_spec(frame: Frame) -> str:
-    out: list[str] = [f"# {frame.title}", ""]
+    out: list[str] = [f"# {heading_safe(frame.title)}", ""]
     ann_claims = _claims(frame, "announcement")
     if ann_claims:
         ann = ann_claims[0]
-        out.append("> " + ann.text)
+        out.append("> " + autolink_urls(ann.text))
         if ann.instruction:
-            out.append(f"> instruction: {ann.instruction}")
+            out.append(f"> instruction: {autolink_urls(ann.instruction)}")
         out.append("")
     out += _claim_section("Audience", _claims(frame, "audience"))
     out += _before_after(frame)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.17.0"
+version = "0.17.1"
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_export_markdownlint_integration.py
+++ b/tests/test_export_markdownlint_integration.py
@@ -1,0 +1,126 @@
+"""#64 integration test: real markdownlint-cli2 against a hostile-input export.
+
+Unit tests (``tests/test_md_safety.py``, ``tests/test_render.py``,
+``tests/test_render_plan.py``) pin the renderer behavior against a hand-rolled
+check and hard-coded expected strings. This test instead drives the actual CLI
+end to end (``devague new`` … ``devague export``; ``devague plan new`` …
+``devague plan export``) against a frame whose announcement ends in '.' and
+whose claims/tasks/risks carry bare URLs, then shells out to the real
+``markdownlint-cli2`` binary — the same dev tool this repo's own ``CLAUDE.md``
+documents (``markdownlint-cli2 "**/*.md"``) and the one league-of-agents-platform's
+CI gates on — and asserts zero errors, with no hand-editing.
+
+``markdownlint-cli2`` is dev tooling here, not installed by this repo's own CI
+(``tests.yml`` / ``security-checks.yml`` run neither Node nor markdownlint), so
+this test skips cleanly when the binary is not on PATH rather than failing the
+suite.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # noqa: S404 - dev-tooling integration check, not shipped code
+from pathlib import Path
+
+import pytest
+
+from devague import plan_store, store
+from devague.cli import main
+
+_MARKDOWNLINT = shutil.which("markdownlint-cli2")
+_CONFIG = Path(__file__).resolve().parent.parent / ".markdownlint-cli2.yaml"
+
+pytestmark = pytest.mark.skipif(
+    _MARKDOWNLINT is None,
+    reason="markdownlint-cli2 not on PATH (dev tooling; not installed by this repo's CI)",
+)
+
+_ALL_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+def _run_markdownlint(*paths: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [_MARKDOWNLINT, "--config", str(_CONFIG), *(str(p) for p in paths)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _export_hostile_spec(monkeypatch, tmp_path) -> Path:
+    monkeypatch.chdir(tmp_path)
+    main(["new", "League of Agents is live at https://league-of-agents.ai."])
+    main(
+        [
+            "interrogate",
+            "c1",
+            "--honesty",
+            "announcement is true, verified at http://status.league-of-agents.ai.",
+            "--origin",
+            "user",
+        ]
+    )
+    for kind in ("audience", "after_state", "before_state", "boundary", "success_signal"):
+        main(
+            [
+                "capture",
+                "--kind",
+                kind,
+                f"{kind} text ends in a period, see https://league-of-agents.ai.",
+                "--origin",
+                "user",
+            ]
+        )
+    frame = store.load(store.current_slug())
+    for c in frame.claims:
+        if c.id == "c1":
+            continue
+        main(["interrogate", c.id, "--honesty", "must hold.", "--origin", "user"])
+    main(["export"])
+    frame = store.load(store.current_slug())
+    return Path("docs/specs") / f"{frame.created[:10]}-{frame.slug}.md"
+
+
+def _export_hostile_plan(monkeypatch, tmp_path) -> Path:
+    spec_path = _export_hostile_spec(monkeypatch, tmp_path)
+    frame = store.load(store.current_slug())
+    main(["plan", "new", "--frame", frame.slug])
+    main(
+        [
+            "plan",
+            "task",
+            "Ship the beautiful, welcoming home page.",
+            "--accept",
+            "page is live, verified at https://league-of-agents.ai.",
+            *[flag for tid in _ALL_TARGETS for flag in ("--covers", tid)],
+        ]
+    )
+    main(
+        [
+            "plan",
+            "risk",
+            "traffic spike risk, see http://status.league-of-agents.ai for load.",
+            "--kind",
+            "unknown_nonblocking",
+            "--task",
+            "t1",
+        ]
+    )
+    main(["plan", "export"])
+    plan = plan_store.load(plan_store.current_slug())
+    plan_path = Path("docs/plans") / f"{plan.created[:10]}-{plan.slug}.md"
+    return spec_path, plan_path
+
+
+def test_hostile_spec_export_passes_markdownlint_cli2(tmp_path, monkeypatch) -> None:
+    spec_path = _export_hostile_spec(monkeypatch, tmp_path)
+    assert spec_path.exists()
+    result = _run_markdownlint(spec_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_hostile_plan_export_passes_markdownlint_cli2(tmp_path, monkeypatch) -> None:
+    spec_path, plan_path = _export_hostile_plan(monkeypatch, tmp_path)
+    assert plan_path.exists()
+    result = _run_markdownlint(spec_path, plan_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"

--- a/tests/test_md_safety.py
+++ b/tests/test_md_safety.py
@@ -1,0 +1,134 @@
+"""Unit tests for ``devague.render._md_safety`` — the render-time markdown-safety
+helpers behind #64 (``devague export`` / ``devague plan export`` emitted markdown
+that failed markdownlint's MD026 no-trailing-punctuation and MD034 no-bare-urls).
+
+These pin the exact stripping/wrapping rules against markdownlint-cli2's actual
+default behavior (verified empirically against markdownlint v0.40.0, the version
+vendored by markdownlint-cli2 v0.21.0): MD026's default punctuation set is
+".,;:!" (all punctuation minus '?', per markdownlint's `allPunctuationNoQuestion`
+helper) and MD034 leaves a URL alone only when it is already wrapped in ``<...>``,
+is the destination of a ``[text](url)`` link, or sits inside a code span.
+"""
+
+from __future__ import annotations
+
+from devague.render._md_safety import autolink_urls, heading_safe
+
+# ── heading_safe (MD026) ──────────────────────────────────────────────────────
+
+
+def test_heading_safe_strips_trailing_period() -> None:
+    assert heading_safe("Ship the feature.") == "Ship the feature"
+
+
+def test_heading_safe_strips_trailing_bang() -> None:
+    assert heading_safe("Ship it!") == "Ship it"
+
+
+def test_heading_safe_strips_trailing_colon() -> None:
+    assert heading_safe("Ship it:") == "Ship it"
+
+
+def test_heading_safe_strips_trailing_semicolon() -> None:
+    assert heading_safe("Ship it;") == "Ship it"
+
+
+def test_heading_safe_strips_trailing_comma() -> None:
+    # MD026's default punctuation set includes ',' too, not only '.:;!'.
+    assert heading_safe("Ship it,") == "Ship it"
+
+
+def test_heading_safe_keeps_trailing_question_mark() -> None:
+    # markdownlint's MD026 default excludes '?' — a rhetorical-question heading
+    # is not flagged, so stripping it would be an unrequested content change.
+    assert heading_safe("Ship it?") == "Ship it?"
+
+
+def test_heading_safe_strips_only_trailing_run() -> None:
+    # Punctuation mid-sentence must survive untouched — only the trailing run goes.
+    assert heading_safe("Ship it. Fast.") == "Ship it. Fast"
+
+
+def test_heading_safe_noop_on_clean_text() -> None:
+    text = "Ship the feature"
+    assert heading_safe(text) == text
+
+
+def test_heading_safe_strips_multiple_trailing_punctuation_chars() -> None:
+    assert heading_safe("Really ship it!!!") == "Really ship it"
+
+
+# ── autolink_urls (MD034) ─────────────────────────────────────────────────────
+
+
+def test_autolink_wraps_bare_https_url() -> None:
+    assert autolink_urls("see https://example.com") == "see <https://example.com>"
+
+
+def test_autolink_wraps_bare_http_url() -> None:
+    assert autolink_urls("see http://example.com") == "see <http://example.com>"
+
+
+def test_autolink_leaves_already_wrapped_url_untouched() -> None:
+    text = "see <https://example.com>"
+    assert autolink_urls(text) == text
+
+
+def test_autolink_leaves_markdown_link_destination_untouched() -> None:
+    text = "see [the site](https://example.com) for more"
+    assert autolink_urls(text) == text
+
+
+def test_autolink_leaves_code_span_untouched() -> None:
+    text = "run `curl https://example.com`"
+    assert autolink_urls(text) == text
+
+
+def test_autolink_wraps_url_inside_plain_parens() -> None:
+    # Plain parens (no preceding "[text]") do NOT protect a bare URL — markdownlint
+    # still flags it (verified against markdownlint-cli2 directly).
+    assert autolink_urls("(https://example.com)") == "(<https://example.com>)"
+
+
+def test_autolink_keeps_trailing_sentence_punctuation_outside_the_wrap() -> None:
+    assert autolink_urls("see https://example.com.") == "see <https://example.com>."
+
+
+def test_autolink_keeps_trailing_comma_outside_the_wrap() -> None:
+    assert autolink_urls("see https://example.com, then go") == (
+        "see <https://example.com>, then go"
+    )
+
+
+def test_autolink_handles_multiple_urls_in_one_string() -> None:
+    text = "see https://a.example and https://b.example"
+    assert autolink_urls(text) == "see <https://a.example> and <https://b.example>"
+
+
+def test_autolink_noop_on_text_without_urls() -> None:
+    text = "no links here at all"
+    assert autolink_urls(text) == text
+
+
+def test_autolink_is_idempotent() -> None:
+    once = autolink_urls("see https://example.com.")
+    twice = autolink_urls(once)
+    assert once == twice
+
+
+def test_autolink_mixed_wrapped_and_bare_urls() -> None:
+    text = "already <https://safe.example> but bare https://bare.example here"
+    assert autolink_urls(text) == (
+        "already <https://safe.example> but bare <https://bare.example> here"
+    )
+
+
+# ── composition: heading text needs both fixes ────────────────────────────────
+
+
+def test_heading_safe_autolinks_then_strips_trailing_period_after_url() -> None:
+    # A URL-ending heading needs the URL wrapped *and* the resulting trailing '.'
+    # stripped — verified against markdownlint-cli2 that "# Ship <url>." still
+    # trips MD026 even though the URL itself is safe.
+    out = heading_safe("Ship https://example.com.")
+    assert out == "Ship <https://example.com>"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -168,3 +168,67 @@ def test_spec_md_omits_honesty_for_unconfirmed_claims() -> None:
 def test_unknown_format_raises() -> None:
     with pytest.raises(DevagueError):
         render.render(_frame(), "nope")
+
+
+# ── #64: markdownlint-safe rendering (MD026 trailing-punctuation headings, ────
+# MD034 bare URLs) ─────────────────────────────────────────────────────────────
+
+
+def _hostile_frame() -> Frame:
+    """A frame whose announcement ends in '.' and whose claims/honesty carry a
+    bare URL — the exact shape league-of-agents-platform hit in #64.
+    """
+    f = Frame(slug="hostile", title="League of Agents is live at https://league-of-agents.ai.")
+    ann = f.add_claim(
+        "announcement",
+        "League of Agents is live at https://league-of-agents.ai.",
+        origin="user",
+    )
+    f.add_honesty(ann, "check http://status.example.com for uptime.", origin="user")
+    f.add_claim("audience", "players who visit https://league-of-agents.ai", origin="user")
+    f.add_vagueness("follow up at https://example.com/todo", "follow_up")
+    return f
+
+
+def test_spec_md_title_heading_strips_trailing_period() -> None:
+    out = render.render(_hostile_frame(), "spec-md")
+    assert out.startswith("# League of Agents is live at <https://league-of-agents.ai>\n")
+    assert not out.split("\n", 1)[0].rstrip().endswith(".")
+
+
+def test_spec_md_blockquote_keeps_sentence_verbatim_but_wraps_url() -> None:
+    # The issue is explicit: blockquote copy keeps the sentence verbatim (period
+    # included) — only the URL gets wrapped, only the *heading* loses punctuation.
+    out = render.render(_hostile_frame(), "spec-md")
+    assert "> League of Agents is live at <https://league-of-agents.ai>." in out
+
+
+def test_spec_md_wraps_bare_url_in_honesty_condition() -> None:
+    out = render.render(_hostile_frame(), "spec-md")
+    assert "- check <http://status.example.com> for uptime." in out
+
+
+def test_spec_md_wraps_bare_url_in_claim_bullet() -> None:
+    out = render.render(_hostile_frame(), "spec-md")
+    assert "- players who visit <https://league-of-agents.ai>" in out
+
+
+def test_spec_md_wraps_bare_url_in_follow_up_text() -> None:
+    out = render.render(_hostile_frame(), "spec-md")
+    assert "- follow up at <https://example.com/todo>" in out
+
+
+def test_spec_md_hostile_input_is_markdownlint_clean() -> None:
+    # The hand-rolled MD022/MD032/MD036 check still holds on hostile input too.
+    assert_markdownlint_clean(render.render(_hostile_frame(), "spec-md"))
+
+
+def test_spec_md_does_not_mutate_frame_claim_text() -> None:
+    # #64 acceptance: "Frame JSON keeps original claim text; only rendered
+    # markdown is adjusted." Rendering must never write back into the Frame.
+    frame = _hostile_frame()
+    before = [c.text for c in frame.claims]
+    render.render(frame, "spec-md")
+    after = [c.text for c in frame.claims]
+    assert before == after
+    assert frame.title == "League of Agents is live at https://league-of-agents.ai."

--- a/tests/test_render_plan.py
+++ b/tests/test_render_plan.py
@@ -76,3 +76,76 @@ def test_cycle_still_renders() -> None:
     p.add_dep(b, "t1")
     out = render_plan(p, None)  # cycle: must not raise, both tasks appear
     assert "### t1" in out and "### t2" in out
+
+
+# ── #64: markdownlint-safe rendering (MD026 trailing-punctuation headings, ────
+# MD034 bare URLs) ─────────────────────────────────────────────────────────────
+
+
+def _hostile_plan_and_frame() -> tuple[Plan, Frame]:
+    f = Frame(slug="hostile", title="Hostile plan frame")
+    f.add_claim(
+        "announcement",
+        "League of Agents is live at https://league-of-agents.ai.",
+        origin="user",
+    )
+    p = Plan(
+        slug="hostile",
+        title="Ship the beautiful, welcoming home page.",
+        frame_slug="hostile",
+    )
+    t1 = p.add_task("Point DNS at https://league-of-agents.ai.")
+    p.add_acceptance(t1, "site resolves at https://league-of-agents.ai.")
+    p.add_cover(t1, "c1")
+    p.add_risk(
+        "traffic spike risk, see http://status.league-of-agents.ai for load.",
+        "unknown_nonblocking",
+        task_id="t1",
+    )
+    return p, f
+
+
+def test_plan_md_title_heading_strips_trailing_period() -> None:
+    out = render_plan(*_hostile_plan_and_frame())
+    first_line = out.split("\n", 1)[0]
+    assert first_line == "# Build Plan — Ship the beautiful, welcoming home page"
+    assert not first_line.endswith(".")
+
+
+def test_plan_md_task_heading_strips_trailing_period_and_wraps_url() -> None:
+    out = render_plan(*_hostile_plan_and_frame())
+    assert "### t1 — Point DNS at <https://league-of-agents.ai>\n" in out
+    heading_line = next(ln for ln in out.split("\n") if ln.startswith("### t1"))
+    assert not heading_line.endswith(".")
+
+
+def test_plan_md_announcement_blockquote_keeps_period_but_wraps_url() -> None:
+    out = render_plan(*_hostile_plan_and_frame())
+    assert "> League of Agents is live at <https://league-of-agents.ai>." in out
+
+
+def test_plan_md_wraps_url_in_acceptance_criterion() -> None:
+    out = render_plan(*_hostile_plan_and_frame())
+    assert "  - site resolves at <https://league-of-agents.ai>." in out
+
+
+def test_plan_md_wraps_url_in_risk_text() -> None:
+    out = render_plan(*_hostile_plan_and_frame())
+    expected = (
+        "- [unknown_nonblocking] traffic spike risk, see "
+        "<http://status.league-of-agents.ai> for load. (task t1)"
+    )
+    assert expected in out
+
+
+def test_plan_md_hostile_input_is_markdownlint_clean() -> None:
+    assert_blanks_around_headings_and_lists(render_plan(*_hostile_plan_and_frame()))
+
+
+def test_plan_md_does_not_mutate_plan_or_task_text() -> None:
+    plan, frame = _hostile_plan_and_frame()
+    before_title = plan.title
+    before_summary = plan.tasks[0].summary
+    render_plan(plan, frame)
+    assert plan.title == before_title
+    assert plan.tasks[0].summary == before_summary

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

`devague export` (spec-md → `docs/specs/*.md`) and `devague plan export`
(plan-md → `docs/plans/*.md`) interpolate free-form claim/task/honesty prose
straight into headings, blockquotes, and bullets. Prose written as a sentence
tripped markdownlint's **MD026** (no-trailing-punctuation) whenever it landed
in a heading — the announcement text becomes the spec's H1, a task summary
becomes its H3 — and a bare `http(s)://` URL tripped **MD034** (no-bare-urls)
wherever it landed. Downstream repos that commit exported specs/plans and
gate PRs on markdownlint were hand-fixing every export
(league-of-agents-platform hand-fixed in commit 1477080 on PR #3; every
re-export re-introduced the errors until now).

## Rendering rules

New shared render-time helper `devague/render/_md_safety.py`, applied only at
render time — the underlying Frame/Plan JSON keeps the original claim/task
text verbatim:

- **`heading_safe(text)`** — strips trailing punctuation markdownlint's MD026
  default set flags (`.` `,` `;` `:` `!`, plus full-width variants; `?` is
  intentionally excluded, matching markdownlint's own default) from a
  `#`/`##`/`###` heading line. Applied to the spec H1 (`frame.title`), the
  plan H1 (`plan.title`), and each task's H3 (`task.summary`). Blockquote and
  body copy are untouched — the announcement's blockquote keeps the sentence
  verbatim, period included.
- **`autolink_urls(text)`** — wraps a bare `http(s)://` URL in `<...>` unless
  it is already inside `<>`, already the destination of a `[text](url)`
  markdown link, or already inside a code span (backticks). Trailing sentence
  punctuation attached to the URL (`.`, `,`, `;`, `:`, `!`, `?`, quotes, an
  unmatched `)`) is kept *outside* the wrap, matching how GFM's
  autolink-literal extension (what MD034 is built on) tokenizes it. Applied
  everywhere claim/honesty/instruction/task/risk/scope-finding text is
  rendered — bullets, blockquotes, and headings alike (a URL inside a heading
  still trips MD034).
- Heading text gets **both** fixes, in order: URLs are autolinked first, then
  trailing punctuation is stripped — a heading ending in a bare URL still
  needs MD034's fix, and once wrapped, a trailing `.` right after the closing
  `>` still trips MD026 (verified directly against markdownlint-cli2, not
  just read from docs).

Both rules were pinned empirically against the actual `markdownlint-cli2`
v0.21.0 (`markdownlint` v0.40.0) behavior — MD026's default punctuation set,
MD034's `<>`/link/code-span exemptions, and the fact that plain parens do
*not* exempt a bare URL — rather than assumed from documentation.

## Tests (TDD — written first, confirmed red before implementation)

- `tests/test_md_safety.py` — 22 unit tests on `heading_safe()` /
  `autolink_urls()` directly (trailing-punctuation set, URL wrap/skip rules,
  idempotence, composition).
- `tests/test_render.py` / `tests/test_render_plan.py` — hostile-input cases
  on `render_spec()` / `render_plan()`: title heading stripped, task heading
  stripped, blockquote keeps the sentence verbatim while wrapping its URL,
  claim/honesty/acceptance/risk bullets wrap their URLs, rendering never
  mutates the source Frame/Plan.
- `tests/test_export_markdownlint_integration.py` — drives the real CLI
  end to end (`devague new` … `export`; `devague plan new` … `plan export`)
  against a frame whose announcement ends in `.` and whose claims/tasks/risks
  carry bare URLs, then shells out to the real `markdownlint-cli2` binary
  against the exported files and asserts zero errors with no hand-editing.
  `markdownlint-cli2` is dev tooling here (this repo's own CI does not
  install it), so the test skips cleanly via `shutil.which` when the binary
  is not on PATH.

## Verification

- Baseline (before any change): `uv run pytest -n auto` → 420 passed.
- After: `uv run pytest -n auto` → 458 passed (38 new tests, 0 removed).
- `uv run flake8 --config=.flake8 devague/ tests/`, `uv run black --check`,
  `uv run isort --profile black --check`, `uv run bandit -r devague/`,
  `uv run pylint devague/` (score unchanged at baseline, 9.25→9.26,
  pre-existing findings only) all clean.
- `markdownlint-cli2 "**/*.md"` across the whole repo: 0 errors.
- Version bumped 0.17.0 → 0.17.1 (patch — a rendering-behavior bug fix, same
  precedent as 0.6.1/0.5.1's renderer fixes), CHANGELOG entry added.

Closes #64

- devague (Claude)