### PR TITLE
The execution seam and deviate (0.18.0)

### DIFF
--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -53,14 +53,16 @@ carries every active task's summary, instruction, acceptance criteria, and
 covered targets keyed by task id — and renders the human-facing
 implementation split plan: task map (task id, wave, summary verbatim, whether
 an instruction is present, acceptance-criteria count), proposed per-task
-agent + model assignment, and the go/no-go question. The `waves` subcommand
-forwards to `devague plan waves` verbatim.
+agent + model assignment, the go/no-go question, and — last — an End state
+section that is the verbatim output of `devague plan deliverables` (#70),
+degrading to a one-line hint on a `devague` too old to have the verb. The
+`waves` subcommand forwards to `devague plan waves` verbatim.
 
 ### Usage
 
 | Subcommand | What it does |
 |------------|--------------|
-| `split-plan [--plan S]` | Read `devague plan waves --json` and print the implementation split plan — task map (summary/instruction/acceptance-criteria count, verbatim) with per-task agent + model proposal — ready for human go/no-go review. |
+| `split-plan [--plan S]` | Read `devague plan waves --json` and print the implementation split plan — task map (summary/instruction/acceptance-criteria count, verbatim) with per-task agent + model proposal, go/no-go, and a trailing End state section quoting `devague plan deliverables` verbatim (one-line hint on an older devague) — ready for human go/no-go review. |
 | `waves [--plan S] [--json]` | Forward to `devague plan waves [--json]`. Read-only; lists wave batches. On a converged plan exits 0 listing the waves. |
 | `help` | Print usage. |
 
@@ -92,6 +94,13 @@ The split plan contains:
    safe to delegate).
 3. **Go/no-go question** — explicit human decision: "Approve this split and
    assign the plan to the workforce, or edit it first?"
+4. **End state** — the verbatim output of `devague plan deliverables` (#70):
+   what the plan actually produces — confirmed after-state claims, terminal
+   tasks with acceptance criteria, and surviving open items. Present this to
+   the human alongside the go/no-go question, not just the task map — approving
+   a fan-out without seeing the world it produces is the gap this closes. On a
+   `devague` too old to have the verb, this degrades to a one-line hint naming
+   the minimum version instead of failing the split plan.
 
 The human may edit any row (agent type, model, scope) before approving. The
 plan is model-agnostic — devague does not pick a backend (#20).
@@ -252,6 +261,13 @@ The `split-plan` subcommand prints to **stdout** and exits 0 when a converged
 plan is found. On error (no plan, cyclic graph) it exits non-zero with a
 `hint:` line on stderr. The `waves` subcommand forwards the CLI's own output
 contract (stdout, `--json` for structured output, exit 0 on success).
+
+The trailing End state section (#70) never fails `split-plan`: on a `devague`
+new enough to have `plan deliverables`, it quotes that command's stdout
+verbatim under an `End state (from \`devague plan deliverables\`):` header; on
+an older `devague`, it prints exactly one hint line naming the minimum version
+(e.g. `hint: End state view requires devague >= 0.18.0 (devague plan
+deliverables)`) and `split-plan` still exits 0.
 
 ## Worked example
 

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -12,7 +12,10 @@
 # is expected to edit it to a real model token (and harness, when it matters)
 # before approving. The actual fan-out (worktree creation, spawning, TDD-gated
 # merges) is performed by the operator/main agent once the human approves the
-# split plan.
+# split plan. Output ends with an End state section (devague#70 t6) — the
+# verbatim output of `devague plan deliverables` — so the human can see what
+# the plan actually produces before saying go; on an older devague lacking
+# that verb the section degrades to a one-line hint instead of failing.
 #
 # The devague CLI is non-orchestrating (#20): `devague plan waves` describes
 # the dependency graph; it does not spawn agents, manage worktrees, or pick
@@ -71,8 +74,10 @@ Commands:
                instruction/acceptance-count markers, verbatim from the
                payload) + a four-column Wave/Task/Model/Task-summary table
                (Model defaults to `sonnet`; edit it before approving) +
-               go/no-go. Present this to the human before any fan-out; do
-               not proceed without approval.
+               go/no-go, ending with an End state section — the verbatim
+               output of `devague plan deliverables` (degrades to a one-line
+               hint on an older devague lacking that verb). Present this to
+               the human before any fan-out; do not proceed without approval.
   waves        Forward `devague plan waves` (and any extra flags) verbatim.
                On a converged plan exits 0 and lists the dependency waves.
 
@@ -222,6 +227,28 @@ print("  3. Await all tasks in the wave; then TDD-gate each merge (tests before 
 print("  4. Advance to the next wave.")
 print("  5. Open the final PR (human gate 3) after all waves merge and tests pass.")
 PY
+
+    # ── End state: quote `devague plan deliverables` verbatim (#70 t6) ───────
+    # Never composed freehand — it is the single synthesized "what do we have
+    # in the end?" view (confirmed after-state claims, terminal tasks, and
+    # surviving open items). Forward the same --plan args used for waves.
+    # Degrades gracefully on an older devague that predates the verb: print
+    # one hint line naming the minimum version and keep exiting 0 — this
+    # section must never fail the script.
+    local deliverables_out deliverables_rc
+    set +e
+    deliverables_out="$("${DEVAGUE[@]}" plan deliverables "${extra_args[@]}" 2>/dev/null)"
+    deliverables_rc=$?
+    set -e
+
+    echo
+    if [ "$deliverables_rc" -eq 0 ]; then
+        echo 'End state (from `devague plan deliverables`):'
+        echo
+        printf '%s\n' "$deliverables_out"
+    else
+        echo 'hint: End state view requires devague >= 0.18.0 (devague plan deliverables)'
+    fi
 }
 
 main() {

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -4,11 +4,15 @@
 # The skill is named `assign-to-workforce`; it reads `devague plan waves --json`
 # — the enriched payload (devague#53 t9: {"plan", "waves", "tasks"}, the latter
 # keyed by task id with summary/instruction/acceptance_criteria/covers) — and
-# renders the implementation split plan: task map (summary, instruction
-# marker, acceptance-criteria count — all verbatim from the payload) +
-# per-task agent/model proposal + a go/no-go prompt for the human. The actual
-# fan-out (worktree creation, spawning, TDD-gated merges) is performed by the
-# operator/main agent once the human approves the split plan.
+# renders the implementation split plan: a wave listing (each task id carries
+# an `[instruction: yes|no, accept: N]` marker, verbatim from the payload) plus
+# a single four-column per-task table — Wave, Task, Model, Task summary (#69)
+# — and a go/no-go prompt for the human. The Model cell is a presentation-only
+# default (`sonnet`); the devague CLI stays model-agnostic (#20) and the human
+# is expected to edit it to a real model token (and harness, when it matters)
+# before approving. The actual fan-out (worktree creation, spawning, TDD-gated
+# merges) is performed by the operator/main agent once the human approves the
+# split plan.
 #
 # The devague CLI is non-orchestrating (#20): `devague plan waves` describes
 # the dependency graph; it does not spawn agents, manage worktrees, or pick
@@ -63,11 +67,12 @@ Usage:
 
 Commands:
   split-plan   Read `devague plan waves --json` and render the human-facing
-               implementation split plan: task map (summary, instruction
-               marker, acceptance-criteria count — all verbatim from the
-               payload) + per-task agent/model proposal + go/no-go. Present
-               this to the human before any fan-out; do not proceed without
-               approval.
+               implementation split plan: a wave listing (with per-task
+               instruction/acceptance-count markers, verbatim from the
+               payload) + a four-column Wave/Task/Model/Task-summary table
+               (Model defaults to `sonnet`; edit it before approving) +
+               go/no-go. Present this to the human before any fan-out; do
+               not proceed without approval.
   waves        Forward `devague plan waves` (and any extra flags) verbatim.
                On a converged plan exits 0 and lists the dependency waves.
 
@@ -143,36 +148,49 @@ waves = data.get("waves") or []
 # contract, keyed by id — summary, instruction, acceptance criteria, covers.
 tasks_meta = data.get("tasks") or {}
 
+# Presentation-only default (issue #69): the devague CLI itself stays
+# model-agnostic (#20) — this is just what the table proposes before a human
+# edits it.
+DEFAULT_MODEL = "sonnet"
+MAX_SUMMARY_LEN = 72
+ELLIPSIS = "..."
+
+
+def marker(task_id):
+    """`[instruction: yes|no, accept: N]`, verbatim from the payload (#53 t13,
+    c12/h5) — no operator paraphrasing of the underlying summary/instruction."""
+    meta = tasks_meta.get(task_id) or {}
+    has_instruction = "yes" if meta.get("instruction") else "no"
+    accept_count = len(meta.get("acceptance_criteria") or [])
+    return f"{task_id} [instruction: {has_instruction}, accept: {accept_count}]"
+
+
+def truncate(summary):
+    if len(summary) > MAX_SUMMARY_LEN:
+        return summary[:MAX_SUMMARY_LEN] + ELLIPSIS
+    return summary
+
+
 print(f"Implementation split plan — plan: {plan_slug}")
 print()
 print("Dependency waves (from `devague plan waves`):")
 for i, wave in enumerate(waves, 1):
-    tasks = ", ".join(wave)
-    print(f"  Wave {i}: [{tasks}]")
+    markers = ", ".join(marker(task_id) for task_id in wave)
+    print(f"  Wave {i}: [{markers}]")
 
 print()
-print("Task assignments (proposed — edit before approving):")
+print("Task assignments (proposed — edit the Model column before approving):")
 print()
 
-headers = ("Task", "Wave", "Summary", "Instruction", "Accept.", "Agent type", "Model", "Scope note")
+headers = ("Wave", "Task", "Model", "Task summary")
 rows = []
 for i, wave in enumerate(waves, 1):
     for task_id in wave:
         meta = tasks_meta.get(task_id) or {}
-        # Verbatim from the payload — no operator paraphrasing (#53 t13, c12/h5).
+        # Verbatim from the payload — no operator paraphrasing (#53 t13, c12/h5) —
+        # never a placeholder unless the payload truly has no summary recorded.
         summary = meta.get("summary") or "(no summary recorded)"
-        has_instruction = "yes" if meta.get("instruction") else "no"
-        accept_count = str(len(meta.get("acceptance_criteria") or []))
-        rows.append((
-            task_id,
-            str(i),
-            summary,
-            has_instruction,
-            accept_count,
-            "subagent",
-            "cheaper/faster",
-            "TDD-scoped task; isolated worktree; tests gate merge",
-        ))
+        rows.append((str(i), task_id, DEFAULT_MODEL, truncate(summary)))
 
 col_widths = [max(len(h), max((len(r[j]) for r in rows), default=0))
               for j, h in enumerate(headers)]
@@ -187,8 +205,13 @@ for row in rows:
     print(row_str(row))
 
 print()
-print("Go/no-go: review the table above, edit agent type / model / scope as needed,")
-print("then confirm: \"Approved — assign to workforce\" or \"Edit first\".")
+print("Model column: edit each row to a real model token (e.g. haiku, sonnet,")
+print("opus, fable), optionally qualified with the harness when it matters")
+print("(e.g. colleague, codex) — the default above is a starting proposal, not")
+print("a recommendation.")
+print()
+print("Go/no-go: review the table above, edit the Model column as needed, then")
+print("confirm: \"Approved — assign to workforce\" or \"Edit first\".")
 print()
 print("Once approved, fan out wave by wave:")
 print("  1. Create one git worktree per task in the wave.")

--- a/.claude/skills/deviate/SKILL.md
+++ b/.claude/skills/deviate/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: deviate
+description: >
+  Stop an in-flight assign-to-workforce run the moment execution must diverge
+  from the confirmed plan, get explicit human approval for the divergence, and
+  record it as a first-class, append-only deviation record via `devague
+  deviate` before resuming — never fold a deviation silently into drift after
+  the fact. Use when the user says "deviate from the plan", "we need to change
+  the plan mid-run", "record a deviation", "this isn't matching the plan
+  anymore", or when a task agent discovers the confirmed plan no longer
+  matches reality partway through a workforce run. Authored and maintained in
+  agentculture/devague (origin = devague); guildmaster pulls this skill from
+  here and broadcasts it to the AgentCulture mesh — it is NOT vendored from
+  guildmaster like the other skills here.
+type: command
+---
+
+# deviate — record an approved mid-run departure from the confirmed plan
+
+The skill is named **`deviate`**; it is the **execution-time leg** of the
+devague method — the *sixth* leg, sitting between the two execution skills:
+
+```text
+scope -> think -> spec-to-plan -> assign-to-workforce -> deviate -> summarize-delivery
+```
+
+Where `/assign-to-workforce` fans out a converged plan's waves and
+`/summarize-delivery` closes the loop afterward, `/deviate` runs **during**
+the fan-out, at the exact moment reality stops matching the plan the human
+approved at gate 2 (the implementation split plan). It is not a new standing
+gate — it is the human owner of gate 2 **amending** the approved split
+mid-flight, scoped to the one deviation in front of them.
+
+The plan the user confirmed is a contract. Task agents hit constraints,
+discover a dependency was wrong, or find the acceptance criteria no longer
+make sense once code is in front of them. Until this skill existed, that
+reality either silently reshaped what got built (undocumented drift) or the
+run stalled with no recorded path forward. `/deviate` is that path: the
+departure is named, approved, and recorded **before** anyone keeps building
+against it.
+
+## The method
+
+1. **STOP the run.** The moment a task agent (or the main agent) discovers
+   the confirmed plan no longer matches what needs to happen, halt — do not
+   keep implementing against the stale contract and do not let the fan-out
+   continue past this task.
+2. **Present what, why, and what it affects.** Lay out, for the human:
+   - **what** is diverging — the specific change from the confirmed task(s);
+   - **why** — the constraint or discovery that forced it;
+   - **what it affects** — the plan item ref(s) involved (`--task`), any
+     other task ids or coverage targets it touches (`--affects`), and which
+     acceptance criteria are no longer accurate.
+3. **Get explicit human approval.** This is the one non-negotiable step. A
+   deviation is not real until a human says yes to *this specific* departure
+   — not a standing blanket permission, not an inference from silence.
+4. **Record it via `devague deviate`.** Once approved, record the deviation
+   as a first-class ledger entry (never edit the plan itself — the plan
+   stays the untouched historical contract; see `devague/delivery.py`). An
+   `--origin llm` record lands `proposed` and still needs the user's
+   `--confirm` — recording is not the same as approval landing as final.
+5. **Adjust the affected task briefs.** Update the working instructions the
+   task agent(s) are building against so they reflect the approved
+   departure, not the stale plan text.
+6. **Resume.** Only after the record exists (and, for an `llm`-origin record,
+   only after it is confirmed) does the fan-out continue.
+
+Deviations are never silently folded into drift after the fact — by the time
+`/summarize-delivery` runs, every departure from the plan already has a
+`dN` record with a reason, an approval, and an optional classification. The
+delivery summary quotes these records; it does not reconstruct drift from
+memory.
+
+## The shipped CLI surface
+
+This skill invokes the CLI directly and stays self-contained (if `devague`
+isn't on your PATH: `uv tool install devague`). Deviation state persists
+under `.devague/deliveries/<plan-slug>.json` — a peer of the plan store, keyed
+by the plan slug, and never touches the plan JSON itself.
+
+| Move | What it does |
+|------|---------------|
+| `devague deviate "<what>" --task <tN> --reason "<text>"` | Record a deviation against plan item `<tN>`. User-origin (the default) auto-approves. |
+| `devague deviate "<what>" --task <tN> --reason "<text>" --affects <ref> [<ref> ...]` | Same, also naming every other plan item ref or coverage target the deviation touches (repeatable). |
+| `devague deviate "<what>" --task <tN> --reason "<text>" --classification acceptable\|risky\|needs-follow-up` | Same, tagging the deviation with the classification the drift-entry contract consumes downstream. |
+| `devague deviate "<what>" --task <tN> --reason "<text>" --origin llm` | An LLM-proposed record; lands `proposed`, not `approved`. |
+| `devague deviate --confirm <dN>` | User-only: approve a `proposed` deviation. |
+| `devague deviate --reject <dN>` | User-only: reject a `proposed` (or any) deviation. |
+| `devague deviate --list [--json]` | Read every recorded deviation back (also the default action with no positional/flag). |
+| `devague deviate ... --plan <slug>` | Target a plan other than the current one. |
+
+`--reason` is required on every record — omitting it is refused with a hint.
+`--task` naming the plan item ref is likewise required.
+
+## Hard rules (do not violate)
+
+- **Never record a deviation the human did not approve.** `devague deviate`
+  without `--origin llm` auto-approves the instant it is run — so a
+  user-origin record IS the approval. Only run it after the human has said
+  yes to this specific departure, never preemptively "to be safe."
+- **Never continue past a refused approval.** If the human does not approve,
+  the run stays stopped on that task. Do not record the deviation anyway, do
+  not quietly implement the diverging approach, and do not advance the wave.
+- **LLM-origin records stay proposed until the user confirms.** `--origin
+  llm` lands `proposed`; only `devague deviate --confirm <dN>` (user-only)
+  makes it `approved`. Same anti-fabrication contract as every other origin
+  in the method — an agent's own proposal never self-confirms.
+- **Deviations are never silently folded into drift after the fact.** Every
+  departure from the confirmed plan gets a `dN` record at the moment it
+  happens — not reconstructed from memory when `/summarize-delivery` runs
+  later.
+- **The CLI stays non-orchestrating (issue #20).** `devague deviate` records
+  a decision the human already made; it does not spawn agents, gate merges,
+  mark tasks done, or make the approval decision itself. Recording is
+  deterministic — no LLM calls inside the CLI.
+- **This is not a fourth standing gate.** `/assign-to-workforce`'s three
+  human gates are the exported spec, the implementation split plan, and the
+  final PR. `/deviate` does not add a fourth — it is the human owner of gate
+  2 amending the approved split for one scoped, in-flight decision.
+
+## Worked example
+
+Mid-fan-out on task `t4`, the task agent discovers the acceptance criteria
+assumed a helper that task `t2` never actually shipped:
+
+```bash
+# 1. STOP — the main agent halts t4's worktree before more code lands
+#    against a criterion that can't be met as written.
+
+# 2. Present what/why/what-it-affects to the human:
+#    what:    t4's acceptance criterion 2 assumes a `--json` flag on a
+#             helper that t2 shipped without one
+#    why:     t2's scope was cut to land its wave on time
+#    affects: t4 (this task), and coverage target c9 (the criterion in
+#             question)
+
+# --- HUMAN: approves dropping the --json assumption from t4's criterion ---
+
+# 3. Record the approved deviation
+devague deviate "drop the --json assumption from t4's acceptance criterion" \
+  --task t4 --reason "t2 shipped its helper without --json to land its wave on time" \
+  --affects t2 --affects c9 --classification acceptable
+
+# 4. Adjust t4's working brief to match what was approved, then resume the
+#    task agent against the corrected instruction.
+
+# Read the ledger back at any point:
+devague deviate --list
+devague deviate --list --json
+```
+
+If the agent had proposed the record itself (`--origin llm`), the same
+record would land `proposed` and need an explicit
+`devague deviate --confirm d1` from the user before `/summarize-delivery`
+could cite it as approved.
+
+## After recording — resume, then hand off to /summarize-delivery
+
+Once the affected task briefs are adjusted and the fan-out resumes, nothing
+further is needed from this skill — the record already lives in the delivery
+store. When the run reaches `/summarize-delivery`, that skill's Drift From
+Plan and Mid-work Decisions sections quote these records by their `dN` id
+instead of reconstructing drift from memory, so the connective tissue between
+the confirmed plan and the delivery summary is the ledger this skill wrote,
+not anyone's recollection of the run.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, the
+*sixth* in the outbound family after `/scope`, `/think`, `/spec-to-plan`,
+`/assign-to-workforce`, and `/summarize-delivery`, covering the execution-time
+leg that runs inside an `/assign-to-workforce` fan-out. guildmaster pulls it
+from here and broadcasts it to the AgentCulture mesh; because devague is
+upstream, it is **never re-vendored back** from guildmaster's re-broadcast
+copy. The `cite, don't import` policy still holds: downstream repos copy it,
+they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/summarize-delivery/SKILL.md
+++ b/.claude/skills/summarize-delivery/SKILL.md
@@ -20,13 +20,23 @@ type: command
 # summarize-delivery — turn a workforce run into an accountability artifact
 
 The skill is named **`summarize-delivery`**; it is the **delivery-side closure
-leg** of the devague method — the *fifth* leg, run *after* the sibling
-**`/assign-to-workforce`** skill has executed (or attempted to execute) a
-converged plan. Where `/assign-to-workforce` takes the plan to delivery, this
-skill *summarizes* that delivery: it separates what was **planned** from what
-was **actually delivered**, records the **mid-work decisions** and **plan
-drift** the execution produced, states **delivery claims** with evidence and
-confidence, and names the **remaining work**.
+leg** that closes the devague method's six-leg flow:
+
+```text
+scope -> think -> spec-to-plan -> assign-to-workforce -> deviate -> summarize-delivery
+```
+
+It runs *after* the sibling **`/assign-to-workforce`** skill has executed (or
+attempted to execute) a converged plan — and after any **`/deviate`** records
+that run produced, since `/deviate` slots in **between**
+`/assign-to-workforce` and this skill, recording approved mid-run departures
+the moment they happen during the fan-out. Where `/assign-to-workforce` takes
+the plan to delivery, this skill *summarizes* that delivery: it separates
+what was **planned** from what was **actually delivered**, records the
+**mid-work decisions** and **plan drift** the execution produced — quoting
+`/deviate`'s approved `dN` records as the recorded ground truth wherever they
+cover an item — states **delivery claims** with evidence and confidence, and
+names the **remaining work**.
 
 The plan the user confirmed is a **contract, not a fiction**. Agents make
 mid-work decisions, hit constraints, cut scope, and produce delivery claims
@@ -70,16 +80,30 @@ directly (if `devague` isn't on your PATH: `uv tool install devague`).
 
 ## The method
 
-1. **Establish the planned-work baseline — verbatim.** Read the plan the run
-   executed. When the run was devague-driven, the baseline is the plan's tasks,
-   acceptance criteria, and waves, available read-only via
-   `` `devague plan show [--json]` `` and `` `devague plan waves --json` `` —
-   the same enriched payload `/assign-to-workforce` fans out, keyed by task id
-   with each task's `summary`, `instruction`, `acceptance_criteria`, and
-   `covers`. Quote task ids and summaries **verbatim** into the Planned Work
-   section — mirroring the verbatim-brief rule in `/assign-to-workforce`. Drift
-   is then measured against the contract the user confirmed, never against a
-   paraphrase.
+1. **Establish the planned-work baseline — verbatim, starting from the
+   skeleton.** Run `devague summary [--plan <slug>] [--json]` first. It
+   renders the eight-section template pre-filled, verbatim, from the plan's
+   tasks, the plan's live source frame, and the delivery (deviation) store —
+   with `<fill: ...>` placeholders standing in for everything
+   execution-dependent (run status, per-task delivery status, evidence,
+   delivery claims). Continue filling in that skeleton rather than retyping
+   it from scratch — fewer transcription errors, same verbatim-baseline rule.
+   **Fall back to hand-assembly** when `devague summary` isn't available at
+   all — the verb is missing (an older devague predates the command) or the
+   underlying state it needs can't be read (no current plan, or a delivery
+   record written by a newer devague) — by reconstructing the baseline
+   read-only via `` `devague plan show [--json]` `` and
+   `` `devague plan waves --json` ``, the same enriched payload
+   `/assign-to-workforce` fans out, keyed by task id with each task's
+   `summary`, `instruction`, `acceptance_criteria`, and `covers`. If no plan
+   state exists at all, degrade further still (see "Degrading when there is
+   no plan state"). **Whichever path was taken, say so in the artifact's
+   `baseline:` line** — one of `` `devague summary skeleton` ``,
+   `` `devague plan (hand-assembled)` ``, or
+   `` `git+PR history (no plan state)` ``. Quote task ids and summaries
+   **verbatim** into the Planned Work section either way — mirroring the
+   verbatim-brief rule in `/assign-to-workforce`. Drift is then measured
+   against the contract the user confirmed, never against a paraphrase.
 2. **Establish actual delivery.** Reconcile the baseline against what merged:
    the merged branches, commits, and PRs of the run. **Every** plan task must
    be accounted for as **delivered / partial / dropped / blocked**, keyed by
@@ -118,7 +142,7 @@ is still a valid input).
 # Delivery Summary — <plan title>
 
 plan: `<slug>` · run: `<complete | partial | failed>` · date: `<created-date>`
-baseline: `<devague plan | git+PR history (no plan state)>`
+baseline: `<devague summary skeleton | devague plan (hand-assembled) | git+PR history (no plan state)>`
 
 ## Intent
 
@@ -126,9 +150,10 @@ baseline: `<devague plan | git+PR history (no plan state)>`
 
 ## Planned Work
 
-<The plan's tasks, quoted VERBATIM from `devague plan waves --json` — task id
-and summary, never paraphrased. When no plan state exists, quote the git/PR
-baseline instead and SAY SO here.>
+<The plan's tasks, quoted VERBATIM from the `devague summary` skeleton (or,
+when hand-assembling, `devague plan waves --json`) — task id and summary,
+never paraphrased. When no plan state exists, quote the git/PR baseline
+instead and SAY SO here.>
 
 - `t1` — <task summary, verbatim>
 - `t2` — <task summary, verbatim>
@@ -148,21 +173,28 @@ delivered / partial / dropped / blocked.>
 ## Mid-work Decisions
 
 <Constraints discovered, scope cuts, and choices made during execution that
-were not in the plan. One per bullet.>
+were not in the plan. When a delivery store exists for this plan, quote each
+approved deviation by its `dN` id — the record is the decision, consumed here,
+not re-litigated. A decision no record covers is still captured directly. One
+per bullet.>
 
-- <decision> — <why it was made>
+- `d2` — <what deviated, from the record> — <the record's reason>
+- <decision not covered by any deviation record> — <why it was made>
 
 ## Drift From Plan
 
 <Every plan task whose delivery differs from its contract. Exhaustive relative
-to the plan. Each entry: the plan item, the reason, and exactly one of
-acceptable / risky / needs-follow-up. If nothing drifted, state "no drift"
-and back it with the task-by-task accounting above.>
+to the plan. When a delivery store exists, an entry covered by an approved
+deviation names the plan item as `` `tN` (`dN`) `` and inherits that record's
+reason and classification verbatim. Drift NOT covered by any record is still
+recorded here exhaustively, exactly as before — never silently normalized. If
+nothing drifted, state "no drift" and back it with the task-by-task accounting
+above.>
 
 | Plan item | Reason for divergence | Classification |
 |-----------|-----------------------|----------------|
-| `t2` | <what changed vs. the confirmed task> | needs-follow-up |
-| `t3` | <what changed vs. the confirmed task> | risky |
+| `t2` (`d2`) | <quoted from the `d2` record's reason> | needs-follow-up |
+| `t3` | <what changed vs. the confirmed task — no record covers this> | risky |
 
 ## Evidence
 
@@ -218,18 +250,34 @@ Every Drift From Plan entry names three things:
   `risky` (may cause a problem; flag it), or `needs-follow-up` (leaves work
   the plan assumed done).
 
+When a delivery store exists and an approved `devague deviate` record covers
+the item, cite it by its `dN` id and inherit its reason and classification
+verbatim — the record is the recorded ground truth, not something this skill
+re-derives. An item no record covers still gets an entry here, worked out the
+same way as before.
+
 ## Degrading when there is no plan state
 
 The summary is producible from **durable** inputs — plan state, git history, PR
-links, test output — and never depends on unrecorded memory of the run. When
-the run was devague-driven, the plan (tasks, acceptance criteria, waves) and
-the exported plan-md are the planned-work baseline.
+links, test output — and never depends on unrecorded memory of the run. There
+are three tiers, most to least mechanical, and the artifact's `baseline:` line
+names which one applied:
 
-**When no devague plan state exists, degrade to git history and PR history as
-the planned-work baseline — and SAY SO in the artifact** (in the `baseline:`
-line and the Planned Work section). The delivery summary is still a valid
-accountability artifact; it just names its baseline honestly instead of
-pretending a plan existed.
+1. **`devague summary` skeleton** — the plan (and, if any, its delivery
+   record) can both be read; the render is fully mechanical.
+   `baseline: devague summary skeleton`.
+2. **Hand-assembly** — `devague summary` isn't available (the verb is missing,
+   or the state it needs can't be read) but the plan itself can still be read:
+   reconstruct the baseline read-only via `devague plan show [--json]` and
+   `devague plan waves --json`. `baseline: devague plan (hand-assembled)`.
+3. **Git + PR history** — no devague plan state exists at all: degrade to git
+   history and PR history as the planned-work baseline.
+   `baseline: git+PR history (no plan state)`.
+
+**Whichever tier applied, SAY SO in the artifact** (in the `baseline:` line
+and the Planned Work section). The delivery summary is still a valid
+accountability artifact either way; it just names its baseline honestly
+instead of pretending a more mechanical path was used.
 
 ## The only devague moves this skill uses — all read-only
 
@@ -238,8 +286,10 @@ it documents is read-only:
 
 | Move | What it reads |
 |------|---------------|
-| `devague plan show [--json]` | The plan's tasks, acceptance criteria, dependencies. |
-| `devague plan waves --json` | The wave batches + per-task `summary` / `instruction` / `acceptance_criteria` / `covers`, keyed by id — the verbatim planned-work baseline. |
+| `devague summary [--pr] [--json]` | The eight-section delivery-summary skeleton (or condensed `--pr` skeleton), pre-filled verbatim from the plan's tasks, its live source frame, and the delivery (deviation) store — the primary planned-work baseline (Method step 1). |
+| `devague deviate --list [--json]` | Every recorded deviation, read back by `dN` id — the source Drift From Plan and Mid-work Decisions quote. Recording or confirming a deviation is `/deviate`'s job, never this skill's. |
+| `devague plan show [--json]` | The plan's tasks, acceptance criteria, dependencies — the hand-assembly fallback when `devague summary` (or the state it needs) is unavailable. |
+| `devague plan waves --json` | The wave batches + per-task `summary` / `instruction` / `acceptance_criteria` / `covers`, keyed by id — the hand-assembly fallback's verbatim planned-work baseline. |
 | `devague scope --list [--json]` | Recorded scope-exploration findings, if the frame carried any. |
 | `devague show [--json]` | A frame / plan rendered for reading. |
 | `devague status [--json]` | Where a frame stands (read-only next-move helper). |
@@ -264,8 +314,10 @@ These are the point of the method — a delivery summary must be trustworthy.
   `git log` to substantiate a claim before writing it. Verification **never**
   mutates code or state. A claim you cannot verify stays `unverified`.
 - **No devague state mutation.** The only devague moves this skill uses are the
-  read-only `plan show`, `plan waves`, `scope --list`, `show`, and `status`
-  (see the table above). Never run a mutating devague command, and never run
+  read-only `summary`, `deviate --list`, `plan show`, `plan waves`,
+  `scope --list`, `show`, and `status` (see the table above). `deviate --list`
+  is read-only — recording or confirming a deviation belongs to `/deviate`,
+  never this skill. Never run a mutating devague command, and never run
   `devague plan` inside a task worktree to "mark a task done" — that is
   `/assign-to-workforce`'s boundary too (#20).
 - **Account for 100 % of plan tasks.** Every plan task appears in Actual
@@ -273,20 +325,24 @@ These are the point of the method — a delivery summary must be trustworthy.
   Both the task count and the claim-evidence coverage are checkable by
   inspecting the artifact alone, with no hidden context.
 - **Quote the plan verbatim.** Planned Work quotes task ids and summaries
-  verbatim from `devague plan waves --json`. Drift is measured against the
-  confirmed contract, not a reworded version of it.
+  verbatim from the `devague summary` skeleton (or `devague plan waves --json`
+  when hand-assembling). Drift is measured against the confirmed contract, not
+  a reworded version of it.
 
 ## Worked example
 
-A **partial** run: three tasks were planned, two merged cleanly, and the third
-failed its post-merge TDD gate and was reverted. Every section is still
-writable — nothing about the failure makes the artifact unproducible.
+A **partial** run: three tasks were planned; `t1` merged cleanly, `t2` merged
+after an approved mid-run deviation, and `t3` failed its post-merge TDD gate
+and was reverted. Every section is still writable — nothing about the failure
+makes the artifact unproducible.
 
 ```bash
 # 1. Establish the planned-work baseline — read-only, quoted verbatim.
-devague plan waves --json      # -> {"plan": "widget-export", "waves": [...],
-                               #     "tasks": {"t1": {...}, "t2": {...}, "t3": {...}}}
-devague plan show              # human-readable plan for the Intent paragraph
+devague summary                # -> pre-filled eight-section skeleton, keyed by
+                               #     task id, `<fill: ...>` placeholders for
+                               #     everything execution-dependent
+devague deviate --list         # -> d1 (approved, acceptable): t2 dropped an
+                               #     assumed flag mid-run
 
 # 2. Establish actual delivery — read-only reconciliation.
 git log --oneline main~4..main   # what merged
@@ -300,7 +356,7 @@ The resulting `docs/deliveries/2026-07-09-widget-export.md`:
 # Delivery Summary — widget export
 
 plan: `widget-export` · run: `partial` · date: `2026-07-09`
-baseline: `devague plan (widget-export)`
+baseline: `devague summary skeleton`
 
 ## Intent
 
@@ -309,7 +365,7 @@ Ship the `widget export` command as three independent tasks fanned out by
 
 ## Planned Work
 
-Quoted verbatim from `devague plan waves --json`:
+Quoted verbatim from the `devague summary` skeleton:
 
 - `t1` — add the `export` verb to the CLI chassis
 - `t2` — implement the widget-md renderer
@@ -325,13 +381,18 @@ Quoted verbatim from `devague plan waves --json`:
 
 ## Mid-work Decisions
 
-- t2 renders an absent field as an empty line rather than filler — matches the
+- `d1` — dropped the `--verbose` flag from `t2`'s CLI surface — the plan
+  assumed it, but the renderer never needed a verbose mode (recorded via
+  `/deviate`, approved)
+- t2 also renders an absent field as an empty line rather than filler — no
+  deviation record covers this; captured here directly, matching the
   no-fabrication rule the plan assumed but did not spell out.
 
 ## Drift From Plan
 
 | Plan item | Reason for divergence | Classification |
 |-----------|-----------------------|----------------|
+| `t2` (`d1`) | dropped the `--verbose` flag — the plan assumed it, but the renderer never needed a verbose mode | acceptable |
 | `t3` | gate raised on an unconverged plan; reverted, not delivered | needs-follow-up |
 
 ## Evidence

--- a/.devague/current_plan
+++ b/.devague/current_plan
@@ -1,1 +1,1 @@
-summarize-delivery-skill
+execution-seam-and-deviate

--- a/.devague/deliveries/execution-seam-and-deviate.json
+++ b/.devague/deliveries/execution-seam-and-deviate.json
@@ -1,0 +1,20 @@
+{
+  "plan_slug": "execution-seam-and-deviate",
+  "schema_version": 1,
+  "created": "2026-07-14T21:34:58Z",
+  "updated": "2026-07-14T21:34:58Z",
+  "deviations": [
+    {
+      "id": "d1",
+      "what": "no PLAN_SCHEMA_VERSION bump shipped with depend --remove and amend",
+      "task_ref": "t1",
+      "reason": "cutting an edge or amending criteria mutates existing list fields \u2014 no persisted shape change, so the frame assumption c14 (conditional on a plan-JSON shape change) did not apply; deviation records live in their own store per resolved q3",
+      "affects": [
+        "c14"
+      ],
+      "origin": "llm",
+      "status": "proposed",
+      "classification": "acceptable"
+    }
+  ]
+}

--- a/.devague/deliveries/execution-seam-and-deviate.json
+++ b/.devague/deliveries/execution-seam-and-deviate.json
@@ -2,7 +2,7 @@
   "plan_slug": "execution-seam-and-deviate",
   "schema_version": 1,
   "created": "2026-07-14T21:34:58Z",
-  "updated": "2026-07-14T21:34:58Z",
+  "updated": "2026-07-14T22:19:30Z",
   "deviations": [
     {
       "id": "d1",
@@ -13,7 +13,7 @@
         "c14"
       ],
       "origin": "llm",
-      "status": "proposed",
+      "status": "approved",
       "classification": "acceptable"
     }
   ]

--- a/.devague/deliveries/execution-seam-and-deviate.json
+++ b/.devague/deliveries/execution-seam-and-deviate.json
@@ -2,7 +2,7 @@
   "plan_slug": "execution-seam-and-deviate",
   "schema_version": 1,
   "created": "2026-07-14T21:34:58Z",
-  "updated": "2026-07-14T22:19:30Z",
+  "updated": "2026-07-14T22:47:00Z",
   "deviations": [
     {
       "id": "d1",
@@ -13,6 +13,18 @@
         "c14"
       ],
       "origin": "llm",
+      "status": "approved",
+      "classification": "acceptable"
+    },
+    {
+      "id": "d2",
+      "what": "devague learn skills teaches authoring all six origin skills, not the original three",
+      "task_ref": "t11",
+      "reason": "user directive at the final PR gate: the skill-authoring recipe still taught only think, spec-to-plan, and assign-to-workforce \u2014 an agent following it would rebuild a three-legged kit while the shipped flow has six legs",
+      "affects": [
+        "devague learn skills recipe"
+      ],
+      "origin": "user",
       "status": "approved",
       "classification": "acceptable"
     }

--- a/.devague/frames/execution-seam-and-deviate.json
+++ b/.devague/frames/execution-seam-and-deviate.json
@@ -1,0 +1,491 @@
+{
+  "slug": "execution-seam-and-deviate",
+  "title": "execution seam and deviate",
+  "schema_version": 2,
+  "status": "exported",
+  "created": "2026-07-14T20:37:30Z",
+  "updated": "2026-07-14T20:57:39Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "devague closes the execution seam: a deliverables view answers what we have in the end at the go or no-go, the split plan renders the table humans actually approve, dependency edges can be removed without task recreation, and human-approved deviations become first-class records that connect the plan to the delivery summary",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "holds only if every leg the announcement names ships in the same release: deliverables view, four-column split-plan table, dependency-edge removal, the deviate move and skill, and the three evidence-based issue closures",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c2",
+      "kind": "requirement",
+      "text": "new read-only `devague plan deliverables` view (name pending q-decision) answers what exists once every task completes, synthesized only from existing state: the frames confirmed announcement, `after_state`, and `success_signal` claims, terminal tasks (tasks no active task depends on) with their acceptance criteria, and surviving parked vagueness; `--json` emits the same structured payload; no mutation, no LLM calls (issues 70 and 20)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "verifiable by inspection and test: the deliverables code path performs zero store writes and zero subprocess or network calls; a test renders the view twice and the state files stay byte-identical",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c3",
+      "kind": "requirement",
+      "text": "the assign-to-workforce split-plan presentation gains an End state section sourced from the deliverables view, and the skill doc gains one line telling the operator to include it at the go or no-go (issue 70)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "the End state section is produced by quoting the CLI deliverables output verbatim, never composed freehand by the operator; the skill doc names the exact move to run",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c4",
+      "kind": "requirement",
+      "text": "split-plan renders one markdown table with exactly the columns Wave, Task, Model, Task summary, ordered by wave then task id, real verbatim summaries (truncated when long), and an honest per-row model default instead of the constant cheaper/faster; the go or no-go prompt and the wave listing stay (issue 69)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "the rendered table matches the issue 69 ask verbatim: header Wave, Task, Model, Task summary; rows ordered by wave then task id; asserted by a script-level test",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c5",
+      "kind": "requirement",
+      "text": "a dependency edge can be removed without recreating tasks; smallest shape is a remove flag on `devague plan depend` (final shape pending q-decision), and removing an edge on a confirmed task flips it to proposed with the same visible note the instruct move prints (issue 68)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "after removing an edge the task keeps its summary, acceptance criteria, covers, and instruction unchanged, and converge no longer reports the removed edge; round-trip covered by a test",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "culture.yaml declares backend claude, the mesh standard; unblocked because agex-cli issue 46 is closed and devex 0.30.0 maps claude onto claude-code; the agex pr lane is re-verified after the edit (issue 66)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "agex pr open succeeds from this repo with backend claude in culture.yaml, verified live before the PR carrying the change merges",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c7",
+      "kind": "requirement",
+      "text": "new deterministic `devague deviate` move records a human-approved deviation from the confirmed plan at the moment it happens: the plan item it deviates from, the reason, what it affects, and the approval; llm-recorded deviations land proposed until the user confirms them, per the standing anti-fabrication contract",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "a deviate record without the explicit approval marker is refused; an llm-origin deviation lands proposed and never counts as approved until the user confirms it",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c8",
+      "kind": "requirement",
+      "text": "new sixth origin skill `/deviate`, the execution-time leg in the flow scope, think, spec-to-plan, assign-to-workforce, deviate, summarize: when execution must diverge from the plan it stops the run, gets explicit human approval, records the deviation via the CLI move, and adjusts the affected task briefs",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "the skill hard rules make the stop-and-get-approval step unskippable: no deviation is recorded that the human did not approve, mirroring the confirm-is-user-only contract",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c9",
+      "kind": "requirement",
+      "text": "the summarize-delivery skill consumes recorded deviations: its Drift From Plan and Mid-work Decisions sections quote deviation records verbatim instead of reconstructing drift from memory, making deviate records the connective tissue between the confirmed plan and the delivery summary",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "the summarize-delivery template names deviation record ids in its Drift From Plan rows, so every drift entry traces to a recorded, approved deviation whenever one exists",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c10",
+      "kind": "decision",
+      "text": "issue 67 is already fixed: plan instruct has warned on the confirmed-to-proposed flip since 0.16.0 (stderr note plus flipped true in JSON), verified empirically on 0.17.2; close it with the repro evidence (whether to also echo the flip on stdout is a pending question)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c11",
+      "kind": "decision",
+      "text": "issue 62 is already delivered: the summarize-delivery skill shipped in 0.17.0 meeting all six acceptance criteria, with the dogfood artifact docs/deliveries/2026-07-09-sharper-end-to-end-method.md; close it citing the release",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c12",
+      "kind": "boundary",
+      "text": "the CLI stays deterministic and non-orchestrating (issue 20): deliverables and deviate record and describe state; they never spawn agents, mark tasks done, gate merges, or call an LLM",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h10",
+          "text": "deliverables performs no mutation at all; deviate mutates only its own record; grepping the new code paths finds no agent spawning, no worktree management, no merge gating, and no LLM call",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c13",
+      "kind": "non_goal",
+      "text": "no full delivery engine in this release: the third structural peer parked in the summarize-delivery skill stays parked; deviate records are the smallest slice of execution-side state, and where they persist is a pending question",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c14",
+      "kind": "assumption",
+      "text": "persisting deviations or removable edges on the plan JSON bumps PLAN_SCHEMA_VERSION from 2 to 3; the 0.17.0 upgrade-on-write fix means older binaries refuse the newer file instead of silently dropping fields",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c15",
+      "kind": "audience",
+      "text": "devague operators (the main agent driving the CLI) and the humans at the go or no-go and final-PR gates",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "matches the three-reader model already shipped in the summarize-delivery skill: the operator, the human at the gates, and the later reader who never watched the run",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c16",
+      "kind": "after_state",
+      "text": "after this ships: the go or no-go presents what exists once every task completes, sourced from state alone; deviations from the confirmed plan are recorded with reason, impact, and human approval, and the delivery summary quotes them instead of reconstructing drift from memory; a wrong dependency edge costs one move to fix instead of a task-recreation cascade; and issues 62, 66, and 67 are closed with cited evidence",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "every element of the after state is checkable from committed artifacts: the view output, the deviation records, a passing edge-removal test, and the issue timelines",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c17",
+      "kind": "why_it_matters",
+      "text": "the plan is a contract: without an end-state view the human approves a workforce without seeing the world after the work; without recorded deviations the delivery summary rebuilds drift from unrecorded memory; without edge removal an honest one-word correction costs an unbounded rewrite of dependent tasks",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "each pain it names traces to a filed issue: 70 for the missing end-state view, 62 plus the deviate gap for drift-from-memory, 68 for the recreation cascade",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c18",
+      "kind": "success_signal",
+      "text": "6 of 6 bundled issues end closed (3 by shipped code, 3 by cited evidence); the deliverables and deviate code paths ship with 0 LLM calls and 0 orchestration, verified by inspection; test coverage stays at or above 95%",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h14",
+          "text": "the numbers are measurable as written: six of six issues closed on the tracker, zero LLM calls verified by inspection, coverage read from the CI gate at or above 95 percent",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c19",
+      "kind": "decision",
+      "text": "issue 68 ships as two explicit moves: a remove flag on `devague plan depend` to cut a single edge, plus a new `devague plan amend` move to edit a task summary and replace or remove acceptance criteria; reject does not auto-prune edges \u2014 every transition stays visible (resolves q1)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c20",
+      "kind": "decision",
+      "text": "the deliverables view ships as the read-only verb `devague plan deliverables` with `--json`, peer of waves and status; on an unconverged plan it renders with an explicit not-converged banner rather than refusing (resolves q2)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c21",
+      "kind": "decision",
+      "text": "deviation state lives in a new delivery store under `.devague/deliveries/` keyed by plan slug \u2014 the first deterministic slice of the parked delivery engine; the plan JSON stays byte-identical through execution (resolves q3)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c22",
+      "kind": "decision",
+      "text": "issue 67 closes with the repro evidence plus a one-line hardening: the stdout result line itself names the confirmed-to-proposed flip, because the report proves agent harnesses drop stderr (resolves q4)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c23",
+      "kind": "decision",
+      "text": "the split-plan table renders strictly Wave, Task, Model, Task summary; the wave-batch listing above it gains per-task has-instruction and acceptance-criteria-count markers (resolves q5)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c24",
+      "kind": "requirement",
+      "text": "new `devague plan amend` move edits a task summary and replaces or removes acceptance criteria; amending a confirmed task flips it to proposed with the visible re-confirm note (issue 68, resolved q1)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h15",
+          "text": "amend round-trips: the summary and criteria change exactly as asked, everything else on the task is untouched, and the flip note appears when the task was confirmed; covered by tests",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c25",
+      "kind": "requirement",
+      "text": "moves that demote a confirmed task (`instruct`, `amend`, `depend --remove`) name the confirmed-to-proposed flip on the stdout result line, not only on stderr and in JSON (issue 67 hardening, resolved q4)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h16",
+          "text": "a harness reading only stdout still sees the flip: asserted by a test that captures stdout alone",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c26",
+      "kind": "decision",
+      "text": "this release ships a render-only `devague summary` verb at the top level, pairing with `devague deviate` as the two execution-side verbs over the delivery store; the full delivery engine (delivery-record moves plus a no-overclaim gate) stays parked per the standing non-goal (resolves q6)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c27",
+      "kind": "requirement",
+      "text": "new deterministic `devague summary [--pr] [--json]` renders a wrap-up from existing state only: the eight-section delivery-summary skeleton pre-filled verbatim from the frame (announcement, after state), the plan (every task id and summary), and approved deviation records, with explicit fill-me placeholders for run status, per-task delivery status, evidence, and claims \u2014 nothing ever renders as done from state alone; `--pr` emits a condensed PR-body skeleton for the cicd lane; the summarize-delivery skill starts from this skeleton instead of hand-assembling the baseline (resolves q6)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h17",
+          "text": "the skeleton is deterministic and fabrication-free: rendering twice yields identical output, every pre-filled line traces verbatim to frame, plan, or deviation state, no placeholder ever renders as a completed claim, and the PR mode is covered by a stdout-only test",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    }
+  ],
+  "open_vagueness": [],
+  "scope_entries": [
+    {
+      "id": "s1",
+      "surface": "devague/plan.py + devague/plan_convergence.py",
+      "finding": "add_dep is append-only, no removal move exists anywhere in the plan verb set, reject does not prune inbound edges, and dependency_blockers reports depends-on-rejected as an integrity failure, so the issue 68 reject-and-recreate cascade is real; terminal tasks are computable from Task.deps alone, no new state needed",
+      "seeds": [
+        "c5",
+        "c14"
+      ]
+    },
+    {
+      "id": "s2",
+      "surface": "devague/cli/_commands/plan.py cmd_plan_instruct + scratchpad repro on 0.17.2",
+      "finding": "instruct already prints the flip note on stderr and emits flipped true in JSON, shipped in 0.16.0 commit 92c60ca; an end-to-end repro on 0.17.2 (converged frame, confirmed task, instruct) shows both streams, so issue 67 came from a harness that dropped stderr, not from current code",
+      "seeds": [
+        "c10"
+      ]
+    },
+    {
+      "id": "s3",
+      "surface": "devague/frame.py CLAIM_KINDS",
+      "finding": "announcement, after_state, and success_signal are first-class claim kinds already, so the deliverables view synthesizes from existing frame state with no schema change on the frame side",
+      "seeds": [
+        "c2"
+      ]
+    },
+    {
+      "id": "s4",
+      "surface": ".claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan",
+      "finding": "split-plan already renders verbatim task summaries from the enriched waves payload since 0.16.0 t13, so the placeholder half of issue 69 is fixed; the remaining delta is table shape: eight columns today with the model column hardcoded to cheaper/faster",
+      "seeds": [
+        "c3",
+        "c4"
+      ]
+    },
+    {
+      "id": "s5",
+      "surface": ".claude/skills/summarize-delivery/SKILL.md",
+      "finding": "all six issue 62 acceptance criteria are met by the shipped 0.17.0 skill; a future delivery engine is explicitly parked in the doc; the Drift From Plan and Mid-work Decisions sections are the natural consumers of recorded deviations",
+      "seeds": [
+        "c7",
+        "c8",
+        "c9",
+        "c11",
+        "c13"
+      ]
+    },
+    {
+      "id": "s6",
+      "surface": "culture.yaml + devex 0.30.0 core/backend.py + closed agex-cli issue 46",
+      "finding": "backend claude-code was a stopgap for an agex rejection that upstream has since fixed: devex 0.30.0 maps claude onto claude-code with an explicit comment naming the culture.yaml standard, so the mesh-standard value now works end to end",
+      "seeds": [
+        "c6"
+      ]
+    },
+    {
+      "id": "s7",
+      "surface": "issue 20 + CLAUDE.md non-orchestration boundary",
+      "finding": "the deterministic non-orchestrating contract covers both new moves cleanly: deliverables reads and renders, deviate records state the human approved; neither executes anything",
+      "seeds": [
+        "c12"
+      ]
+    }
+  ]
+}

--- a/.devague/plans/execution-seam-and-deviate.json
+++ b/.devague/plans/execution-seam-and-deviate.json
@@ -1,0 +1,419 @@
+{
+  "slug": "execution-seam-and-deviate",
+  "title": "execution seam and deviate",
+  "frame_slug": "execution-seam-and-deviate",
+  "schema_version": 2,
+  "status": "exported",
+  "created": "2026-07-14T21:05:46Z",
+  "updated": "2026-07-14T21:09:16Z",
+  "targets": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "devague closes the execution seam: a deliverables view answers what we have in the end at the go or no-go, the split plan renders the table humans actually approve, dependency edges can be removed without task recreation, and human-approved deviations become first-class records that connect the plan to the delivery summary"
+    },
+    {
+      "id": "h1",
+      "kind": "honesty",
+      "text": "holds only if every leg the announcement names ships in the same release: deliverables view, four-column split-plan table, dependency-edge removal, the deviate move and skill, and the three evidence-based issue closures"
+    },
+    {
+      "id": "c2",
+      "kind": "requirement",
+      "text": "new read-only `devague plan deliverables` view (name pending q-decision) answers what exists once every task completes, synthesized only from existing state: the frames confirmed announcement, `after_state`, and `success_signal` claims, terminal tasks (tasks no active task depends on) with their acceptance criteria, and surviving parked vagueness; `--json` emits the same structured payload; no mutation, no LLM calls (issues 70 and 20)"
+    },
+    {
+      "id": "h2",
+      "kind": "honesty",
+      "text": "verifiable by inspection and test: the deliverables code path performs zero store writes and zero subprocess or network calls; a test renders the view twice and the state files stay byte-identical"
+    },
+    {
+      "id": "c3",
+      "kind": "requirement",
+      "text": "the assign-to-workforce split-plan presentation gains an End state section sourced from the deliverables view, and the skill doc gains one line telling the operator to include it at the go or no-go (issue 70)"
+    },
+    {
+      "id": "h3",
+      "kind": "honesty",
+      "text": "the End state section is produced by quoting the CLI deliverables output verbatim, never composed freehand by the operator; the skill doc names the exact move to run"
+    },
+    {
+      "id": "c4",
+      "kind": "requirement",
+      "text": "split-plan renders one markdown table with exactly the columns Wave, Task, Model, Task summary, ordered by wave then task id, real verbatim summaries (truncated when long), and an honest per-row model default instead of the constant cheaper/faster; the go or no-go prompt and the wave listing stay (issue 69)"
+    },
+    {
+      "id": "h4",
+      "kind": "honesty",
+      "text": "the rendered table matches the issue 69 ask verbatim: header Wave, Task, Model, Task summary; rows ordered by wave then task id; asserted by a script-level test"
+    },
+    {
+      "id": "c5",
+      "kind": "requirement",
+      "text": "a dependency edge can be removed without recreating tasks; smallest shape is a remove flag on `devague plan depend` (final shape pending q-decision), and removing an edge on a confirmed task flips it to proposed with the same visible note the instruct move prints (issue 68)"
+    },
+    {
+      "id": "h5",
+      "kind": "honesty",
+      "text": "after removing an edge the task keeps its summary, acceptance criteria, covers, and instruction unchanged, and converge no longer reports the removed edge; round-trip covered by a test"
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "culture.yaml declares backend claude, the mesh standard; unblocked because agex-cli issue 46 is closed and devex 0.30.0 maps claude onto claude-code; the agex pr lane is re-verified after the edit (issue 66)"
+    },
+    {
+      "id": "h6",
+      "kind": "honesty",
+      "text": "agex pr open succeeds from this repo with backend claude in culture.yaml, verified live before the PR carrying the change merges"
+    },
+    {
+      "id": "c7",
+      "kind": "requirement",
+      "text": "new deterministic `devague deviate` move records a human-approved deviation from the confirmed plan at the moment it happens: the plan item it deviates from, the reason, what it affects, and the approval; llm-recorded deviations land proposed until the user confirms them, per the standing anti-fabrication contract"
+    },
+    {
+      "id": "h7",
+      "kind": "honesty",
+      "text": "a deviate record without the explicit approval marker is refused; an llm-origin deviation lands proposed and never counts as approved until the user confirms it"
+    },
+    {
+      "id": "c8",
+      "kind": "requirement",
+      "text": "new sixth origin skill `/deviate`, the execution-time leg in the flow scope, think, spec-to-plan, assign-to-workforce, deviate, summarize: when execution must diverge from the plan it stops the run, gets explicit human approval, records the deviation via the CLI move, and adjusts the affected task briefs"
+    },
+    {
+      "id": "h8",
+      "kind": "honesty",
+      "text": "the skill hard rules make the stop-and-get-approval step unskippable: no deviation is recorded that the human did not approve, mirroring the confirm-is-user-only contract"
+    },
+    {
+      "id": "c9",
+      "kind": "requirement",
+      "text": "the summarize-delivery skill consumes recorded deviations: its Drift From Plan and Mid-work Decisions sections quote deviation records verbatim instead of reconstructing drift from memory, making deviate records the connective tissue between the confirmed plan and the delivery summary"
+    },
+    {
+      "id": "h9",
+      "kind": "honesty",
+      "text": "the summarize-delivery template names deviation record ids in its Drift From Plan rows, so every drift entry traces to a recorded, approved deviation whenever one exists"
+    },
+    {
+      "id": "c12",
+      "kind": "boundary",
+      "text": "the CLI stays deterministic and non-orchestrating (issue 20): deliverables and deviate record and describe state; they never spawn agents, mark tasks done, gate merges, or call an LLM"
+    },
+    {
+      "id": "h10",
+      "kind": "honesty",
+      "text": "deliverables performs no mutation at all; deviate mutates only its own record; grepping the new code paths finds no agent spawning, no worktree management, no merge gating, and no LLM call"
+    },
+    {
+      "id": "c15",
+      "kind": "audience",
+      "text": "devague operators (the main agent driving the CLI) and the humans at the go or no-go and final-PR gates"
+    },
+    {
+      "id": "h11",
+      "kind": "honesty",
+      "text": "matches the three-reader model already shipped in the summarize-delivery skill: the operator, the human at the gates, and the later reader who never watched the run"
+    },
+    {
+      "id": "c16",
+      "kind": "after_state",
+      "text": "after this ships: the go or no-go presents what exists once every task completes, sourced from state alone; deviations from the confirmed plan are recorded with reason, impact, and human approval, and the delivery summary quotes them instead of reconstructing drift from memory; a wrong dependency edge costs one move to fix instead of a task-recreation cascade; and issues 62, 66, and 67 are closed with cited evidence"
+    },
+    {
+      "id": "h12",
+      "kind": "honesty",
+      "text": "every element of the after state is checkable from committed artifacts: the view output, the deviation records, a passing edge-removal test, and the issue timelines"
+    },
+    {
+      "id": "c17",
+      "kind": "why_it_matters",
+      "text": "the plan is a contract: without an end-state view the human approves a workforce without seeing the world after the work; without recorded deviations the delivery summary rebuilds drift from unrecorded memory; without edge removal an honest one-word correction costs an unbounded rewrite of dependent tasks"
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "each pain it names traces to a filed issue: 70 for the missing end-state view, 62 plus the deviate gap for drift-from-memory, 68 for the recreation cascade"
+    },
+    {
+      "id": "c18",
+      "kind": "success_signal",
+      "text": "6 of 6 bundled issues end closed (3 by shipped code, 3 by cited evidence); the deliverables and deviate code paths ship with 0 LLM calls and 0 orchestration, verified by inspection; test coverage stays at or above 95%"
+    },
+    {
+      "id": "h14",
+      "kind": "honesty",
+      "text": "the numbers are measurable as written: six of six issues closed on the tracker, zero LLM calls verified by inspection, coverage read from the CI gate at or above 95 percent"
+    },
+    {
+      "id": "c24",
+      "kind": "requirement",
+      "text": "new `devague plan amend` move edits a task summary and replaces or removes acceptance criteria; amending a confirmed task flips it to proposed with the visible re-confirm note (issue 68, resolved q1)"
+    },
+    {
+      "id": "h15",
+      "kind": "honesty",
+      "text": "amend round-trips: the summary and criteria change exactly as asked, everything else on the task is untouched, and the flip note appears when the task was confirmed; covered by tests"
+    },
+    {
+      "id": "c25",
+      "kind": "requirement",
+      "text": "moves that demote a confirmed task (`instruct`, `amend`, `depend --remove`) name the confirmed-to-proposed flip on the stdout result line, not only on stderr and in JSON (issue 67 hardening, resolved q4)"
+    },
+    {
+      "id": "h16",
+      "kind": "honesty",
+      "text": "a harness reading only stdout still sees the flip: asserted by a test that captures stdout alone"
+    },
+    {
+      "id": "c27",
+      "kind": "requirement",
+      "text": "new deterministic `devague summary [--pr] [--json]` renders a wrap-up from existing state only: the eight-section delivery-summary skeleton pre-filled verbatim from the frame (announcement, after state), the plan (every task id and summary), and approved deviation records, with explicit fill-me placeholders for run status, per-task delivery status, evidence, and claims \u2014 nothing ever renders as done from state alone; `--pr` emits a condensed PR-body skeleton for the cicd lane; the summarize-delivery skill starts from this skeleton instead of hand-assembling the baseline (resolves q6)"
+    },
+    {
+      "id": "h17",
+      "kind": "honesty",
+      "text": "the skeleton is deterministic and fabrication-free: rendering twice yields identical output, every pre-filled line traces verbatim to frame, plan, or deviation state, no placeholder ever renders as a completed claim, and the PR mode is covered by a stdout-only test"
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "plan-engine escape hatches and demotion visibility: `depend --remove`, new `amend` move, stdout flip echo",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "depend remove cuts exactly the named edge; the task keeps summary, acceptance criteria, covers, and instruction unchanged (round-trip test)",
+        "amend edits the summary and replaces or removes acceptance criteria by index without touching deps, covers, or instruction",
+        "each demoting move (`instruct`, `amend`, `depend --remove`) on a confirmed task flips it to proposed and names the flip in the stdout result line, asserted by a test that captures stdout alone",
+        "converge stops reporting a removed edge; `--json` payloads carry the flipped field"
+      ],
+      "deps": [],
+      "covers": [
+        "c5",
+        "h5",
+        "c24",
+        "h15",
+        "c25",
+        "h16"
+      ],
+      "instruction": "OWNS: devague/plan.py, devague/cli/_commands/plan.py, tests/test_plan_escape_hatches.py (new). Add Plan.remove_dep and an amend transition (summary edit; acceptance-criteria replace/remove by index). CLI: `depend <tN> --on <tM> --remove` cuts one edge; new `amend <tN> [--summary \"<text>\"] [--accept-replace <n> \"<text>\"] [--accept-remove <n>]`. Any demoting change (instruct, amend, depend remove) on a confirmed task flips it to proposed AND appends the flip to the stdout result line, e.g. `t1: instruction set (confirmed -> proposed; re-confirm)`; keep the stderr note and the flipped field in `--json`. TDD: write the stdout-only capture test first."
+    },
+    {
+      "id": "t2",
+      "summary": "read-only `devague plan deliverables` view with `--json` and not-converged banner",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "on a converged plan, prints the confirmed announcement, after_state, and success_signal claims verbatim, terminal tasks with their acceptance criteria, and surviving parked items",
+        "on an unconverged plan it renders with an explicit not-converged banner and converged false in `--json` \u2014 it never refuses",
+        "two consecutive renders leave .devague/ byte-identical (read-only proof)"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c2",
+        "h2"
+      ],
+      "instruction": "OWNS: devague/render/deliverables_md.py (new), devague/cli/_commands/plan.py (registration only), devague/plan.py (terminal-task helper), tests/test_plan_deliverables.py (new). Terminal tasks = active tasks no other active task depends on. Render from the live source frame: confirmed announcement / after_state / success_signal verbatim; terminal tasks with acceptance criteria; surviving frame parked vagueness plus non-blocking plan risks. Banner line when the plan has not converged; `--json` mirrors with a converged flag. Reuse the _md_safety helpers."
+    },
+    {
+      "id": "t3",
+      "summary": "delivery store and the `devague deviate` move",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "a deviate record persists under `.devague/deliveries/<plan-slug>.json` with its own schema_version, fail-closed load, and upgrade-on-write",
+        "llm-origin deviations land proposed; only user confirm marks them approved; user-origin records auto-approve; a record without a reason is refused with a hint",
+        "the plan JSON is byte-identical before and after every deviate operation (test-asserted)"
+      ],
+      "deps": [],
+      "covers": [
+        "c7",
+        "h7",
+        "c12",
+        "h10"
+      ],
+      "instruction": "OWNS: devague/delivery.py (new), devague/delivery_store.py (new), devague/cli/_commands/deviate.py (new), devague/cli/__init__.py (registration), tests/test_deviate.py (new). Store mirrors plan_store incl. the 0.17.0 version-stamping fix. Record `dN`: plan item ref, reason, affects (repeatable), origin, status proposed/approved/rejected, optional classification acceptable/risky/needs-follow-up (feeds the drift entry contract). CLI: `devague deviate \"<what>\" --task <tN> --reason \"<text>\" [--affects <ref> ...] [--classification <kind>] [--origin llm]`; `--confirm <dN>` / `--reject <dN>` are user-only; `--list [--json]` reads back."
+    },
+    {
+      "id": "t4",
+      "summary": "render-only `devague summary` verb with `--pr` PR-body mode",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "renders all eight sections: Intent and Planned Work pre-filled verbatim from frame and plan; Actual Delivery one row per task with explicit fill placeholders; drift and mid-work sections quote approved deviation ids",
+        "no placeholder ever renders as a completed claim; the run status stays a placeholder; two renders are byte-identical and state is untouched",
+        "`--pr` emits the condensed PR-body skeleton, asserted by a stdout-only test; output is markdownlint-safe"
+      ],
+      "deps": [
+        "t3"
+      ],
+      "covers": [
+        "c27",
+        "h17"
+      ],
+      "instruction": "OWNS: devague/render/summary_md.py (new), devague/cli/_commands/summary.py (new), devague/cli/__init__.py (registration), tests/test_summary.py (new). Eight-section skeleton from state only: Intent quotes the frame announcement and after_state; Planned Work lists every task id and summary verbatim; Actual Delivery emits one row per task with `<fill: status>` and `<fill: what landed>` placeholders (backtick-safe); Mid-work Decisions and Drift From Plan pre-seed from approved deviation records by id; Evidence, Delivery Claims, Remaining Work stay placeholders; run status renders as the `<complete | partial | failed>` placeholder. `--pr` renders title, announcement, wave and task map, approved deviations, and a pointer to the docs/deliveries artifact. Reuse _md_safety."
+    },
+    {
+      "id": "t5",
+      "summary": "split-plan renders the four-column table with wave-listing markers",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "split-plan prints exactly one per-task table with header Wave, Task, Model, Task summary, rows ordered by wave then task id",
+        "the summary cell is the real task summary from the waves payload, truncated with an ellipsis when long \u2014 never a placeholder; the model cell defaults to sonnet per row",
+        "the wave listing shows has-instruction and acceptance-count markers; the go or no-go prompt stays; a pytest drives the script end to end against a fixture plan"
+      ],
+      "deps": [],
+      "covers": [
+        "c4",
+        "h4"
+      ],
+      "instruction": "OWNS: .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh, tests/test_assign_to_workforce_script.py (new). Reshape the per-task table to exactly Wave, Task, Model, Task summary; model default sonnet (presentation only \u2014 the CLI stays model-agnostic per issue 20); truncate summaries past 72 chars with an ellipsis. Move the has-instruction marker and acceptance-criteria count into the wave-batch listing lines. Keep the go or no-go prompt and the fan-out steps."
+    },
+    {
+      "id": "t6",
+      "summary": "split-plan End state section quoting `plan deliverables`",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "split-plan output ends with an End state section that is the verbatim output of `devague plan deliverables`",
+        "with an older devague lacking the verb, the section degrades to a one-line hint naming the minimum version instead of failing",
+        "SKILL.md tells the operator to present the deliverables view at the go or no-go"
+      ],
+      "deps": [
+        "t2",
+        "t5"
+      ],
+      "covers": [
+        "c3",
+        "h3"
+      ],
+      "instruction": "OWNS: .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh (End state addition), .claude/skills/assign-to-workforce/SKILL.md. After the table, print an End state section produced by running `devague plan deliverables` and quoting its output verbatim \u2014 never composed freehand. Degrade gracefully on older devague versions (portable mesh script). Extend the t5 script test."
+    },
+    {
+      "id": "t7",
+      "summary": "new sixth origin skill `/deviate`",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "the skill file exists with type command frontmatter and the stop, approve, record, adjust, resume method",
+        "hard rules forbid recording an unapproved deviation and continuing past a refused approval",
+        "docs/skill-sources.md registers deviate as the sixth origin skill; markdownlint passes"
+      ],
+      "deps": [
+        "t3"
+      ],
+      "covers": [
+        "c8",
+        "h8"
+      ],
+      "instruction": "OWNS: .claude/skills/deviate/SKILL.md (new), docs/skill-sources.md. Model the doc on scope and summarize-delivery at their birth: method-first, `type: command` frontmatter (the culture-backend gotcha), origin devague, guildmaster re-broadcasts. Method: when execution must diverge from the confirmed plan, STOP the run; present what, why, and what it affects (tasks, coverage targets, acceptance criteria); get explicit human approval; record via `devague deviate` (llm origin lands proposed, the user confirms); adjust the affected task briefs; resume. Deviations are never silently folded into drift after the fact."
+    },
+    {
+      "id": "t8",
+      "summary": "summarize-delivery consumes deviation records and the summary skeleton",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "the baseline step starts from the `devague summary` skeleton and degrades loudly to hand-assembly when the verb or store is absent",
+        "Drift From Plan and Mid-work Decisions quote approved deviation record ids when a delivery store exists",
+        "the read-only moves table lists `devague summary` and `devague deviate --list`; markdownlint passes"
+      ],
+      "deps": [
+        "t3",
+        "t4"
+      ],
+      "covers": [
+        "c9",
+        "h9"
+      ],
+      "instruction": "OWNS: .claude/skills/summarize-delivery/SKILL.md. Method step 1 becomes: start from the `devague summary` skeleton, falling back to hand-assembly from `plan show` / `plan waves --json` when the verb or store is absent \u2014 and say so in the baseline line. Drift and mid-work sections reference approved deviation records by `dN` id. Hard rules unchanged; the no-overclaim contract stays intact."
+    },
+    {
+      "id": "t9",
+      "summary": "culture.yaml backend reverts to claude with live agex verification",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "culture.yaml declares backend claude; no other file changes in this task",
+        "`agex pr open` succeeds live from this repo before the release PR merges, recorded in the PR body"
+      ],
+      "deps": [],
+      "covers": [
+        "c6",
+        "h6"
+      ],
+      "instruction": "OWNS: culture.yaml. One-line change: backend claude-code becomes claude (the mesh standard). devex 0.30.0 maps claude onto claude-code (agex-cli issue 46, closed), so the cicd lane keeps working. Verification is live: the release PR opened via `agex pr open` IS the test \u2014 record the result in the PR body. Leave .claude/skills/cicd/scripts/workflow.sh alone: its claude-code default is agex-internal vocabulary."
+    },
+    {
+      "id": "t10",
+      "summary": "close issues 62 and 67 with cited evidence",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "issue 67 is closed with the 0.17.2 repro transcript (stderr note plus flipped true in `--json`, shipped 0.16.0 commit 92c60ca) and a pointer to the stdout-echo hardening in this release",
+        "issue 62 is closed citing 0.17.0 (#63) and docs/deliveries/2026-07-09-sharper-end-to-end-method.md; both comments signed per convention"
+      ],
+      "deps": [],
+      "covers": [
+        "c17",
+        "h13"
+      ],
+      "instruction": "No repo files. Use gh issue comment + close (or the communicate skill). Sign as - devague (Claude). The 67 comment should paste the actual stdout/stderr split from the repro so the already-fixed claim is checkable."
+    },
+    {
+      "id": "t11",
+      "summary": "release closure: version bump, changelog, docs, coverage and boundary audit",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "version bumped to 0.18.0 with a CHANGELOG entry naming every leg of the release",
+        "CLAUDE.md and README name the six-leg flow and the new verbs; the audience (operators driving the CLI, humans at the go or no-go and final-PR gates) is named",
+        "`uv run pytest -n auto` is green with coverage at or above 95 percent",
+        "the boundary audit finds no subprocess, network, or LLM call in the deliverables, deviate, or summary code paths"
+      ],
+      "deps": [
+        "t1",
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7",
+        "t8",
+        "t9",
+        "t10"
+      ],
+      "covers": [
+        "c1",
+        "h1",
+        "c15",
+        "h11",
+        "c16",
+        "h12",
+        "c18",
+        "h14"
+      ],
+      "instruction": "OWNS: pyproject.toml, CHANGELOG.md, CLAUDE.md, README.md, docs/skills.md. Bump minor via /version-bump; the CHANGELOG entry names: deliverables view, four-column split plan plus End state, depend remove plus amend plus stdout flip echo, deviate move plus skill plus delivery store, summary verb plus `--pr`, culture.yaml revert, and the two evidence-based closures. Docs name the six-leg flow scope, think, spec-to-plan, assign-to-workforce, deviate, summarize-delivery."
+    }
+  ],
+  "risks": [
+    {
+      "id": "r1",
+      "text": "the live agex pr verification can only run at PR-open time outside any task worktree \u2014 the release PR itself is the test vehicle",
+      "kind": "unknown_nonblocking",
+      "task_id": "t9"
+    },
+    {
+      "id": "r2",
+      "text": "the v1 deviate record shape beyond the specced fields (classification, timestamps) is fixed by instruction rather than spec \u2014 dogfooding may revise it in a follow-up",
+      "kind": "unknown_nonblocking",
+      "task_id": "t3"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-07-15
+
+The execution seam and deviate — devague#53's follow-on plan
+(execution-seam-and-deviate, tasks t1–t11), implemented by a
+devague-orchestrated workforce fan-out. Adds a sixth origin skill and closes
+the loop between the confirmed plan and what the workforce actually produces
+and does mid-run.
+
+### Added
+
+- **`devague plan deliverables [--json]`** — a read-only "end state" view over
+  a plan: the confirmed announcement / after-state / success-signal claims
+  verbatim from the plan's live source frame, every terminal task (an active
+  task no other active task depends on) with its acceptance criteria, and the
+  surviving open items (parked/pending). Never refuses — shows a
+  not-converged banner instead of gating — because previewing the end state is
+  exactly what's useful before convergence (#70, esd t2).
+- **`devague deviate`** — first-class, append-only deviation records in a new
+  delivery store, `.devague/deliveries/<plan-slug>.json`
+  (`DELIVERY_SCHEMA_VERSION` 1, fail-closed load, upgrade-on-write like the
+  frame/plan stores). `--origin llm` lands `proposed`; only the user
+  `--confirm`/`--reject`s a proposed record — the same anti-fabrication rule as
+  claims and tasks. `devague deviate --list [--json]` reads records back by
+  `dN` id (esd t3).
+- **New sixth origin skill `/deviate`** (`.claude/skills/deviate/SKILL.md`) —
+  the execution-time leg: stop an in-flight `/assign-to-workforce` run the
+  moment execution must diverge from the confirmed plan, get explicit human
+  approval, and record the divergence via `devague deviate` before resuming —
+  never fold a deviation silently into drift after the fact. Registered in
+  `docs/skill-sources.md` alongside the other five origin skills (esd t7).
+- **`devague summary [--pr] [--json]`** — a render-only, eight-section
+  delivery-summary skeleton assembled from state alone (the plan, its live
+  source frame, and the delivery/deviation store) — no fabricated content,
+  no-overclaim placeholders throughout. `--pr` swaps in a condensed
+  PR-body-shaped skeleton for pasting straight into a pull request description
+  (esd t4).
+- **`assign-to-workforce` split-plan renders a four-column table** — Wave |
+  Task | Model | Task summary — with real, editable model tokens (e.g.
+  `haiku`, `sonnet`) in the Model column and 72-character task-summary
+  truncation for a scannable table, plus has-instruction and
+  acceptance-criteria-count markers on the wave listing so the human sees at a
+  glance which tasks carry working instructions (#69, esd t5).
+- **`assign-to-workforce` split-plan gains a trailing End state section** that
+  quotes `devague plan deliverables` verbatim — so the human go/no-go decision
+  sees what the plan actually produces, not just its task map — degrading
+  gracefully to a one-line version hint on a `devague` too old to have the verb
+  (#70, esd t6).
+- **`summarize-delivery` consumes deviation records and the summary
+  skeleton** — the delivery-side closure leg now starts from
+  `devague summary`'s skeleton and quotes every approved deviation by its `dN`
+  id as recorded ground truth for Drift From Plan and Mid-work Decisions,
+  instead of reconstructing execution-time drift from memory (esd t8).
+
+### Changed
+
+- **`devague plan depend <tN> --on <tM> --remove`** removes exactly one
+  dependency edge; a new **`devague plan amend`** move edits a task's summary
+  and/or replaces or removes acceptance criteria by index (#68, esd t1).
+  Amending or demoting a CONFIRMED task (`amend`, `depend --remove`, and the
+  existing `instruct`) flips it back to `proposed` for re-confirmation, and
+  every demoting move now echoes that flip to stdout so the operator doesn't
+  miss it silently (#67 hardening, esd t1). No `PLAN_SCHEMA_VERSION` bump was
+  needed — edge removal and amendment mutate existing fields rather than
+  adding new ones; recorded as deviation `d1` in this release's own delivery
+  store.
+- `culture.yaml` reverts the `backend` field to `claude`, the mesh standard,
+  now that the upstream `agex-cli#46` blocker is closed (#66, esd t9).
+- Docs (`CLAUDE.md`, `README.md`, `docs/skills.md`) now name the **six-leg
+  flow** — `scope` → `think` → `spec-to-plan` → `assign-to-workforce` →
+  `deviate` → `summarize-delivery` — and the audience each leg serves:
+  operators (the main agent driving the CLI) and the humans who own the
+  go/no-go and final-PR gates.
+
+### Fixed
+
+- Issues **#62** and **#67** closed with cited evidence (no code change in
+  either case — evidence posted directly on the tracking issues).
+
 ## [0.17.2] - 2026-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ and does mid-run.
   `deviate` → `summarize-delivery` — and the audience each leg serves:
   operators (the main agent driving the CLI) and the humans who own the
   go/no-go and final-PR gates.
+- `devague learn skills` now teaches authoring all six origin skills,
+  marking scope/deviate/summarize-delivery method-only.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
+**The execution seam and deviate (0.18.0, #53 esd t1–t11).** The flow gains a
+**sixth leg** — **`deviate`** — plus the read-only "end state" that closes the
+loop between a confirmed plan and what the workforce actually produces mid-run.
+New CLI surface: `devague plan deliverables [--json]` (a never-refusing preview
+of the plan's confirmed announcement/after-state/success-signal claims,
+terminal-task acceptance criteria, and surviving open items, #70);
+`devague plan depend <tN> --on <tM> --remove` and a new `devague plan amend`
+move (edit a task's summary and/or acceptance criteria by index, #68), both
+joining `instruct` in flipping a CONFIRMED task back to `proposed` and now
+echoing that flip to stdout on every demoting move (#67 hardening);
+`devague deviate` (`--list [--json]`, `--confirm`/`--reject`) recording
+first-class, append-only deviation records in a new delivery store,
+`.devague/deliveries/<plan-slug>.json`; and `devague summary [--pr] [--json]`,
+a render-only eight-section delivery-summary skeleton built from state alone.
+New sixth origin skill **`/deviate`** — stop an in-flight
+`/assign-to-workforce` run the moment execution must diverge from the
+confirmed plan, get explicit human approval, and record it via
+`devague deviate` before resuming; it uses the existing implementation-split-plan
+gate (gate 2), not a new fourth gate. `assign-to-workforce`'s split-plan now
+renders a four-column Wave/Task/Model/Task-summary table with real model
+tokens and a trailing End state section quoting `devague plan deliverables`
+verbatim (#69, #70); `summarize-delivery` now starts from the `devague summary`
+skeleton and quotes approved deviations by `dN` id instead of reconstructing
+drift from memory. `culture.yaml` reverts `backend` to `claude`, the mesh
+standard, now that `agex-cli#46` is closed (#66). Docs (this file, `README.md`,
+`docs/skills.md`) now name the **six-leg flow** — `scope` → `think` →
+`spec-to-plan` → `assign-to-workforce` → `deviate` → `summarize-delivery` — and
+the two audiences it serves: operators (the main agent driving the CLI) and
+the humans who own the go/no-go and final-PR gates.
+
 **Operator kit carries the sharper method + new `/scope` skill (0.15.0).** The
 sharper end-to-end method spec+plan merged in #53 (0.14.1: docs + state only);
 this release carries its *method-level* half into the operator skills. New
@@ -124,7 +154,10 @@ verbs). The workflow:
    conditions). Refuses an unconverged frame; refuses to clobber an existing plan.
 2. `devague plan task "<summary>" [--accept … --dep … --covers … --origin]` —
    add tasks; `--origin llm` lands `proposed` (user must `confirm`). Refine with
-   `accept` / `depend` / `cover`.
+   `accept` / `depend` (or `depend --remove` to cut an edge, #68) / `cover` /
+   `instruct` / `amend` (edit a task's summary and/or replace/remove acceptance
+   criteria by index, #68). Amending or demoting a CONFIRMED task flips it back
+   to `proposed` and echoes that flip to stdout (#67).
 3. `devague plan risk "<text>" --kind <kind>` — park a genuine unknown as a
    first-class plan risk instead of guessing.
 4. `devague plan converge` — re-evaluates the gate **against the live frame**
@@ -140,6 +173,13 @@ verbs). The workflow:
    orchestration** — Devague describes the graph; it does not spawn subagents,
    manage worktrees, mark tasks done, or pick a backend (#20). A cyclic or
    dangling graph is refused via the plan-convergence dependency blockers.
+7. `devague plan deliverables [--json]` — a read-only "end state" preview:
+   the plan's confirmed announcement/after-state/success-signal claims
+   verbatim from its live source frame, every terminal task (an active task no
+   other active task depends on) with its acceptance criteria, and the
+   surviving open items. Never refuses — shows a not-converged banner instead
+   of gating, since previewing the end state is useful before convergence
+   too (#70).
 
 Both `devague export` and `devague plan export` prefix the written file with the
 frame/plan creation date (`<YYYY-MM-DD>-<slug>.md`, #12), so re-exporting an
@@ -158,7 +198,9 @@ the devague CLI deterministic and non-orchestrating (#20).
 1. **Spec gate**: the exported frame/spec.
 2. **Implementation split plan gate**: the plan tasks map, per-task subagent +
    model assignment, and the go/no-go decision on assigning the plan to the
-   workforce.
+   workforce. A mid-run deviation (recorded via `devague deviate` and the
+   cited `/deviate` skill) is **not** a fourth standing gate — it is the human
+   owner of this gate approving an amendment to it in-flight.
 3. **Final PR gate**: human code review of the merged result.
 
 ### Worktree contention safety
@@ -188,14 +230,21 @@ skill and this convention, not in new CLI and not in a CI/CD runner.
   worktree (gated by TDD); owns the implementation split plan.
 - **Per-task subagents**: may be simpler or cheaper models; each builds a single
   task test-first within its worktree.
-- **Human**: owns the three gates (spec, implementation split plan, final PR).
+- **Human**: owns the three gates (spec, implementation split plan, final PR),
+  including approving mid-run deviations against gate 2 via `/deviate`.
 
-### Current gap
+### What consumes the scheduling metadata
 
-`devague plan waves [--json]` emits the scheduling metadata (`{plan, waves}`),
-but nothing downstream consumes it yet. The `assign-to-workforce` skill (cited
-from superpowers:subagent-driven-development) is what consumes waves and
-orchestrates the fan-out; its use is shared via `devague learn`.
+`devague plan waves [--json]` emits the scheduling metadata (`{plan, waves,
+tasks}`); the `assign-to-workforce` skill's `split-plan` subcommand is the
+consumer — it renders the implementation split plan (task map, per-task
+agent/model proposal, go/no-go) and a trailing End state section quoting
+`devague plan deliverables` verbatim (#70), then performs the fan-out itself.
+`devague deviate` and the cited `/deviate` skill are the consumer for
+mid-run departures from that plan; `devague summary` and `/summarize-delivery`
+are the consumer for what actually shipped once the run ends. Devague itself
+never orchestrates any of this (#20) — its use across all four is shared via
+`devague learn`.
 
 ## Project intent
 
@@ -208,11 +257,18 @@ and hard questions, parking unresolved uncertainty as first-class "open
 vagueness," and only exporting a buildable spec once the frame *converges*. The
 plan method: seed a plan from that converged frame and converge it on coverage,
 acceptance criteria, and an acyclic dependency order before exporting a plan.
-The operator skills cover the legs in flow order: **`/scope`** (idea→explored
-scope, the optional opening leg), **`/think`** (idea→spec), **`/spec-to-plan`**
-(spec→plan), **`/assign-to-workforce`** (plan→parallel implementation), and
+The operator skills cover the **six legs** in flow order: **`/scope`**
+(idea→explored scope, the optional opening leg), **`/think`** (idea→spec),
+**`/spec-to-plan`** (spec→plan), **`/assign-to-workforce`**
+(plan→parallel implementation), **`/deviate`** (the execution-time leg — stop
+an in-flight fan-out the moment it must diverge from the confirmed plan, get
+explicit human approval, and record the divergence before resuming), and
 **`/summarize-delivery`** (execution→a committed accountability artifact, the
-delivery-side closure leg); the product/CLI they drive is **`devague`**.
+delivery-side closure leg); the product/CLI they drive is **`devague`**. The
+skills are written for two audiences: **operators** — the main agent driving
+the deterministic CLI move by move — and the **humans** who own the go/no-go
+decision on the implementation split plan (gate 2, including any deviation
+against it) and the final PR review (gate 3).
 
 This is a **state machine over claims, honesty conditions, open vagueness, and
 convergence** driven by LLM-chosen moves — not a linear wizard. The CLI is
@@ -238,8 +294,9 @@ steward→guildmaster cutover; `steward` is still a sibling but no longer
 broadcasts). Vendored skills are cited, not imported (cite-don't-import): copy
 from `../guildmaster/.claude/skills/<name>/` and track provenance in
 `docs/skill-sources.md`. The exception is devague's own `scope` / `think` /
-`spec-to-plan` / `assign-to-workforce` / `summarize-delivery` — devague is their
-origin, so guildmaster re-broadcasts them *from* here; never re-vendor them back.
+`spec-to-plan` / `assign-to-workforce` / `deviate` / `summarize-delivery` —
+devague is their origin, so guildmaster re-broadcasts them *from* here; never
+re-vendor them back.
 
 ## Stack expectations (when code lands)
 
@@ -256,8 +313,13 @@ that unless the user asks otherwise. The established sibling shape is:
 - `devague/cli/_commands/` — one module per verb, each exposing `register()`.
   Frame verbs: `new`, `capture`, `interrogate`, `confirm`, `reject`, `park`,
   `converge`, `export`, `status`, `show`, `list`, `learn`, `explain` (`status`
-  shares `cli/_status.py` with the plan engine). The plan engine adds one module,
-  `_commands/plan.py`, registering the nested `plan` subcommand group.
+  shares `cli/_status.py` with the plan engine), plus two more flat verbs,
+  `deviate` (`--list`, `--confirm`, `--reject`) and `summary` (`--pr`), backed
+  by `devague/delivery.py` + `devague/delivery_store.py`. The plan engine adds
+  one module, `_commands/plan.py`, registering the nested `plan` subcommand
+  group — `new` / `task` / `instruct` / `accept` / `amend` / `depend` (plus
+  `--remove`) / `cover` / `confirm` / `reject` / `risk` / `converge` / `export`
+  / `waves` / `deliverables` / `status` / `show` / `list` / `learn` / `explain`.
 - Frame engine: `devague/frame.py`, `convergence.py`, `store.py`,
   `render/{spec_md,frame_md}.py`. Plan engine (its peer): `devague/plan.py`,
   `plan_convergence.py`, `plan_store.py`, `render/plan_md.py`, `cli/_plans.py`.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,20 @@ committed.
 ## Driving it from an agent
 
 Inside AgentCulture, an assistant drives this CLI through a family of operator
-skills that cover the flow end to end, in order: **`/scope`** (idea→explored
-scope, the optional opening leg), **`/think`** (idea→spec), **`/spec-to-plan`**
-(spec→plan), **`/assign-to-workforce`** (plan→parallel implementation), and
+skills that cover the **six-leg flow** end to end, in order: **`/scope`**
+(idea→explored scope, the optional opening leg), **`/think`** (idea→spec),
+**`/spec-to-plan`** (spec→plan), **`/assign-to-workforce`**
+(plan→parallel implementation), **`/deviate`** (the execution-time leg — stop
+an in-flight fan-out the moment it must diverge from the confirmed plan, get
+explicit human approval via `devague deviate`, and resume), and
 **`/summarize-delivery`** (execution→a committed accountability artifact). The
 CLI-driving pair — `/think` and `/spec-to-plan` — add a portable wrapper and a
 `status` next-move helper over the convergence gate; the CLI is the
-deterministic affordance and the agent decides the next move. See `CLAUDE.md`
-for that workflow and `docs/superpowers/specs/` for the design docs.
+deterministic affordance and the agent decides the next move.
+
+These skills serve two audiences: **operators** — the main agent that drives
+the deterministic CLI move by move across all six legs — and the **humans**
+who own the three standing gates: the exported spec, the go/no-go on the
+implementation split plan (including any mid-run deviation approved against
+it via `/deviate`), and the final PR review. See `CLAUDE.md` for that workflow
+and `docs/superpowers/specs/` for the design docs.

--- a/culture.yaml
+++ b/culture.yaml
@@ -1,3 +1,3 @@
 agents:
 - suffix: devague
-  backend: claude-code
+  backend: claude

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -72,6 +72,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import scope as _scope_cmd
     from devague.cli._commands import show as _show_cmd
     from devague.cli._commands import status as _status_cmd
+    from devague.cli._commands import summary as _summary_cmd
 
     _learn_cmd.register(sub)
     _explain_cmd.register(sub)
@@ -89,6 +90,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _plan_cmd.register(sub)
     _deviate_cmd.register(sub)
     _status_cmd.register(sub)
+    _summary_cmd.register(sub)
     _show_cmd.register(sub)
     _list_cmd.register(sub)
 

--- a/devague/cli/__init__.py
+++ b/devague/cli/__init__.py
@@ -57,6 +57,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from devague.cli._commands import capture as _capture_cmd
     from devague.cli._commands import confirm as _confirm_cmd
     from devague.cli._commands import converge as _converge_cmd
+    from devague.cli._commands import deviate as _deviate_cmd
     from devague.cli._commands import explain as _explain_cmd
     from devague.cli._commands import export as _export_cmd
     from devague.cli._commands import interrogate as _interrogate_cmd
@@ -86,6 +87,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _converge_cmd.register(sub)
     _export_cmd.register(sub)
     _plan_cmd.register(sub)
+    _deviate_cmd.register(sub)
     _status_cmd.register(sub)
     _show_cmd.register(sub)
     _list_cmd.register(sub)

--- a/devague/cli/_commands/deviate.py
+++ b/devague/cli/_commands/deviate.py
@@ -12,17 +12,39 @@ initial status exactly like a claim or a task: ``--origin llm`` lands
 (the default) auto-approves. ``--confirm`` / ``--reject`` are therefore the
 only way a proposed deviation is resolved, mirroring the frame/plan
 anti-fabrication rule that LLM proposals never self-confirm.
+
+Referential integrity (PR #72 review, Q2): a typo'd ``--task``/``--affects``
+ref would otherwise silently sever plan traceability, and a raw ref is later
+interpolated into a markdown table by :mod:`devague.render.summary_md`.
+``--task`` must name an existing task on the resolved plan. An *id-shaped*
+``--affects`` ref (``^[a-z]\\d+$`` — e.g. ``t3``/``c14``/``h5``/``r1``) must
+resolve somewhere real: a plan task id, a plan coverage-target id, or the
+plan's live source frame's claim/honesty-condition id — the frame id need not
+be a coverage target (a confirmed ``assumption`` claim, for instance, is
+real but not spec-affecting; see the committed
+``.devague/deliveries/execution-seam-and-deviate.json`` record ``d1``, whose
+``affects: ["c14"]`` names exactly such a claim). Free text that is not
+id-shaped stays allowed — "what it affects" can legitimately be prose. Nothing
+is ever auto-corrected; an unresolvable ref is a fail-closed refusal.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 
-from devague import delivery_store
+from devague import delivery_store, store
+from devague.cli._deliveries import resolve_delivery
 from devague.cli._errors import EXIT_USER_ERROR, DevagueError
 from devague.cli._output import emit_result
 from devague.cli._plans import resolve_plan
 from devague.delivery import CLASSIFICATIONS, ORIGINS
+
+# An id-shaped ref: a single lowercase letter followed by digits — the shape
+# every devague-generated id uses (t3 tasks, c14 claims, h5 honesty
+# conditions, r1 plan risks, d1 deviations, v/q/s ids elsewhere). Anything
+# else is free-form prose and is never refused.
+_ID_SHAPED_RE = re.compile(r"^[a-z]\d+$")
 
 
 def _record_dict(rec) -> dict:
@@ -42,6 +64,54 @@ def _plan_slug(args: argparse.Namespace) -> str:
     return resolve_plan(args.plan).slug
 
 
+def _load_source_frame(frame_slug: str):
+    """Best-effort load of the plan's source frame; ``None`` when it is gone
+    or corrupt (mirrors ``cmd_summary``'s graceful degradation in
+    :mod:`devague.cli._commands.summary`) — a missing frame narrows what a
+    ``--affects`` ref can validate against, it never crashes the move."""
+    try:
+        return store.load(frame_slug)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _known_ids(plan, frame) -> set[str]:
+    """Every id an id-shaped ``--task``/``--affects`` ref may resolve to: the
+    plan's task ids, its coverage-target ids, and — if the source frame still
+    loads — every one of *its* claim and honesty-condition ids, regardless of
+    confirmation status. A frame claim need not be a coverage target to be a
+    real, referenceable id (see the module docstring's c14 example)."""
+    ids = {t.id for t in plan.tasks}
+    ids.update(tg.id for tg in plan.targets)
+    if frame is not None:
+        ids.update(c.id for c in frame.claims)
+        ids.update(h.id for c in frame.claims for h in c.honesty_conditions)
+    return ids
+
+
+def _validate_refs(plan, args: argparse.Namespace) -> None:
+    if plan.find_task(args.task) is None:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"no such task on plan {plan.slug!r}: {args.task}",
+            "run 'devague plan show' to see the plan's task ids",
+        )
+    affects = args.affects or []
+    if not affects:
+        return
+    frame = _load_source_frame(plan.frame_slug)
+    known = _known_ids(plan, frame)
+    for ref in affects:
+        if _ID_SHAPED_RE.match(ref) and ref not in known:
+            raise DevagueError(
+                EXIT_USER_ERROR,
+                f"--affects {ref!r} does not resolve to a known plan task, "
+                "coverage target, or frame claim/honesty-condition id",
+                "run 'devague plan show' or 'devague show' to see valid ids "
+                "(free-form text that isn't shaped like an id is always allowed)",
+            )
+
+
 def _record(args: argparse.Namespace) -> int:
     if not args.reason:
         raise DevagueError(
@@ -55,8 +125,9 @@ def _record(args: argparse.Namespace) -> int:
             "missing --task",
             "pass --task <tN> naming the plan item this deviation relates to",
         )
-    slug = _plan_slug(args)
-    delivery = delivery_store.load_or_new(slug)
+    plan = resolve_plan(args.plan)
+    _validate_refs(plan, args)
+    delivery = resolve_delivery(plan.slug)
     rec = delivery.add_deviation(
         args.what,
         args.task,
@@ -75,13 +146,22 @@ def _record(args: argparse.Namespace) -> int:
 
 def _resolve_status(args: argparse.Namespace, did: str, status: str) -> int:
     slug = _plan_slug(args)
-    delivery = delivery_store.load_or_new(slug)
-    if not delivery.set_status(did, status):
+    delivery = resolve_delivery(slug)
+    rec = delivery.find_deviation(did)
+    if rec is None:
         raise DevagueError(
             EXIT_USER_ERROR,
             f"no such deviation: {did}",
             "run 'devague deviate --list' to see recorded deviation ids",
         )
+    if rec.status != "proposed":
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"deviation {did} is already {rec.status}",
+            f"only a 'proposed' deviation can be confirmed/rejected — "
+            f"{did} is already {rec.status}",
+        )
+    delivery.set_status(did, status)
     delivery_store.save(delivery)
     if getattr(args, "json", False):
         emit_result({"id": did, "status": status}, json_mode=True)
@@ -92,7 +172,7 @@ def _resolve_status(args: argparse.Namespace, did: str, status: str) -> int:
 
 def _list(args: argparse.Namespace) -> int:
     slug = _plan_slug(args)
-    delivery = delivery_store.load_or_new(slug)
+    delivery = resolve_delivery(slug)
     records = delivery.deviations
     if getattr(args, "json", False):
         emit_result(
@@ -113,6 +193,21 @@ def _list(args: argparse.Namespace) -> int:
 
 
 def cmd_deviate(args: argparse.Namespace) -> int:
+    if (args.confirm or args.reject) and args.what:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "cannot combine --confirm/--reject with a positional 'what' argument",
+            "resolve and record are separate moves: run "
+            "'devague deviate --confirm <id>' (or --reject), then "
+            '\'devague deviate "<what>" --task <tN> --reason "<text>"\'',
+        )
+    if args.list and args.what:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "cannot combine --list with a positional 'what' argument",
+            "list and record are separate moves: run 'devague deviate --list' "
+            'or \'devague deviate "<what>" --task <tN> --reason "<text>"\'',
+        )
     if args.confirm:
         return _resolve_status(args, args.confirm, "approved")
     if args.reject:
@@ -140,9 +235,14 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Optional risk classification (feeds the drift-entry contract).",
     )
     p.add_argument("--origin", choices=ORIGINS, default="user", help="Who proposed it.")
-    p.add_argument("--confirm", metavar="ID", help="Approve a proposed deviation id (user-only).")
-    p.add_argument("--reject", metavar="ID", help="Reject a deviation id (user-only).")
-    p.add_argument("--list", action="store_true", help="List recorded deviations (default).")
+    resolution = p.add_mutually_exclusive_group()
+    resolution.add_argument(
+        "--confirm", metavar="ID", help="Approve a proposed deviation id (user-only)."
+    )
+    resolution.add_argument("--reject", metavar="ID", help="Reject a deviation id (user-only).")
+    resolution.add_argument(
+        "--list", action="store_true", help="List recorded deviations (default)."
+    )
     p.add_argument("--plan", help="Plan slug (default: current plan).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_deviate)

--- a/devague/cli/_commands/deviate.py
+++ b/devague/cli/_commands/deviate.py
@@ -1,0 +1,148 @@
+"""``devague deviate`` — record an execution-time deviation from a confirmed plan.
+
+The execution-seam move (#53 esd t3): while `assign-to-workforce` fans out a
+converged plan's tasks, reality sometimes departs from what the plan said. This
+move records that departure as a first-class, append-only ledger entry instead
+of silently rewriting the plan the user confirmed — the plan itself is never
+touched (see `devague/delivery_store.py`).
+
+Recording is deterministic: no LLM calls, no subprocess. Origin drives the
+initial status exactly like a claim or a task: ``--origin llm`` lands
+``proposed`` and needs an explicit user ``--confirm``; a user-authored record
+(the default) auto-approves. ``--confirm`` / ``--reject`` are therefore the
+only way a proposed deviation is resolved, mirroring the frame/plan
+anti-fabrication rule that LLM proposals never self-confirm.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from devague import delivery_store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
+from devague.cli._output import emit_result
+from devague.cli._plans import resolve_plan
+from devague.delivery import CLASSIFICATIONS, ORIGINS
+
+
+def _record_dict(rec) -> dict:
+    return {
+        "id": rec.id,
+        "what": rec.what,
+        "task": rec.task_ref,
+        "reason": rec.reason,
+        "affects": rec.affects,
+        "origin": rec.origin,
+        "status": rec.status,
+        "classification": rec.classification,
+    }
+
+
+def _plan_slug(args: argparse.Namespace) -> str:
+    return resolve_plan(args.plan).slug
+
+
+def _record(args: argparse.Namespace) -> int:
+    if not args.reason:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "missing --reason",
+            'pass --reason "<text>" explaining why the deviation happened',
+        )
+    if not args.task:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "missing --task",
+            "pass --task <tN> naming the plan item this deviation relates to",
+        )
+    slug = _plan_slug(args)
+    delivery = delivery_store.load_or_new(slug)
+    rec = delivery.add_deviation(
+        args.what,
+        args.task,
+        args.reason,
+        affects=args.affects,
+        origin=args.origin,
+        classification=args.classification,
+    )
+    delivery_store.save(delivery)
+    if getattr(args, "json", False):
+        emit_result(_record_dict(rec), json_mode=True)
+    else:
+        emit_result(f"recorded {rec.id} ({rec.status})", json_mode=False)
+    return 0
+
+
+def _resolve_status(args: argparse.Namespace, did: str, status: str) -> int:
+    slug = _plan_slug(args)
+    delivery = delivery_store.load_or_new(slug)
+    if not delivery.set_status(did, status):
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"no such deviation: {did}",
+            "run 'devague deviate --list' to see recorded deviation ids",
+        )
+    delivery_store.save(delivery)
+    if getattr(args, "json", False):
+        emit_result({"id": did, "status": status}, json_mode=True)
+    else:
+        emit_result(f"{did} -> {status}", json_mode=False)
+    return 0
+
+
+def _list(args: argparse.Namespace) -> int:
+    slug = _plan_slug(args)
+    delivery = delivery_store.load_or_new(slug)
+    records = delivery.deviations
+    if getattr(args, "json", False):
+        emit_result(
+            {"plan": slug, "deviations": [_record_dict(r) for r in records]},
+            json_mode=True,
+        )
+    elif not records:
+        emit_result("no deviations recorded yet", json_mode=False)
+    else:
+        lines = []
+        for r in records:
+            line = f"{r.id}: {r.what} (task {r.task_ref}, {r.status})"
+            if r.classification:
+                line += f" [{r.classification}]"
+            lines.append(line)
+        emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def cmd_deviate(args: argparse.Namespace) -> int:
+    if args.confirm:
+        return _resolve_status(args, args.confirm, "approved")
+    if args.reject:
+        return _resolve_status(args, args.reject, "rejected")
+    if args.what:
+        return _record(args)
+    return _list(args)
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("deviate", help="Record an execution-time deviation from a confirmed plan.")
+    p.add_argument("what", nargs="?", help="What deviated (omit with --confirm/--reject/--list).")
+    p.add_argument("--task", help="Plan item ref this deviation relates to (e.g. t3).")
+    p.add_argument("--reason", help="Why the deviation happened.")
+    p.add_argument(
+        "--affects",
+        action="append",
+        default=None,
+        metavar="REF",
+        help="A plan item ref this deviation affects (repeatable).",
+    )
+    p.add_argument(
+        "--classification",
+        choices=CLASSIFICATIONS,
+        help="Optional risk classification (feeds the drift-entry contract).",
+    )
+    p.add_argument("--origin", choices=ORIGINS, default="user", help="Who proposed it.")
+    p.add_argument("--confirm", metavar="ID", help="Approve a proposed deviation id (user-only).")
+    p.add_argument("--reject", metavar="ID", help="Reject a deviation id (user-only).")
+    p.add_argument("--list", action="store_true", help="List recorded deviations (default).")
+    p.add_argument("--plan", help="Plan slug (default: current plan).")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_deviate)

--- a/devague/cli/_commands/learn.py
+++ b/devague/cli/_commands/learn.py
@@ -209,7 +209,7 @@ _TEXT = (
 )
 
 
-# --- Authoring the three operator skills (devague#34) -----------------------
+# --- Authoring the six operator skills (devague#34, extended #53 esd) -------
 #
 # `devague learn` knows the operator skills exist but never taught an agent how
 # to *author* them. This section closes that gap: it is written as instructions
@@ -240,12 +240,16 @@ SKILLS_CONSENT = (
 SKILL_AUTHORING = {
     "layout": (
         "Each skill is one directory in your runtime's skills folder "
-        "(Claude Code: .claude/skills/<name>/):\n"
-        "  <skills>/<name>/SKILL.md           frontmatter + the operating doc\n"
-        "  <skills>/<name>/scripts/<name>.sh  portable CLI resolver (executable)"
+        "(Claude Code: .claude/skills/<name>/). Two shapes ship in this repo:\n"
+        "  CLI-driving (think, spec-to-plan, assign-to-workforce):\n"
+        "    <skills>/<name>/SKILL.md           frontmatter + the operating doc\n"
+        "    <skills>/<name>/scripts/<name>.sh  portable CLI resolver (executable)\n"
+        "  Method-only (scope, deviate, summarize-delivery):\n"
+        "    <skills>/<name>/SKILL.md           frontmatter + the operating doc — "
+        "no scripts/ directory; the skill invokes the devague CLI directly."
     ),
     "frontmatter": (
-        "SKILL.md opens with YAML frontmatter:\n"
+        "SKILL.md opens with YAML frontmatter (all six skills):\n"
         "  name: <name>\n"
         "  description: >\n"
         "    one paragraph — what it does, when to use it, and that it is\n"
@@ -254,12 +258,15 @@ SKILL_AUTHORING = {
         "                   # without it is SILENTLY SKIPPED. Harmless on claude-code."
     ),
     "resolver": (
-        "scripts/<name>.sh resolves the devague CLI portably and forwards every "
-        "move verbatim:\n"
+        "scripts/<name>.sh applies to the CLI-driving skills only (think, "
+        "spec-to-plan, assign-to-workforce) — it resolves the devague CLI "
+        "portably and forwards every move verbatim:\n"
         "  1. an installed 'devague' on PATH (the normal case);\n"
         "  2. else 'uv run devague' when inside a devague checkout;\n"
         "  3. else print the hint 'uv tool install devague' and exit non-zero.\n"
-        "Copy the exact script from the per-skill source below — don't hand-write it."
+        "Copy the exact script from the per-skill source below — don't hand-write it.\n"
+        "The method-only skills (scope, deviate, summarize-delivery) have no "
+        "scripts/ resolver at all — SKILL.md invokes the devague CLI directly."
     ),
     "contract": (
         "The skill drives the deterministic CLI and adds no logic of its own:\n"
@@ -270,8 +277,23 @@ SKILL_AUTHORING = {
     ),
 }
 
-# The three operator skills, in workflow order.
+# The six operator skills, in six-leg workflow order (devague#53 esd):
+#   scope -> think -> spec-to-plan -> assign-to-workforce -> deviate -> summarize-delivery
+# `method_only` marks the three that ship a SKILL.md and NO scripts/<name>.sh
+# resolver (scope, deviate, summarize-delivery) — they invoke the devague CLI
+# directly rather than going through the portable resolver script.
 OPERATOR_SKILLS = (
+    {
+        "name": "scope",
+        "leg": "idea -> explored scope (the optional opening leg)",
+        "role": (
+            "Surveys what an idea touches — code, docs, skills, CI, sibling repos — "
+            "read-only, then records each finding with 'devague scope' and seeds the "
+            "coming frame's boundary/non_goal/assumption claims with provenance. "
+            "Optional-by-size and freely skippable for a small idea."
+        ),
+        "method_only": True,
+    },
     {
         "name": "think",
         "leg": "idea -> spec (working backwards)",
@@ -280,6 +302,7 @@ OPERATOR_SKILLS = (
             "and classify claims, interrogate them, park open vagueness, and export "
             "a spec only once the frame converges."
         ),
+        "method_only": False,
     },
     {
         "name": "spec-to-plan",
@@ -289,6 +312,7 @@ OPERATOR_SKILLS = (
             "cover every target with TDD-accepted tasks in an acyclic order, and "
             "export a plan only once it converges."
         ),
+        "method_only": False,
     },
     {
         "name": "assign-to-workforce",
@@ -298,20 +322,51 @@ OPERATOR_SKILLS = (
             "isolated git worktrees, with main-agent TDD-gated merges. Three human "
             "gates; devague never orchestrates (#20)."
         ),
+        "method_only": False,
+    },
+    {
+        "name": "deviate",
+        "leg": "execution-time: record human-approved departures from the confirmed plan",
+        "role": (
+            "Stops an in-flight assign-to-workforce run the moment execution must "
+            "diverge from the confirmed plan, gets explicit human approval for the "
+            "departure, and records it via 'devague deviate' before resuming. "
+            "llm-origin records land 'proposed' — the user confirms, same "
+            "anti-fabrication rule as claims and tasks."
+        ),
+        "method_only": True,
+    },
+    {
+        "name": "summarize-delivery",
+        "leg": "execution -> committed accountability artifact (the closure leg)",
+        "role": (
+            "Closes the loop after an assign-to-workforce run: turns what actually "
+            "happened into a committed accountability artifact — planned vs actual "
+            "delivery, mid-work decisions, plan drift, and remaining work. A "
+            "delivery claim without evidence stays 'unverified' — never asserted "
+            "as done."
+        ),
+        "method_only": True,
     },
 )
 
 _SKILL_NAMES = tuple(s["name"] for s in OPERATOR_SKILLS)
 
 
-def _skill_source(name: str) -> dict[str, str]:
-    """Canonical, always-resolvable source locations for one skill's files."""
-    return {
+def _skill_source(name: str, *, method_only: bool = False) -> dict[str, str]:
+    """Canonical, always-resolvable source locations for one skill's files.
+
+    Method-only skills (scope, deviate, summarize-delivery) ship no
+    scripts/<name>.sh — omit 'script_raw' rather than emit a URL that 404s.
+    """
+    src = {
         "browse": f"{_SKILLS_BROWSE}/{name}/SKILL.md",
         "skill_md_raw": f"{_SKILLS_RAW}/{name}/SKILL.md",
-        "script_raw": f"{_SKILLS_RAW}/{name}/scripts/{name}.sh",
         "repo_path": f".claude/skills/{name}/",
     }
+    if not method_only:
+        src["script_raw"] = f"{_SKILLS_RAW}/{name}/scripts/{name}.sh"
+    return src
 
 
 def _skills_payload(names: tuple[str, ...]) -> dict[str, object]:
@@ -320,7 +375,9 @@ def _skills_payload(names: tuple[str, ...]) -> dict[str, object]:
         "consent": list(SKILLS_CONSENT),
         "authoring": SKILL_AUTHORING,
         "operator_skills": [
-            {**s, **_skill_source(s["name"])} for s in OPERATOR_SKILLS if s["name"] in names
+            {**s, **_skill_source(s["name"], method_only=s.get("method_only", False))}
+            for s in OPERATOR_SKILLS
+            if s["name"] in names
         ],
         "doc_url": SKILLS_DOC_URL,
         "doc_repo_path": SKILLS_DOC_REPO_PATH,
@@ -333,8 +390,10 @@ def _skills_text(names: tuple[str, ...], *, full: bool) -> str:
         "Authoring your operator skills (create them with user consent)",
         "=============================================================",
         "",
-        "devague is driven by three operator skills. Recreate them in your own "
-        "runtime so you can drive devague the same way everywhere.",
+        "devague is driven by six operator skills — three CLI-driving (a "
+        "scripts/<name>.sh resolver) and three method-only (SKILL.md only, no "
+        "resolver script). Recreate them in your own runtime so you can drive "
+        "devague the same way everywhere.",
         "",
         "Consent — read before creating anything:",
     ]
@@ -350,22 +409,30 @@ def _skills_text(names: tuple[str, ...], *, full: bool) -> str:
         "",
         SKILL_AUTHORING["contract"],
         "",
-        "The three skills:",
+        "The six skills (six-leg workflow order):",
     ]
     for s in OPERATOR_SKILLS:
         if s["name"] not in names:
             continue
-        parts.append(f"  {s['name']}  [{s['leg']}]")
+        method_only = s.get("method_only", False)
+        label = " (method-only)" if method_only else ""
+        parts.append(f"  {s['name']}{label}  [{s['leg']}]")
         parts.append(f"    {s['role']}")
         if full:
-            src = _skill_source(s["name"])
+            src = _skill_source(s["name"], method_only=method_only)
             parts.append(f"    SKILL.md:  {src['skill_md_raw']}")
-            parts.append(f"    script:    {src['script_raw']}")
+            if method_only:
+                parts.append(
+                    "    script:    method-only — no scripts/ resolver; "
+                    "SKILL.md invokes the devague CLI directly"
+                )
+            else:
+                parts.append(f"    script:    {src['script_raw']}")
             parts.append(f"    browse:    {src['browse']}")
         parts.append("")
     if not full:
         parts.append(
-            "Run 'devague learn skills:all' for the source URLs of all three, or "
+            "Run 'devague learn skills:all' for the source URLs of all six, or "
             "'devague learn skills:<name>' for one."
         )
         parts.append("")

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -661,9 +661,9 @@ def cmd_plan_learn(args: argparse.Namespace) -> int:
         "criteria, the dependency graph is acyclic, and no blocking risk remains.\n\n"
         "Moves:\n"
         + "\n".join(f"  {name:<9} {desc}" for name, desc in PLAN_MOVES.items())
-        + "\n\nTo author the operator skills (think / spec-to-plan / "
-        "assign-to-workforce) in\nyour own runtime, run 'devague learn skills' "
-        "(with user consent)."
+        + "\n\nTo author the six operator skills (scope / think / spec-to-plan / "
+        "assign-to-workforce /\ndeviate / summarize-delivery) in your own runtime, "
+        "run 'devague learn skills'\n(with user consent)."
     )
     if getattr(args, "json", False):
         emit_result(

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -41,7 +41,14 @@ PLAN_MOVES = {
     "task": "Add a task; optionally --accept / --dep / --covers / --instruction inline.",
     "instruct": "Add/update a task's working instruction (may flip confirmed -> proposed).",
     "accept": "Add an acceptance criterion to a task.",
-    "depend": "Record that a task depends on another (--on).",
+    "amend": (
+        "Edit a task's summary and/or replace/remove acceptance criteria by index "
+        "(may flip confirmed -> proposed; refuses on a rejected task)."
+    ),
+    "depend": (
+        "Record that a task depends on another (--on); --remove cuts one edge "
+        "(may flip confirmed -> proposed)."
+    ),
     "cover": "Mark a task as covering a coverage target (c*/h*).",
     "confirm": "Confirm a task (user-only — no fabricated rigor).",
     "reject": "Reject a task.",
@@ -111,6 +118,35 @@ def _require_target(plan: Plan, target_id: str) -> None:
             f"unknown coverage target: {target_id}",
             "run 'devague plan show' to see targets (c*/h*)",
         )
+
+
+# ── the re-confirm rule (#53 t5, sharpened in #53-esd t1) ────────────────────
+# A demoting change — ``instruct``, ``amend``, ``depend --remove`` — alters something
+# the user already confirmed, so it must go back through the user: setting/changing it
+# on a CONFIRMED task flips the task back to 'proposed'. A task that is already
+# 'proposed' or 'rejected' is unaffected by this rule; only its field(s) change.
+_FLIP_SUFFIX = " (confirmed -> proposed; re-confirm)"
+
+
+def _demote_if_confirmed(task) -> bool:
+    flipped = task.status == "confirmed"
+    if flipped:
+        task.status = "proposed"
+    return flipped
+
+
+def _flip_suffix(flipped: bool) -> str:
+    """The stdout-visible flip note (#53-esd t1, issue #67 hardening): a harness that
+    reads only stdout must still see the confirmed -> proposed demotion, not just the
+    stderr diagnostic."""
+    return _FLIP_SUFFIX if flipped else ""
+
+
+def _flip_diagnostic(task_id: str, what_changed: str) -> None:
+    emit_diagnostic(
+        f"note: {task_id} was confirmed; {what_changed} flips it back to 'proposed' — "
+        f"re-confirm it (devague plan confirm {task_id})"
+    )
 
 
 # ── moves ───────────────────────────────────────────────────────────────────
@@ -192,9 +228,7 @@ def cmd_plan_instruct(args: argparse.Namespace) -> int:
     plan = resolve_plan(args.plan)
     task = _require_task(plan, args.id)
     task.instruction = args.text
-    flipped = task.status == "confirmed"
-    if flipped:
-        task.status = "proposed"
+    flipped = _demote_if_confirmed(task)
     plan_store.save(plan)
     if getattr(args, "json", False):
         emit_result(
@@ -207,13 +241,9 @@ def cmd_plan_instruct(args: argparse.Namespace) -> int:
             json_mode=True,
         )
     else:
-        emit_result(f"{task.id}: instruction set", json_mode=False)
+        emit_result(f"{task.id}: instruction set{_flip_suffix(flipped)}", json_mode=False)
     if flipped:
-        emit_diagnostic(
-            f"note: {task.id}'s instruction changed on a confirmed task — "
-            "flipped back to 'proposed'; re-confirm it (devague plan confirm "
-            f"{task.id})"
-        )
+        _flip_diagnostic(task.id, "changing its instruction")
     return 0
 
 
@@ -229,15 +259,109 @@ def cmd_plan_accept(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_plan_amend(args: argparse.Namespace) -> int:
+    """``amend`` — edit a task's summary and/or replace/remove acceptance criteria
+    by index (#53-esd t1, issue #68's task-recreation escape hatch).
+
+    Scoped to summary + acceptance criteria only — deps/covers/instruction each
+    already have their own move (``depend``/``cover``/``instruct``). Re-confirm rule:
+    amending a CONFIRMED task flips it back to 'proposed' (same rule as ``instruct``
+    and ``depend --remove``). Design decision (deliberately stricter than
+    ``instruct``): amend REFUSES outright on a REJECTED task — silently letting a
+    rejected task's declared work keep changing would make 'rejected' meaningless;
+    the honest move is a new task, not a resurrection through the back door.
+    """
+    plan = resolve_plan(args.plan)
+    task = _require_task(plan, args.id)
+    if task.status == "rejected":
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"{task.id} is rejected; amend refuses to edit a rejected task",
+            "add a new task instead — a rejected task's content should not change",
+        )
+    if args.summary is None and not args.accept_replace and not args.accept_remove:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "nothing to amend",
+            'pass --summary "<text>", --accept-replace <n> "<text>", ' "and/or --accept-remove <n>",
+        )
+    try:
+        accept_replace = [(int(n), text) for n, text in (args.accept_replace or [])]
+        accept_remove = [int(n) for n in (args.accept_remove or [])]
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"acceptance criterion index must be an integer: {exc}",
+            'e.g. --accept-replace 1 "new text" / --accept-remove 2',
+        ) from exc
+    try:
+        plan.amend_task(
+            task, summary=args.summary, accept_replace=accept_replace, accept_remove=accept_remove
+        )
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR, str(exc), "run 'devague plan show' to see current criteria"
+        ) from exc
+    flipped = _demote_if_confirmed(task)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result(
+            {
+                "id": task.id,
+                "summary": task.summary,
+                "acceptance_criteria": list(task.acceptance_criteria),
+                "status": task.status,
+                "flipped": flipped,
+            },
+            json_mode=True,
+        )
+    else:
+        emit_result(f"{task.id}: amended{_flip_suffix(flipped)}", json_mode=False)
+    if flipped:
+        _flip_diagnostic(task.id, "amending it")
+    return 0
+
+
 def cmd_plan_depend(args: argparse.Namespace) -> int:
     plan = resolve_plan(args.plan)
     task = _require_task(plan, args.id)
+    if args.remove:
+        return _cmd_plan_depend_remove(args, plan, task)
     plan.add_dep(task, args.on)
     plan_store.save(plan)
     if getattr(args, "json", False):
         emit_result({"id": task.id, "deps": task.deps}, json_mode=True)
     else:
         emit_result(f"{task.id} depends on {args.on}", json_mode=False)
+    return 0
+
+
+def _cmd_plan_depend_remove(args: argparse.Namespace, plan: Plan, task) -> int:
+    """``depend <tN> --on <tM> --remove`` — cut exactly one edge (#53-esd t1, issue #68).
+
+    Everything else on the task (summary, acceptance criteria, covers, instruction)
+    stays untouched; only ``deps`` and — if the task was confirmed — ``status`` change.
+    """
+    removed = plan.remove_dep(task, args.on)
+    if not removed:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"{task.id} does not depend on {args.on}",
+            "run 'devague plan show' to see its current deps",
+        )
+    flipped = _demote_if_confirmed(task)
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result(
+            {"id": task.id, "deps": task.deps, "status": task.status, "flipped": flipped},
+            json_mode=True,
+        )
+    else:
+        emit_result(
+            f"{task.id} no longer depends on {args.on}{_flip_suffix(flipped)}", json_mode=False
+        )
+    if flipped:
+        _flip_diagnostic(task.id, f"removing its dependency on {args.on}")
     return 0
 
 
@@ -527,9 +651,33 @@ def register(sub: argparse._SubParsersAction) -> None:
     _plan_opt(pa)
     pa.set_defaults(func=cmd_plan_accept)
 
-    pd = psub.add_parser("depend", help="Record that a task depends on another.")
+    pam = psub.add_parser(
+        "amend", help="Edit a task's summary and/or replace/remove acceptance criteria by index."
+    )
+    pam.add_argument("id", help=_TASK_ID_HELP)
+    pam.add_argument("--summary", help="Replace the task summary verbatim.")
+    pam.add_argument(
+        "--accept-replace",
+        nargs=2,
+        action="append",
+        metavar=("N", "TEXT"),
+        help="Replace the Nth (1-indexed) acceptance criterion with TEXT (repeatable).",
+    )
+    pam.add_argument(
+        "--accept-remove",
+        action="append",
+        metavar="N",
+        help="Remove the Nth (1-indexed) acceptance criterion (repeatable).",
+    )
+    _plan_opt(pam)
+    pam.set_defaults(func=cmd_plan_amend)
+
+    pd = psub.add_parser("depend", help="Record that a task depends on another (or --remove).")
     pd.add_argument("id", help="The dependent task id.")
     pd.add_argument("--on", required=True, help="The task id it depends on.")
+    pd.add_argument(
+        "--remove", action="store_true", help="Remove this dependency edge instead of adding it."
+    )
     _plan_opt(pd)
     pd.set_defaults(func=cmd_plan_depend)
 

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -24,10 +24,17 @@ from devague.cli._plans import resolve_plan
 from devague.cli._status import StatusLabels, emit_empty, emit_status
 from devague.convergence import evaluate as evaluate_frame
 from devague.frame import Frame
-from devague.plan import RISK_KINDS, Plan, dependency_waves, targets_from_frame, to_dict
+from devague.plan import (
+    RISK_KINDS,
+    Plan,
+    dependency_waves,
+    targets_from_frame,
+    terminal_tasks,
+    to_dict,
+)
 from devague.plan_convergence import dependency_blockers
 from devague.plan_convergence import evaluate as evaluate_plan
-from devague.render import plan_md
+from devague.render import deliverables_md, plan_md
 
 PLANS_OUT_DIR = Path("docs/plans")
 
@@ -56,6 +63,10 @@ PLAN_MOVES = {
     "converge": "Check whether the plan can export, against the live frame.",
     "export": "Write the buildable plan — only once the plan converges.",
     "waves": "Emit deterministic dependency waves (scheduling metadata, not orchestration).",
+    "deliverables": (
+        "Read-only preview of what exists once every task completes "
+        "(renders even when not converged)."
+    ),
     "status": "Report where the plan stands + the recommended next move (read-only).",
     "show": "Render the plan.",
     "list": "List plans.",
@@ -101,6 +112,23 @@ def _live(plan: Plan):
             f"source frame '{frame.slug}' has regressed below convergence",
             f"re-converge the frame first: devague converge --frame {frame.slug}",
         )
+    return frame, targets_from_frame(frame)
+
+
+def _live_frame_and_targets(plan: Plan):
+    """Load the live source frame and re-derive targets — WITHOUT gating on the
+    frame's own convergence (unlike :func:`_live`).
+
+    ``deliverables`` is a read-only preview that must never refuse (#70, issue
+    #20): even a frame that has regressed below its own convergence gate still
+    has *some* confirmed announcement/after_state/success_signal claims worth
+    showing, so this deliberately skips the ``evaluate_frame`` check that
+    ``converge``/``export``/``status`` use to catch frame drift. A missing or
+    corrupt source frame still raises via :func:`_load_source_frame` — there is
+    no state to synthesize from at all, which is a different failure than "not
+    converged yet."
+    """
+    frame = _load_source_frame(plan.frame_slug)
     return frame, targets_from_frame(frame)
 
 
@@ -511,6 +539,64 @@ def cmd_plan_waves(args: argparse.Namespace) -> int:
     return 0
 
 
+def _confirmed_texts(frame: Frame, kind: str) -> list[str]:
+    return [c.text for c in frame.claims if c.kind == kind and c.status == "confirmed"]
+
+
+def _open_items_payload(frame: Frame, plan: Plan) -> list[dict]:
+    items = [
+        {"kind": v.kind, "text": v.text}
+        for v in frame.open_vagueness
+        if v.kind != "unknown_blocking"
+    ]
+    items += [{"kind": r.kind, "text": r.text} for r in plan.risks if r.kind != "unknown_blocking"]
+    return items
+
+
+def cmd_plan_deliverables(args: argparse.Namespace) -> int:
+    """The read-only "what do we have in the end?" view (issue #70).
+
+    Synthesizes from the live frame + plan state only — the frame's confirmed
+    ``announcement`` / ``after_state`` / ``success_signal`` claims (verbatim), the
+    plan's terminal tasks (active tasks no other active task depends on) with their
+    acceptance criteria, and surviving open items (the frame's non-blocking parked
+    vagueness plus the plan's non-blocking risks). Evaluates the plan gate read-only
+    — like ``status`` — but never persists the drafting/converged transition, and
+    unlike every gated move it never refuses on a not-converged plan: it renders an
+    explicit banner instead (#20). Never writes to ``.devague/`` at all.
+    """
+    plan = resolve_plan(args.plan)
+    frame, targets = _live_frame_and_targets(plan)
+    result = evaluate_plan(plan, targets=targets)
+    terminal = terminal_tasks(plan.tasks)
+    if getattr(args, "json", False):
+        emit_result(
+            {
+                "plan": plan.slug,
+                "converged": result.ready,
+                "announcement": _confirmed_texts(frame, "announcement"),
+                "after_state": _confirmed_texts(frame, "after_state"),
+                "success_signal": _confirmed_texts(frame, "success_signal"),
+                "terminal_tasks": [
+                    {
+                        "id": t.id,
+                        "summary": t.summary,
+                        "acceptance_criteria": list(t.acceptance_criteria),
+                    }
+                    for t in terminal
+                ],
+                "open_items": _open_items_payload(frame, plan),
+            },
+            json_mode=True,
+        )
+    else:
+        emit_result(
+            deliverables_md.render_deliverables(plan, frame, converged=result.ready),
+            json_mode=False,
+        )
+    return 0
+
+
 def cmd_plan_status(args: argparse.Namespace) -> int:
     """Where the plan stands + the recommended next move — read-only.
 
@@ -716,6 +802,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     pwv = psub.add_parser("waves", help="Emit deterministic dependency waves (metadata only).")
     _plan_opt(pwv)
     pwv.set_defaults(func=cmd_plan_waves)
+
+    pdl = psub.add_parser(
+        "deliverables", help="Preview what exists once every task completes (read-only)."
+    )
+    _plan_opt(pdl)
+    pdl.set_defaults(func=cmd_plan_deliverables)
 
     pst = psub.add_parser("status", help="Where the plan stands + the recommended next move.")
     _plan_opt(pst)

--- a/devague/cli/_commands/summary.py
+++ b/devague/cli/_commands/summary.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import argparse
 
-from devague import delivery_store, store
+from devague import store
+from devague.cli._deliveries import resolve_delivery
 from devague.cli._output import emit_result
 from devague.cli._plans import resolve_plan
 from devague.frame import Frame
@@ -35,17 +36,19 @@ def _load_source_frame(frame_slug: str) -> Frame | None:
 def cmd_summary(args: argparse.Namespace) -> int:
     plan: Plan = resolve_plan(args.plan)
     frame = _load_source_frame(plan.frame_slug)
-    delivery = delivery_store.load_or_new(plan.slug)
+    delivery = resolve_delivery(plan.slug)
     json_mode = getattr(args, "json", False)
 
-    if args.pr:
-        if json_mode:
-            emit_result(summary_md.pr_data(plan, frame, delivery), json_mode=True)
-        else:
-            emit_result(summary_md.render_pr_summary(plan, frame, delivery), json_mode=False)
-        return 0
-
-    if json_mode:
+    # A single return path (SonarCloud python:S3516 — a function with several
+    # `return 0` branches always returning the same literal value): select
+    # which payload to emit, then emit and return once. `_dispatch` treats a
+    # `None` return as success (exit 0) exactly like an explicit `return 0`,
+    # so the CLI contract is unchanged.
+    if args.pr and json_mode:
+        emit_result(summary_md.pr_data(plan, frame, delivery), json_mode=True)
+    elif args.pr:
+        emit_result(summary_md.render_pr_summary(plan, frame, delivery), json_mode=False)
+    elif json_mode:
         emit_result(summary_md.summary_data(plan, frame, delivery), json_mode=True)
     else:
         emit_result(summary_md.render_summary(plan, frame, delivery), json_mode=False)

--- a/devague/cli/_commands/summary.py
+++ b/devague/cli/_commands/summary.py
@@ -1,0 +1,63 @@
+"""``devague summary`` — render a delivery-summary skeleton from state alone.
+
+The execution-seam wrap-up leg (#53-esd t4): a render-only view over a plan, its
+live source frame, and its delivery (deviation) store, producing the eight-section
+skeleton the ``summarize-delivery`` skill starts from instead of hand-assembling
+the baseline. See :mod:`devague.render.summary_md` for the rendering logic and the
+no-overclaim rules it enforces.
+
+Read-only: no store is ever saved here. ``--pr`` swaps in the condensed PR-body
+skeleton (:func:`devague.render.summary_md.render_pr_summary`); ``--json`` emits
+the structured equivalent of whichever mode is selected.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from devague import delivery_store, store
+from devague.cli._output import emit_result
+from devague.cli._plans import resolve_plan
+from devague.frame import Frame
+from devague.plan import Plan
+from devague.render import summary_md
+
+
+def _load_source_frame(frame_slug: str) -> Frame | None:
+    """Best-effort load of the plan's source frame; degrade to ``None`` when it is
+    gone or corrupt, mirroring ``cmd_plan_show``'s graceful degradation."""
+    try:
+        return store.load(frame_slug)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def cmd_summary(args: argparse.Namespace) -> int:
+    plan: Plan = resolve_plan(args.plan)
+    frame = _load_source_frame(plan.frame_slug)
+    delivery = delivery_store.load_or_new(plan.slug)
+    json_mode = getattr(args, "json", False)
+
+    if args.pr:
+        if json_mode:
+            emit_result(summary_md.pr_data(plan, frame, delivery), json_mode=True)
+        else:
+            emit_result(summary_md.render_pr_summary(plan, frame, delivery), json_mode=False)
+        return 0
+
+    if json_mode:
+        emit_result(summary_md.summary_data(plan, frame, delivery), json_mode=True)
+    else:
+        emit_result(summary_md.render_summary(plan, frame, delivery), json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "summary",
+        help="Render a delivery-summary skeleton from plan/frame/delivery state (read-only).",
+    )
+    p.add_argument("--plan", help="Plan slug (default: current plan).")
+    p.add_argument("--pr", action="store_true", help="Emit the condensed PR-body skeleton instead.")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_summary)

--- a/devague/cli/_deliveries.py
+++ b/devague/cli/_deliveries.py
@@ -1,0 +1,43 @@
+"""Resolve the delivery ledger for a move: `.devague/deliveries/<slug>.json`.
+
+The delivery-store peer of :mod:`devague.cli._plans` (read that module for the
+pattern this mirrors). :func:`devague.delivery_store.load_or_new` already treats
+"no ledger yet" as the normal starting state (a plan may never have had a
+deviation recorded against it) and returns a fresh :class:`Delivery` for a
+missing file — that is not an error and stays untranslated here. What *is* an
+error is an existing-but-broken ledger: a schema_version newer than this binary
+understands, or a file that fails to parse/validate. Before this module existed,
+those exceptions fell through to ``_dispatch``'s last-resort ``except Exception``
+handler and were misreported as "unexpected: ..." (Q5, PR #72 review) instead of
+a clear, actionable :class:`DevagueError`.
+"""
+
+from __future__ import annotations
+
+from devague import delivery_store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
+from devague.delivery import Delivery
+
+
+def resolve_delivery(slug: str) -> Delivery:
+    """Load-or-new the delivery ledger for ``slug``, translating store errors.
+
+    Mirrors :func:`devague.cli._plans.resolve_plan`'s translation of
+    :mod:`devague.plan_store` errors, applied to :mod:`devague.delivery_store`.
+    """
+    try:
+        return delivery_store.load_or_new(slug)
+    except delivery_store.IncompatibleDeliverySchemaError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            str(exc),
+            "upgrade devague (uv tool install -U devague)",
+        ) from exc
+    except ValueError as exc:
+        # Covers malformed JSON (json.JSONDecodeError is a ValueError subclass)
+        # and the delivery_store slug-mismatch/tampered-slug ValueErrors.
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            f"delivery ledger {slug!r} is malformed: {exc}",
+            f"repair or remove .devague/deliveries/{slug}.json",
+        ) from exc

--- a/devague/delivery.py
+++ b/devague/delivery.py
@@ -100,6 +100,20 @@ class Delivery:
         return next((d for d in self.deviations if d.id == did), None)
 
     def set_status(self, did: str, status: str) -> bool:
+        """Set ``did``'s status, failing closed on a typo'd/unknown status.
+
+        Validates ``status`` against :data:`DEVIATION_STATUSES` **before**
+        touching the record — an invalid string never mutates anything and
+        never gets persisted (a bad status value would otherwise brick the
+        ledger on the next fail-closed load, mirroring
+        :class:`DeviationRecord`'s own ``__post_init__`` guard). Transition
+        legality (e.g. "only a proposed record may be confirmed/rejected") is
+        the CLI layer's job (:mod:`devague.cli._commands.deviate`), which can
+        report the record's *current* status in its refusal hint; this method
+        only guards against garbage status values.
+        """
+        if status not in DEVIATION_STATUSES:
+            raise ValueError(f"unknown deviation status: {status!r}")
         rec = self.find_deviation(did)
         if rec is not None:
             rec.status = status

--- a/devague/delivery.py
+++ b/devague/delivery.py
@@ -1,0 +1,135 @@
+"""The Delivery domain model — execution-time deviations from a confirmed plan.
+
+The *delivery store* is the execution-seam peer of the plan engine
+(:mod:`devague.plan`): where a Plan is the contract the user confirmed, a
+Delivery records where execution actually deviated from it — `devague deviate`
+is the CLI move that appends to it. Pure data + transitions, no I/O;
+persistence lives in :mod:`devague.delivery_store`.
+
+Each :class:`DeviationRecord` names the plan item it relates to (``task_ref``,
+e.g. ``t3``), why the deviation happened (``reason`` — required, never
+fabricated), what else it touches (``affects``, repeatable plan-item/coverage
+refs), who proposed it, and an optional ``classification`` that feeds the
+drift-entry contract consumed by the ``summarize-delivery`` skill.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Optional
+
+from devague.frame import ORIGINS, parse_schema_version
+
+# Bump when the persisted delivery shape changes incompatibly.
+# `delivery_store.load` fails closed on a delivery whose schema_version is
+# newer/unknown — the delivery-engine peer of frame.SCHEMA_VERSION /
+# plan.PLAN_SCHEMA_VERSION (see #5 / #18 for the frame/plan precedent).
+DELIVERY_SCHEMA_VERSION = 1
+
+DEVIATION_STATUSES = ("proposed", "approved", "rejected")
+# Feeds the drift-entry contract consumed by the summarize-delivery skill.
+CLASSIFICATIONS = ("acceptable", "risky", "needs-follow-up")
+
+
+@dataclass
+class DeviationRecord:
+    id: str
+    what: str
+    task_ref: str
+    reason: str
+    affects: list[str] = field(default_factory=list)
+    origin: str = "user"  # user | llm
+    status: str = "approved"  # proposed | approved | rejected
+    classification: Optional[str] = None  # one of CLASSIFICATIONS, or None
+
+    def __post_init__(self) -> None:
+        if self.origin not in ORIGINS:
+            raise ValueError(f"unknown deviation origin: {self.origin!r}")
+        if self.status not in DEVIATION_STATUSES:
+            raise ValueError(f"unknown deviation status: {self.status!r}")
+        if self.classification is not None and self.classification not in CLASSIFICATIONS:
+            raise ValueError(f"unknown deviation classification: {self.classification!r}")
+
+
+@dataclass
+class Delivery:
+    plan_slug: str
+    schema_version: int = DELIVERY_SCHEMA_VERSION
+    created: str = ""
+    updated: str = ""
+    deviations: list[DeviationRecord] = field(default_factory=list)
+
+    @staticmethod
+    def _next(items: list, prefix: str) -> str:
+        n = 0
+        for it in items:
+            if it.id.startswith(prefix):
+                try:
+                    n = max(n, int(it.id[len(prefix) :]))
+                except ValueError:
+                    pass
+        return f"{prefix}{n + 1}"
+
+    def add_deviation(
+        self,
+        what: str,
+        task_ref: str,
+        reason: str,
+        affects: Optional[list[str]] = None,
+        origin: str = "user",
+        classification: Optional[str] = None,
+    ) -> DeviationRecord:
+        if not reason:
+            raise ValueError("a deviation requires a --reason")
+        status = "proposed" if origin == "llm" else "approved"
+        rec = DeviationRecord(
+            id=self._next(self.deviations, "d"),
+            what=what,
+            task_ref=task_ref,
+            reason=reason,
+            affects=list(affects) if affects else [],
+            origin=origin,
+            status=status,
+            classification=classification,
+        )
+        self.deviations.append(rec)
+        return rec
+
+    def find_deviation(self, did: str) -> Optional[DeviationRecord]:
+        return next((d for d in self.deviations if d.id == did), None)
+
+    def set_status(self, did: str, status: str) -> bool:
+        rec = self.find_deviation(did)
+        if rec is not None:
+            rec.status = status
+            return True
+        return False
+
+
+def to_dict(delivery: Delivery) -> dict:
+    return dataclasses.asdict(delivery)
+
+
+def from_dict(d: dict) -> Delivery:
+    deviations = [
+        DeviationRecord(
+            id=r["id"],
+            what=r["what"],
+            task_ref=r["task_ref"],
+            reason=r["reason"],
+            affects=list(r.get("affects", [])),
+            origin=r.get("origin", "user"),
+            status=r.get("status", "approved"),
+            classification=r.get("classification"),
+        )
+        for r in d.get("deviations", [])
+    ]
+    return Delivery(
+        plan_slug=d["plan_slug"],
+        # A pre-field delivery predates schema_version; treat it as current.
+        schema_version=parse_schema_version(d, DELIVERY_SCHEMA_VERSION),
+        created=d.get("created", ""),
+        updated=d.get("updated", ""),
+        deviations=deviations,
+    )

--- a/devague/delivery_store.py
+++ b/devague/delivery_store.py
@@ -1,0 +1,83 @@
+"""Delivery persistence: JSON under .devague/deliveries/<plan-slug>.json.
+
+The peer of :mod:`devague.plan_store` (itself the peer of :mod:`devague.store`).
+Paths are cwd-relative so a delivery ledger lives alongside the plan it tracks
+deviations for. A delivery's key is its source plan's slug verbatim — a
+delivery has no independent identity, unlike a frame or plan, so there is no
+separate "current delivery" pointer; the move that reads/writes one always
+resolves the plan first (see :mod:`devague.cli._plans`).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from devague.delivery import DELIVERY_SCHEMA_VERSION, Delivery, from_dict, to_dict
+from devague.store import validate_slug
+
+DELIVERIES_DIR = Path(".devague/deliveries")
+
+
+class IncompatibleDeliverySchemaError(ValueError):
+    """A persisted delivery declares a schema_version this devague cannot read."""
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def path_for(slug: str) -> Path:
+    return DELIVERIES_DIR / f"{validate_slug(slug)}.json"
+
+
+def save(delivery: Delivery) -> Path:
+    DELIVERIES_DIR.mkdir(parents=True, exist_ok=True)
+    # Stamp the version this binary actually writes: a delivery loaded under an
+    # older label then mutated with newer fields must not be rewritten under that
+    # older label, or the fail-closed load gate (schema_version >
+    # DELIVERY_SCHEMA_VERSION) is defeated and an old binary silently drops the
+    # newer payload (data loss) — the 0.17.0 frame/plan-store fix, applied here.
+    delivery.schema_version = DELIVERY_SCHEMA_VERSION
+    delivery.updated = _now()
+    if not delivery.created:
+        delivery.created = delivery.updated
+    p = path_for(delivery.plan_slug)
+    p.write_text(json.dumps(to_dict(delivery), indent=2) + "\n", encoding="utf-8")
+    return p
+
+
+def load(slug: str) -> Delivery:
+    p = path_for(slug)
+    if not p.exists():
+        raise FileNotFoundError(slug)
+    delivery = from_dict(json.loads(p.read_text(encoding="utf-8")))
+    validate_slug(delivery.plan_slug)  # reject a tampered file whose internal slug escapes
+    if delivery.plan_slug != slug:
+        # The embedded plan_slug drives save(); a file whose internal slug disagrees
+        # with its filename could silently redirect a later save onto a different
+        # plan's ledger, so reject it.
+        raise ValueError(
+            f"delivery plan slug mismatch: file {slug!r} declares plan_slug "
+            f"{delivery.plan_slug!r}"
+        )
+    if delivery.schema_version > DELIVERY_SCHEMA_VERSION:
+        raise IncompatibleDeliverySchemaError(
+            f"delivery {slug!r} uses schema_version {delivery.schema_version}, but this "
+            f"devague supports up to {DELIVERY_SCHEMA_VERSION}; upgrade devague to read it"
+        )
+    return delivery
+
+
+def load_or_new(slug: str) -> Delivery:
+    """Load the delivery ledger for ``slug``, or a fresh empty one if none exists yet.
+
+    A plan may never have had a deviation recorded against it, so "no file yet"
+    is the normal starting state, not an error (unlike :func:`load`, which is
+    for callers that require an existing ledger).
+    """
+    try:
+        return load(slug)
+    except FileNotFoundError:
+        return Delivery(plan_slug=slug)

--- a/devague/plan.py
+++ b/devague/plan.py
@@ -267,6 +267,27 @@ def dependency_waves(tasks: list[Task]) -> list[list[str]]:
     return waves
 
 
+def terminal_tasks(tasks: list[Task]) -> list[Task]:
+    """Active (non-rejected) tasks that no other active task depends on.
+
+    These are the leaves of the dependency graph — the tasks whose output nothing
+    downstream consumes — used by the read-only ``deliverables`` view (#70) to answer
+    "what exists once every task completes" without re-deriving the whole graph. A
+    task with no dependents is terminal even if it itself has deps of its own; a plan
+    with no tasks at all yields an empty (vacuously total) list. Order is stored
+    order (stable), not topological — the caller decides how to present them.
+
+    Only *active* tasks are consulted on both sides: a rejected task is never
+    terminal (it is not part of "what ships"), and a rejected task's ``deps`` entry
+    naming another task does not keep that other task off the terminal list — a
+    dependency edge only "uses up" a task's terminal status when another *active*
+    task still depends on it.
+    """
+    active = [t for t in tasks if t.status != "rejected"]
+    depended_on = {d for t in active for d in t.deps}
+    return [t for t in active if t.id not in depended_on]
+
+
 def to_dict(plan: Plan) -> dict:
     return dataclasses.asdict(plan)
 

--- a/devague/plan.py
+++ b/devague/plan.py
@@ -126,6 +126,19 @@ class Plan:
         if dep_id not in task.deps:
             task.deps.append(dep_id)
 
+    def remove_dep(self, task: Task, dep_id: str) -> bool:
+        """Cut a single dependency edge (#53-esd t1, issue #68's edge-removal escape hatch).
+
+        Returns whether ``dep_id`` was actually present. Everything else on the task —
+        summary, acceptance criteria, covers, instruction — is untouched; the caller
+        (the CLI ``depend --remove`` move) is responsible for the re-confirm rule when
+        the task was confirmed.
+        """
+        if dep_id in task.deps:
+            task.deps.remove(dep_id)
+            return True
+        return False
+
     def add_cover(self, task: Task, target_id: str) -> None:
         if target_id not in task.covers:
             task.covers.append(target_id)
@@ -144,6 +157,50 @@ class Plan:
 
     def find_target(self, target_id: str) -> Optional[CoverageTarget]:
         return next((tg for tg in self.targets if tg.id == target_id), None)
+
+    @staticmethod
+    def _validate_acceptance_index(task: Task, index: int) -> None:
+        if not 1 <= index <= len(task.acceptance_criteria):
+            raise ValueError(
+                f"acceptance criterion index out of range: {index} "
+                f"(task {task.id} has {len(task.acceptance_criteria)})"
+            )
+
+    def amend_task(
+        self,
+        task: Task,
+        *,
+        summary: Optional[str] = None,
+        accept_replace: Optional[list[tuple[int, str]]] = None,
+        accept_remove: Optional[list[int]] = None,
+    ) -> None:
+        """The ``amend`` transition (#53-esd t1, issue #68): edit a summary and/or
+        acceptance criteria in place.
+
+        Scoped deliberately narrow — deps, covers, and instruction are untouched here;
+        they each already have their own move (``depend``, ``cover``, ``instruct``).
+        ``accept_replace``/``accept_remove`` index criteria 1-based (matching how they
+        are listed to the user). Replacements are applied first, against the *current*
+        list; removals are then applied in descending index order within this call, so
+        several ``--accept-remove`` indices always refer to the pre-call list rather
+        than shifting under each other. Raises ``ValueError`` on an out-of-range index
+        — the caller (the CLI ``amend`` move) is responsible for the re-confirm rule
+        when the task was confirmed, and for refusing a rejected task outright.
+        """
+        accept_replace = list(accept_replace or [])
+        accept_remove = list(accept_remove or [])
+        # Validate every index against the pre-call list before mutating anything, so a
+        # single bad index in a multi-item batch never leaves a partial edit behind.
+        for index, _text in accept_replace:
+            self._validate_acceptance_index(task, index)
+        for index in accept_remove:
+            self._validate_acceptance_index(task, index)
+        if summary is not None:
+            task.summary = summary
+        for index, text in accept_replace:
+            task.acceptance_criteria[index - 1] = text
+        for index in sorted(set(accept_remove), reverse=True):
+            del task.acceptance_criteria[index - 1]
 
     def set_status(self, task_id: str, status: str) -> bool:
         task = self.find_task(task_id)

--- a/devague/render/deliverables_md.py
+++ b/devague/render/deliverables_md.py
@@ -1,0 +1,106 @@
+"""Renderer: the read-only deliverables view — "what do we have in the end?" (#70).
+
+At the assign-to-workforce go/no-go, a human approves a workforce fan-out without
+seeing the world the plan actually produces. ``devague plan deliverables`` answers
+that question, synthesized *only* from existing frame/plan state: the live source
+frame's confirmed ``announcement`` / ``after_state`` / ``success_signal`` claims
+(verbatim), the plan's terminal tasks (:func:`devague.plan.terminal_tasks` — active
+tasks no other active task depends on) with their acceptance criteria, and surviving
+open items (the frame's non-blocking parked vagueness plus the plan's non-blocking
+risks).
+
+Like :mod:`devague.render.plan_md` this is **not** registered in the
+``devague.render`` registry (that registry is ``Callable[[Frame], str]``; a
+deliverables render needs the plan too) — ``devague plan deliverables`` calls
+:func:`render_deliverables` directly. Unlike every other exported artifact, this view
+never gates on convergence: an unconverged plan still renders, with an explicit
+banner instead of a refusal (issue #20 — Devague describes state, it does not judge
+whether the human should proceed).
+"""
+
+from __future__ import annotations
+
+from devague.frame import Claim, Frame
+from devague.plan import Plan, Task, terminal_tasks
+from devague.render._md_safety import autolink_urls, heading_safe
+
+NOT_CONVERGED_BANNER = "note: plan has not converged — this is a preview, not a commitment"
+
+_WORLD_AFTER_KINDS = (
+    ("announcement", "Announcement"),
+    ("after_state", "After state"),
+    ("success_signal", "Success signals"),
+)
+
+
+def _confirmed(frame: Frame, kind: str) -> list[Claim]:
+    return [c for c in frame.claims if c.kind == kind and c.status == "confirmed"]
+
+
+def _world_after_section(frame: Frame) -> list[str]:
+    """Confirmed announcement / after_state / success_signal claims, verbatim."""
+    out: list[str] = []
+    for kind, heading in _WORLD_AFTER_KINDS:
+        claims = _confirmed(frame, kind)
+        if not claims:
+            continue
+        out.append(f"## {heading}")
+        out.append("")
+        out.extend(f"- {autolink_urls(c.text)}" for c in claims)
+        out.append("")
+    return out
+
+
+def _task_lines(task: Task) -> list[str]:
+    lines = [f"- `{task.id}` — {autolink_urls(task.summary)}"]
+    lines.extend(f"  - {autolink_urls(a)}" for a in task.acceptance_criteria)
+    return lines
+
+
+def _terminal_tasks_section(plan: Plan) -> list[str]:
+    terminal = terminal_tasks(plan.tasks)
+    if not terminal:
+        return []
+    out = ["## Terminal tasks", ""]
+    for t in terminal:
+        out.extend(_task_lines(t))
+    out.append("")
+    return out
+
+
+def _open_items_section(frame: Frame, plan: Plan) -> list[str]:
+    """Surviving open items: non-blocking frame vagueness + non-blocking plan risks.
+
+    ``unknown_blocking`` items are excluded on both sides — a genuinely blocking item
+    would have kept the frame/plan from converging in the first place, so what
+    survives here is exactly the tracked-but-non-blocking uncertainty (mirrors
+    ``convergence._parked_items`` / ``plan_convergence._parked_items``).
+    """
+    items = [
+        f"[{v.kind}] {autolink_urls(v.text)}"
+        for v in frame.open_vagueness
+        if v.kind != "unknown_blocking"
+    ]
+    items += [
+        f"[{r.kind}] {autolink_urls(r.text)}" for r in plan.risks if r.kind != "unknown_blocking"
+    ]
+    if not items:
+        return []
+    out = ["## Open items", ""]
+    out.extend(f"- {i}" for i in items)
+    out.append("")
+    return out
+
+
+def render_deliverables(plan: Plan, frame: Frame, *, converged: bool) -> str:
+    """Render the deliverables view. Never refuses: an unconverged plan still
+    renders, with :data:`NOT_CONVERGED_BANNER` at the top instead of a gate error.
+    """
+    out = [f"# Deliverables — {heading_safe(plan.title)}", ""]
+    if not converged:
+        out.append(NOT_CONVERGED_BANNER)
+        out.append("")
+    out.extend(_world_after_section(frame))
+    out.extend(_terminal_tasks_section(plan))
+    out.extend(_open_items_section(frame, plan))
+    return "\n".join(out).rstrip() + "\n"

--- a/devague/render/summary_md.py
+++ b/devague/render/summary_md.py
@@ -36,10 +36,29 @@ from devague.render._md_safety import autolink_urls, heading_safe
 
 RUN_STATUS_PLACEHOLDER = "<complete | partial | failed>"
 
+# SonarCloud python:S1192 — this literal was duplicated across three render
+# paths (Planned Work / Actual Delivery / the --pr wave-task-map); one
+# constant backs all of them now.
+NO_TASKS_PLACEHOLDER = "(no tasks recorded on this plan)"
+
 # Kept local (not imported from devague.cli._paths) so this render module has no
 # dependency on the CLI layer — the same layering plan_md.py/spec_md.py already
 # keep. Mirrors cli/_paths.py's UNDATED_PREFIX sentinel and date-validity check.
 _UNDATED_PREFIX = "0000-00-00"
+
+
+def _escape_table_cell(text: str) -> str:
+    """Make ``text`` safe to interpolate into a single GFM markdown-table cell.
+
+    A raw ``|`` inside a cell is parsed as an extra column separator, silently
+    corrupting the row's column count; a raw newline breaks the row onto a
+    second line GFM does not treat as part of the same row. Both are
+    neutralised — the pipe is escaped (``\\|``, rendered as a literal ``|``),
+    and any newline is flattened to a space — so free-form prose interpolated
+    into a table cell (a deviation's ``reason`` in :func:`_drift_lines`) can
+    never break the table it renders into (#72 review, Q2).
+    """
+    return text.replace("|", "\\|").replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
 
 
 def _date_prefix(created: str) -> str:
@@ -100,7 +119,7 @@ def _intent_lines(plan: Plan, frame: Optional[Frame]) -> list[str]:
 def _planned_work_lines(plan: Plan) -> list[str]:
     lines = ["## Planned Work", ""]
     if not plan.tasks:
-        lines.append("(no tasks recorded on this plan)")
+        lines.append(NO_TASKS_PLACEHOLDER)
         lines.append("")
         return lines
     for t in plan.tasks:
@@ -113,7 +132,7 @@ def _planned_work_lines(plan: Plan) -> list[str]:
 def _actual_delivery_lines(plan: Plan) -> list[str]:
     lines = ["## Actual Delivery", ""]
     if not plan.tasks:
-        lines.append("(no tasks recorded on this plan)")
+        lines.append(NO_TASKS_PLACEHOLDER)
         lines.append("")
         return lines
     lines.append("| Plan task | Status | What actually landed |")
@@ -155,9 +174,13 @@ def _drift_lines(delivery: Delivery) -> list[str]:
     lines.append("|-----------|------------------------|-----------------|")
     for d in approved:
         classification = f"`{d.classification}`" if d.classification else "`<fill: classification>`"
-        lines.append(
-            f"| `{d.task_ref}` (`{d.id}`) | {autolink_urls(d.reason)} | {classification} |"
-        )
+        # d.task_ref/d.id are backticked refs; d.reason is free-form prose --
+        # _escape_table_cell keeps a raw '|' or newline in it from corrupting
+        # the row (#72 review, Q2).
+        reason = _escape_table_cell(autolink_urls(d.reason))
+        task_ref = _escape_table_cell(d.task_ref)
+        did = _escape_table_cell(d.id)
+        lines.append(f"| `{task_ref}` (`{did}`) | {reason} | {classification} |")
     lines.append("")
     return lines
 
@@ -271,7 +294,7 @@ def _wave_task_map_lines(plan: Plan) -> list[str]:
     lines = ["## Wave / Task Map", ""]
     waves = dependency_waves(plan.tasks)
     if not waves:
-        lines.append("(no tasks recorded on this plan)")
+        lines.append(NO_TASKS_PLACEHOLDER)
         lines.append("")
         return lines
     for i, wave in enumerate(waves):

--- a/devague/render/summary_md.py
+++ b/devague/render/summary_md.py
@@ -1,0 +1,334 @@
+"""Renderer: the eight-section delivery-summary skeleton, from state alone (#53-esd t4).
+
+Structural peer of :mod:`devague.render.plan_md` — but where a plan render fills in
+what was *contracted*, this renderer fills in only what is *mechanically derivable*
+from a plan, its live source frame, and its delivery (deviation) store. It never
+claims anything is done: run status, per-task delivery status, evidence, and
+delivery claims all stay explicit ``<fill: ...>`` placeholders (backticked so they
+render as literal code spans, not inline HTML — MD033-safe) until a human fills
+them in. This is the no-overclaim boundary the whole feature exists to hold.
+
+Section names and order are pinned to the eight-section template in
+``.claude/skills/summarize-delivery/SKILL.md`` — Intent, Planned Work, Actual
+Delivery, Mid-work Decisions, Drift From Plan, Evidence, Delivery Claims,
+Remaining Work / Follow-up. Only two sections are pre-filled from real state
+beyond the plan's task list: Mid-work Decisions and Drift From Plan quote
+**approved** deviation records by id; a ``proposed`` deviation is never rendered
+as if it were an approved decision — it surfaces (if at all) under an explicit
+"pending approval" line, never folded into the approved lists.
+
+``--pr`` mode (see :func:`render_pr_summary`) is a separate, condensed rendering
+for a PR body: title, announcement, the wave/task map, approved deviations, and a
+pointer to the ``docs/deliveries/<date>-<slug>.md`` artifact this skeleton seeds.
+
+Pure functions of ``(Plan, Optional[Frame], Delivery)`` — no I/O, no mutation.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from devague.delivery import Delivery, DeviationRecord
+from devague.frame import Frame
+from devague.plan import Plan, dependency_waves
+from devague.render._md_safety import autolink_urls, heading_safe
+
+RUN_STATUS_PLACEHOLDER = "<complete | partial | failed>"
+
+# Kept local (not imported from devague.cli._paths) so this render module has no
+# dependency on the CLI layer — the same layering plan_md.py/spec_md.py already
+# keep. Mirrors cli/_paths.py's UNDATED_PREFIX sentinel and date-validity check.
+_UNDATED_PREFIX = "0000-00-00"
+
+
+def _date_prefix(created: str) -> str:
+    date = (created or "")[:10]
+    try:
+        time.strptime(date, "%Y-%m-%d")
+        return date
+    except ValueError:
+        return _UNDATED_PREFIX
+
+
+def _deliveries_pointer(plan: Plan) -> str:
+    return f"docs/deliveries/{_date_prefix(plan.created)}-{plan.slug}.md"
+
+
+def _confirmed_claim_texts(frame: Optional[Frame], kind: str) -> list[str]:
+    if frame is None:
+        return []
+    return [c.text for c in frame.claims if c.kind == kind and c.status == "confirmed"]
+
+
+def _confirmed_claim_text(frame: Optional[Frame], kind: str) -> Optional[str]:
+    texts = _confirmed_claim_texts(frame, kind)
+    return texts[0] if texts else None
+
+
+def _approved(delivery: Delivery) -> list[DeviationRecord]:
+    return [d for d in delivery.deviations if d.status == "approved"]
+
+
+def _pending(delivery: Delivery) -> list[DeviationRecord]:
+    return [d for d in delivery.deviations if d.status == "proposed"]
+
+
+# ── markdown sections ────────────────────────────────────────────────────────
+def _intent_lines(plan: Plan, frame: Optional[Frame]) -> list[str]:
+    lines = ["## Intent", ""]
+    if frame is None:
+        lines.append(
+            f"No source frame available (`{plan.frame_slug}` could not be loaded) — "
+            "fill in the intent manually."
+        )
+        lines.append("")
+        return lines
+    ann = _confirmed_claim_text(frame, "announcement")
+    if ann:
+        lines.append("> " + autolink_urls(ann))
+    else:
+        lines.append("(no confirmed announcement recorded in the source frame)")
+    afters = _confirmed_claim_texts(frame, "after_state")
+    if afters:
+        lines.append("")
+        lines.append("After: " + "; ".join(autolink_urls(a) for a in afters))
+    lines.append("")
+    return lines
+
+
+def _planned_work_lines(plan: Plan) -> list[str]:
+    lines = ["## Planned Work", ""]
+    if not plan.tasks:
+        lines.append("(no tasks recorded on this plan)")
+        lines.append("")
+        return lines
+    for t in plan.tasks:
+        mark = "" if t.status == "confirmed" else f" _({t.status})_"
+        lines.append(f"- `{t.id}` — {autolink_urls(t.summary)}{mark}")
+    lines.append("")
+    return lines
+
+
+def _actual_delivery_lines(plan: Plan) -> list[str]:
+    lines = ["## Actual Delivery", ""]
+    if not plan.tasks:
+        lines.append("(no tasks recorded on this plan)")
+        lines.append("")
+        return lines
+    lines.append("| Plan task | Status | What actually landed |")
+    lines.append("|-----------|--------|----------------------|")
+    for t in plan.tasks:
+        lines.append(f"| `{t.id}` | `<fill: status>` | `<fill: what landed>` |")
+    lines.append("")
+    return lines
+
+
+def _mid_work_lines(delivery: Delivery) -> list[str]:
+    lines = ["## Mid-work Decisions", ""]
+    approved = _approved(delivery)
+    pending = _pending(delivery)
+    if not approved and not pending:
+        lines.append("(no deviations recorded yet)")
+        lines.append("")
+        return lines
+    for d in approved:
+        lines.append(f"- `{d.id}` — {autolink_urls(d.what)} — {autolink_urls(d.reason)}")
+    if pending:
+        ids = ", ".join(f"`{d.id}`" for d in pending)
+        lines.append(f"- pending approval (not yet a decision): {ids}")
+    lines.append("")
+    return lines
+
+
+def _drift_lines(delivery: Delivery) -> list[str]:
+    lines = ["## Drift From Plan", ""]
+    approved = _approved(delivery)
+    if not approved:
+        lines.append(
+            "no approved deviation records yet — record drift via `devague deviate` "
+            "before this section can be filled in"
+        )
+        lines.append("")
+        return lines
+    lines.append("| Plan item | Reason for divergence | Classification |")
+    lines.append("|-----------|------------------------|-----------------|")
+    for d in approved:
+        classification = f"`{d.classification}`" if d.classification else "`<fill: classification>`"
+        lines.append(
+            f"| `{d.task_ref}` (`{d.id}`) | {autolink_urls(d.reason)} | {classification} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _evidence_lines() -> list[str]:
+    return [
+        "## Evidence",
+        "",
+        "- tests: `<fill: pytest node id>` — `<fill: pass | fail>`",
+        "- lint: `<fill: command>` — `<fill: result>`",
+        "- commits: `<fill: sha>..<fill: sha>`",
+        "- PRs / issues: `<fill: #NN>`",
+        "",
+    ]
+
+
+def _delivery_claims_lines() -> list[str]:
+    return [
+        "## Delivery Claims",
+        "",
+        "| Claim | Confidence | Evidence |",
+        "|-------|------------|----------|",
+        "| `<fill: what was delivered>` | `<fill: confidence>` | `<fill: evidence>` |",
+        "",
+    ]
+
+
+def _remaining_work_lines() -> list[str]:
+    return [
+        "## Remaining Work / Follow-up",
+        "",
+        "- `<fill: remaining item>` — `<fill: next step / owner>`",
+        "",
+    ]
+
+
+def render_summary(plan: Plan, frame: Optional[Frame], delivery: Delivery) -> str:
+    """The eight-section delivery-summary skeleton, pre-filled from state alone.
+
+    Deterministic and read-only: calling this twice on unchanged ``(plan, frame,
+    delivery)`` produces byte-identical output, and nothing here writes to disk.
+    """
+    date = _date_prefix(plan.created)
+    out = [
+        f"# Delivery Summary — {heading_safe(plan.title)}",
+        "",
+        f"plan: `{plan.slug}` · run: `{RUN_STATUS_PLACEHOLDER}` · date: `{date}`",
+        f"baseline: `devague plan ({plan.slug})`",
+        "",
+    ]
+    out += _intent_lines(plan, frame)
+    out += _planned_work_lines(plan)
+    out += _actual_delivery_lines(plan)
+    out += _mid_work_lines(delivery)
+    out += _drift_lines(delivery)
+    out += _evidence_lines()
+    out += _delivery_claims_lines()
+    out += _remaining_work_lines()
+    return "\n".join(out).rstrip() + "\n"
+
+
+def summary_data(plan: Plan, frame: Optional[Frame], delivery: Delivery) -> dict:
+    """The structured (``--json``) equivalent of :func:`render_summary`.
+
+    Carries the same pre-filled data and the same explicit placeholder markers —
+    a consumer parsing JSON gets no more certainty than a reader of the markdown.
+    """
+    approved = _approved(delivery)
+    pending = _pending(delivery)
+    return {
+        "plan": plan.slug,
+        "title": plan.title,
+        "run_status": RUN_STATUS_PLACEHOLDER,
+        "date": _date_prefix(plan.created),
+        "baseline": f"devague plan ({plan.slug})",
+        "frame_available": frame is not None,
+        "sections": {
+            "intent": {
+                "announcement": _confirmed_claim_text(frame, "announcement"),
+                "after_state": _confirmed_claim_texts(frame, "after_state"),
+            },
+            "planned_work": [
+                {"id": t.id, "summary": t.summary, "status": t.status} for t in plan.tasks
+            ],
+            "actual_delivery": [
+                {"id": t.id, "status": "<fill: status>", "what_landed": "<fill: what landed>"}
+                for t in plan.tasks
+            ],
+            "mid_work_decisions": [
+                {"id": d.id, "what": d.what, "reason": d.reason} for d in approved
+            ],
+            "drift_from_plan": [
+                {
+                    "task": d.task_ref,
+                    "deviation": d.id,
+                    "reason": d.reason,
+                    "classification": d.classification or "<fill: classification>",
+                }
+                for d in approved
+            ],
+            "pending_deviations": [d.id for d in pending],
+            "evidence": "<fill: evidence>",
+            "delivery_claims": "<fill: delivery claims>",
+            "remaining_work": "<fill: remaining work>",
+        },
+    }
+
+
+# ── --pr mode: condensed PR-body skeleton ────────────────────────────────────
+def _wave_task_map_lines(plan: Plan) -> list[str]:
+    lines = ["## Wave / Task Map", ""]
+    waves = dependency_waves(plan.tasks)
+    if not waves:
+        lines.append("(no tasks recorded on this plan)")
+        lines.append("")
+        return lines
+    for i, wave in enumerate(waves):
+        lines.append(f"- wave {i}: " + ", ".join(f"`{tid}`" for tid in wave))
+    by_id = {t.id: t for t in plan.tasks}
+    lines.append("")
+    for wave in waves:
+        for tid in wave:
+            t = by_id.get(tid)
+            if t is not None:
+                lines.append(f"- `{t.id}` — {autolink_urls(t.summary)}")
+    lines.append("")
+    return lines
+
+
+def _approved_deviations_lines(delivery: Delivery) -> list[str]:
+    lines = ["## Approved Deviations", ""]
+    approved = _approved(delivery)
+    if not approved:
+        lines.append("(none recorded)")
+        lines.append("")
+        return lines
+    for d in approved:
+        lines.append(
+            f"- `{d.id}` (task `{d.task_ref}`) — {autolink_urls(d.what)}: {autolink_urls(d.reason)}"
+        )
+    lines.append("")
+    return lines
+
+
+def render_pr_summary(plan: Plan, frame: Optional[Frame], delivery: Delivery) -> str:
+    """The condensed ``--pr`` skeleton: title, announcement, wave/task map,
+    approved deviations, and a pointer to the ``docs/deliveries`` artifact.
+    """
+    out = [f"# {heading_safe(plan.title)}", ""]
+    ann = _confirmed_claim_text(frame, "announcement")
+    if ann:
+        out += ["> " + autolink_urls(ann), ""]
+    out += _wave_task_map_lines(plan)
+    out += _approved_deviations_lines(delivery)
+    out += [f"Delivery summary: `{_deliveries_pointer(plan)}`", ""]
+    return "\n".join(out).rstrip() + "\n"
+
+
+def pr_data(plan: Plan, frame: Optional[Frame], delivery: Delivery) -> dict:
+    """The structured (``--json``) equivalent of :func:`render_pr_summary`."""
+    waves = dependency_waves(plan.tasks)
+    by_id = {t.id: t for t in plan.tasks}
+    approved = _approved(delivery)
+    return {
+        "plan": plan.slug,
+        "title": plan.title,
+        "announcement": _confirmed_claim_text(frame, "announcement"),
+        "waves": waves,
+        "tasks": {tid: by_id[tid].summary for wave in waves for tid in wave if tid in by_id},
+        "approved_deviations": [
+            {"id": d.id, "task": d.task_ref, "what": d.what, "reason": d.reason} for d in approved
+        ],
+        "deliveries_pointer": _deliveries_pointer(plan),
+    }

--- a/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
+++ b/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
@@ -56,6 +56,11 @@ Quoted verbatim from the `devague summary` skeleton:
   `amend` (task `t1`, classification `acceptable`) — recorded during the run
   as llm-origin `proposed`, **approved by the user** at the final gate via
   `devague deviate --confirm d1`.
+- `d2` — `devague learn skills` teaches authoring all six origin skills, not
+  the original three (task `t11`, classification `acceptable`) — user-directed
+  at the final PR gate (user origin, auto-approved); the recipe also stopped
+  emitting script URLs for the three method-only skills, which would have
+  been 404s.
 - Mid-run, the human owner refined the split-plan Model-column contract
   ("should be the model, and if matters, harness — haiku, sonnet, opus, fable,
   colleague, codex"); forwarded verbatim to the `t5` agent and applied as a
@@ -79,6 +84,7 @@ Quoted verbatim from the `devague summary` skeleton:
 | Plan item | Reason for divergence | Classification |
 |-----------|-----------------------|----------------|
 | `t1` (`d1`, approved) | cutting an edge or amending criteria mutates existing list fields — no persisted shape change, so the frame assumption c14 (conditional on a plan-JSON shape change) did not apply; deviation records live in their own store per resolved q3 | acceptable |
+| `t11` (`d2`, approved) | user directive at the final PR gate: the skill-authoring recipe still taught only think, spec-to-plan, and assign-to-workforce — an agent following it would rebuild a three-legged kit while the shipped flow has six legs | acceptable |
 | `t9` | acceptance criterion 2 (live `agex pr open`) was sequenced after this artifact's first commit by design (risk `r1`); resolved in-run — PR `#72` opened via `agex pr open`, requiring a `git stash -u` workaround for an unrelated agex bug (filed upstream as devex issue 92) | acceptable |
 
 No other task drifted: `t2`–`t8`, `t10`, `t11` delivered against their
@@ -86,10 +92,10 @@ acceptance criteria as confirmed.
 
 ## Evidence
 
-- tests: `uv run pytest -n auto` — **577 passed** (post-merge, full suite, all
-  four waves in)
-- coverage: `uv run pytest -n auto --cov=devague` — **97.85 %** (`TOTAL 2515
-  54 98%`; CI gate requires ≥ 95 %)
+- tests: `uv run pytest -n auto` — **614 passed** (final: all four waves +
+  gate-3 review fixes + the d2 learn extension; 577 at wave close)
+- coverage: `uv run pytest -n auto --cov=devague` — **98.02 %** (CI gate
+  requires ≥ 95 %)
 - lint: `uv run flake8 --config=.flake8 devague/ tests/` — clean;
   `markdownlint-cli2 "CHANGELOG.md" "README.md" "CLAUDE.md" "docs/skills.md"`
   — 0 errors
@@ -116,6 +122,7 @@ acceptance criteria as confirmed.
 | human-approved deviations are first-class, append-only records | high | commit `6b06ec7` · `tests/test_deviate.py` (44 tests) · live record `d1` produced during this run |
 | `devague summary` renders the eight-section skeleton with no overclaim | high | commit `1bcc8d0` · `tests/test_summary.py` (30 tests) · this artifact's own baseline |
 | the six-leg flow is documented end to end | high | commits `6934479`, `003d0c6`, `8e729e3` · files `.claude/skills/deviate/SKILL.md`, `docs/skill-sources.md`, `CLAUDE.md` |
+| `devague learn skills` teaches authoring all six origin skills (method-only ones without fabricated script URLs) | high | commit `18af032` · `tests/test_cli_learn.py` |
 | the cicd lane works with `backend: claude` from this repo | high | PR `#72` opened via `agex pr open` (signed, Qodo review posted) with `backend: claude` in `culture.yaml` |
 | 0.18.0 publishes cleanly to PyPI | unverified | publish workflow runs post-merge — not claimed done |
 

--- a/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
+++ b/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
@@ -46,7 +46,7 @@ Quoted verbatim from the `devague summary` skeleton:
 | `t6` | delivered | trailing End state section quoting `devague plan deliverables` verbatim, with graceful degradation hint on older devague; commit `436d323` |
 | `t7` | delivered | `.claude/skills/deviate/SKILL.md` (sixth origin skill) + `docs/skill-sources.md` registration; commit `6934479` |
 | `t8` | delivered | summarize-delivery starts from the `devague summary` skeleton, quotes approved deviations by `dN` id, three-tier baseline ladder; commit `003d0c6` |
-| `t9` | partial | `culture.yaml` declares `backend: claude` (commit `bee2158`); the live `agex pr open` verification (acceptance criterion 2, plan risk `r1`) happens at PR-open time, immediately after this artifact is committed |
+| `t9` | delivered | `culture.yaml` declares `backend: claude` (commit `bee2158`); live verification passed — PR `#72` was opened via `agex pr open` with the reverted backend in place (criterion 2, risk `r1`) |
 | `t10` | delivered | #67 closed with the 0.17.2 repro transcript; #62 closed citing 0.17.0/#63 and the dogfood artifact; both comments signed (operator task, no code) |
 | `t11` | delivered | version 0.18.0, full CHANGELOG entry, six-leg-flow docs (`CLAUDE.md`, `README.md`, `docs/skills.md`), coverage + boundary audits; commit `8e729e3` |
 
@@ -79,7 +79,7 @@ Quoted verbatim from the `devague summary` skeleton:
 | Plan item | Reason for divergence | Classification |
 |-----------|-----------------------|----------------|
 | `t1` (`d1` — proposed, awaiting user confirmation) | cutting an edge or amending criteria mutates existing list fields — no persisted shape change, so the frame assumption c14 (conditional on a plan-JSON shape change) did not apply; deviation records live in their own store per resolved q3 | acceptable (per the record; pending) |
-| `t9` | acceptance criterion 2 (live `agex pr open` before the release PR merges) is sequenced after this artifact by design — plan risk `r1` named the release PR itself as the test vehicle | needs-follow-up |
+| `t9` | acceptance criterion 2 (live `agex pr open`) was sequenced after this artifact's first commit by design (risk `r1`); resolved in-run — PR `#72` opened via `agex pr open`, requiring a `git stash -u` workaround for an unrelated agex bug (filed upstream as devex issue 92) | acceptable |
 
 No other task drifted: `t2`–`t8`, `t10`, `t11` delivered against their
 acceptance criteria as confirmed.
@@ -116,15 +116,11 @@ acceptance criteria as confirmed.
 | human-approved deviations are first-class, append-only records | high | commit `6b06ec7` · `tests/test_deviate.py` (44 tests) · live record `d1` produced during this run |
 | `devague summary` renders the eight-section skeleton with no overclaim | high | commit `1bcc8d0` · `tests/test_summary.py` (30 tests) · this artifact's own baseline |
 | the six-leg flow is documented end to end | high | commits `6934479`, `003d0c6`, `8e729e3` · files `.claude/skills/deviate/SKILL.md`, `docs/skill-sources.md`, `CLAUDE.md` |
-| the cicd lane works with `backend: claude` from this repo | unverified | pending the live `agex pr open` at gate 3 — not claimed done until the PR exists |
+| the cicd lane works with `backend: claude` from this repo | high | PR `#72` opened via `agex pr open` (signed, Qodo review posted) with `backend: claude` in `culture.yaml` |
 | 0.18.0 publishes cleanly to PyPI | unverified | publish workflow runs post-merge — not claimed done |
 
 ## Remaining Work / Follow-up
 
-- `t9` — complete acceptance criterion 2: open the release PR via
-  `agex pr open` (the live verification, risk `r1`) and record the result in
-  the PR body; then upgrade the corresponding claim above with the PR number
-  as evidence. Owner: operator, immediately after this commit.
 - `d1` — user decision pending: `devague deviate --confirm d1` (or
   `--reject d1`). Owner: human.
 - Issues #66, #68, #69, #70 close on PR merge (close-keywords in the PR body).
@@ -136,3 +132,6 @@ acceptance criteria as confirmed.
   `baseline:` line renders `devague plan (<slug>)` rather than the SKILL.md
   tier vocabulary (`devague summary skeleton`) — align the renderer's label
   with the skill's three-tier names. Candidate issue for 0.18.x.
+- Upstream: devex issue 92 (`agex pr open` misreads gh's untracked-files
+  warning as failure with a misleading network hint) — filed during this run;
+  the `git stash -u` workaround stands until it lands. Owner: devex.

--- a/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
+++ b/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
@@ -52,10 +52,10 @@ Quoted verbatim from the `devague summary` skeleton:
 
 ## Mid-work Decisions
 
-- pending approval (not yet a decision): `d1` — no PLAN_SCHEMA_VERSION bump
-  shipped with `depend --remove` and `amend` (task `t1`, proposed,
-  classification `acceptable` on the record) — **awaiting user
-  confirm/reject** via `devague deviate --confirm d1`.
+- `d1` — no PLAN_SCHEMA_VERSION bump shipped with `depend --remove` and
+  `amend` (task `t1`, classification `acceptable`) — recorded during the run
+  as llm-origin `proposed`, **approved by the user** at the final gate via
+  `devague deviate --confirm d1`.
 - Mid-run, the human owner refined the split-plan Model-column contract
   ("should be the model, and if matters, harness — haiku, sonnet, opus, fable,
   colleague, codex"); forwarded verbatim to the `t5` agent and applied as a
@@ -78,7 +78,7 @@ Quoted verbatim from the `devague summary` skeleton:
 
 | Plan item | Reason for divergence | Classification |
 |-----------|-----------------------|----------------|
-| `t1` (`d1` — proposed, awaiting user confirmation) | cutting an edge or amending criteria mutates existing list fields — no persisted shape change, so the frame assumption c14 (conditional on a plan-JSON shape change) did not apply; deviation records live in their own store per resolved q3 | acceptable (per the record; pending) |
+| `t1` (`d1`, approved) | cutting an edge or amending criteria mutates existing list fields — no persisted shape change, so the frame assumption c14 (conditional on a plan-JSON shape change) did not apply; deviation records live in their own store per resolved q3 | acceptable |
 | `t9` | acceptance criterion 2 (live `agex pr open`) was sequenced after this artifact's first commit by design (risk `r1`); resolved in-run — PR `#72` opened via `agex pr open`, requiring a `git stash -u` workaround for an unrelated agex bug (filed upstream as devex issue 92) | acceptable |
 
 No other task drifted: `t2`–`t8`, `t10`, `t11` delivered against their
@@ -103,7 +103,7 @@ acceptance criteria as confirmed.
   (comment 4974139790), [#62](https://github.com/agentculture/devague/issues/62)
   closed (comment 4974140038)
 - deviation store: `.devague/deliveries/execution-seam-and-deviate.json`
-  (record `d1`, status `proposed`)
+  (record `d1`, status `approved`)
 
 ## Delivery Claims
 
@@ -121,8 +121,6 @@ acceptance criteria as confirmed.
 
 ## Remaining Work / Follow-up
 
-- `d1` — user decision pending: `devague deviate --confirm d1` (or
-  `--reject d1`). Owner: human.
 - Issues #66, #68, #69, #70 close on PR merge (close-keywords in the PR body).
   Owner: human at gate 3.
 - guildmaster re-broadcast: four origin skills changed here (`deviate` new;

--- a/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
+++ b/docs/deliveries/2026-07-14-execution-seam-and-deviate.md
@@ -1,0 +1,138 @@
+# Delivery Summary — execution seam and deviate
+
+plan: `execution-seam-and-deviate` · run: `complete` · date: `2026-07-14`
+baseline: `devague summary skeleton`
+
+## Intent
+
+Ship devague 0.18.0 — the execution seam: a deliverables view that answers
+"what do we have in the end?" at the go/no-go (#70), the four-column split-plan
+table humans actually approve (#69), dependency-edge removal and task amending
+without recreation cascades (#68), stdout-visible demotion (#67 hardening),
+first-class human-approved deviation records connecting the plan to the
+delivery summary (the new sixth leg), a render-only `devague summary` skeleton,
+the `culture.yaml` backend revert (#66), and evidence-based closures of issues
+62 and 67. Executed as 11 tasks over 4 dependency waves by an `/assign-to-workforce`
+fan-out (one agent per task, isolated worktrees, TDD-gated merges).
+
+## Planned Work
+
+Quoted verbatim from the `devague summary` skeleton:
+
+- `t1` — plan-engine escape hatches and demotion visibility: `depend --remove`,
+  new `amend` move, stdout flip echo
+- `t2` — read-only `devague plan deliverables` view with `--json` and
+  not-converged banner
+- `t3` — delivery store and the `devague deviate` move
+- `t4` — render-only `devague summary` verb with `--pr` PR-body mode
+- `t5` — split-plan renders the four-column table with wave-listing markers
+- `t6` — split-plan End state section quoting `plan deliverables`
+- `t7` — new sixth origin skill `/deviate`
+- `t8` — summarize-delivery consumes deviation records and the summary skeleton
+- `t9` — culture.yaml backend reverts to claude with live agex verification
+- `t10` — close issues 62 and 67 with cited evidence
+- `t11` — release closure: version bump, changelog, docs, coverage and
+  boundary audit
+
+## Actual Delivery
+
+| Plan task | Status | What actually landed |
+|-----------|--------|----------------------|
+| `t1` | delivered | `Plan.remove_dep` + `amend` move + stdout flip echo on all demoting moves; commit `d0b684f`, 24 tests in `tests/test_plan_escape_hatches.py` |
+| `t2` | delivered | `devague plan deliverables [--json]`, `devague/render/deliverables_md.py`, `terminal_tasks` helper; commit `b12db1a`, 22 tests |
+| `t3` | delivered | `devague/delivery.py`, `devague/delivery_store.py`, `devague deviate` verb; commit `6b06ec7`, 44 tests; dogfooded live in this very run (record `d1`) |
+| `t4` | delivered | `devague summary [--pr] [--json]`, `devague/render/summary_md.py`; commit `1bcc8d0`, 30 tests; this artifact's baseline was rendered by it |
+| `t5` | delivered | four-column `Wave / Task / Model / Task summary` table, real model tokens, 72-char truncation, wave-listing markers; commit `ba94f84` |
+| `t6` | delivered | trailing End state section quoting `devague plan deliverables` verbatim, with graceful degradation hint on older devague; commit `436d323` |
+| `t7` | delivered | `.claude/skills/deviate/SKILL.md` (sixth origin skill) + `docs/skill-sources.md` registration; commit `6934479` |
+| `t8` | delivered | summarize-delivery starts from the `devague summary` skeleton, quotes approved deviations by `dN` id, three-tier baseline ladder; commit `003d0c6` |
+| `t9` | partial | `culture.yaml` declares `backend: claude` (commit `bee2158`); the live `agex pr open` verification (acceptance criterion 2, plan risk `r1`) happens at PR-open time, immediately after this artifact is committed |
+| `t10` | delivered | #67 closed with the 0.17.2 repro transcript; #62 closed citing 0.17.0/#63 and the dogfood artifact; both comments signed (operator task, no code) |
+| `t11` | delivered | version 0.18.0, full CHANGELOG entry, six-leg-flow docs (`CLAUDE.md`, `README.md`, `docs/skills.md`), coverage + boundary audits; commit `8e729e3` |
+
+## Mid-work Decisions
+
+- pending approval (not yet a decision): `d1` — no PLAN_SCHEMA_VERSION bump
+  shipped with `depend --remove` and `amend` (task `t1`, proposed,
+  classification `acceptable` on the record) — **awaiting user
+  confirm/reject** via `devague deviate --confirm d1`.
+- Mid-run, the human owner refined the split-plan Model-column contract
+  ("should be the model, and if matters, harness — haiku, sonnet, opus, fable,
+  colleague, codex"); forwarded verbatim to the `t5` agent and applied as a
+  guidance line after the table, not a new column. Gate-2 owner amending the
+  split in-flight; `t5`'s acceptance criteria were unchanged.
+- `t3` made `--task` required when recording a deviation (the brief left it
+  ambiguous) — symmetric with the missing-`--reason` refusal.
+- `t2` extended "never refuses" to a regressed source frame: `deliverables`
+  renders with the banner where `status`/`converge`/`export` raise; a
+  missing/corrupt frame still raises.
+- `t6` placed the End state section last (after the go/no-go block): the
+  acceptance criterion "output ends with the End state section" overrode the
+  brief's looser "before the go/no-go" wording — criteria are the contract.
+- `t11` fixed two pre-existing stale doc statements the release made obviously
+  wrong (plan-move lists missing `instruct`; the "Current gap: nothing
+  consumes waves" paragraph) — invited by its instruction, noted for
+  completeness.
+
+## Drift From Plan
+
+| Plan item | Reason for divergence | Classification |
+|-----------|-----------------------|----------------|
+| `t1` (`d1` — proposed, awaiting user confirmation) | cutting an edge or amending criteria mutates existing list fields — no persisted shape change, so the frame assumption c14 (conditional on a plan-JSON shape change) did not apply; deviation records live in their own store per resolved q3 | acceptable (per the record; pending) |
+| `t9` | acceptance criterion 2 (live `agex pr open` before the release PR merges) is sequenced after this artifact by design — plan risk `r1` named the release PR itself as the test vehicle | needs-follow-up |
+
+No other task drifted: `t2`–`t8`, `t10`, `t11` delivered against their
+acceptance criteria as confirmed.
+
+## Evidence
+
+- tests: `uv run pytest -n auto` — **577 passed** (post-merge, full suite, all
+  four waves in)
+- coverage: `uv run pytest -n auto --cov=devague` — **97.85 %** (`TOTAL 2515
+  54 98%`; CI gate requires ≥ 95 %)
+- lint: `uv run flake8 --config=.flake8 devague/ tests/` — clean;
+  `markdownlint-cli2 "CHANGELOG.md" "README.md" "CLAUDE.md" "docs/skills.md"`
+  — 0 errors
+- boundary audit: grep for `subprocess|urllib|requests|httpx|socket|anthropic|
+  openai` across `deliverables_md.py`, `summary_md.py`, `deviate.py`,
+  `summary.py`, `delivery.py`, `delivery_store.py` — zero usages (one
+  docstring stating the absence)
+- commits: `40fa144..2bf6c33` (11 task commits + 11 merge commits on
+  `spec/execution-seam-and-deviate`)
+- issues: [#67](https://github.com/agentculture/devague/issues/67) closed
+  (comment 4974139790), [#62](https://github.com/agentculture/devague/issues/62)
+  closed (comment 4974140038)
+- deviation store: `.devague/deliveries/execution-seam-and-deviate.json`
+  (record `d1`, status `proposed`)
+
+## Delivery Claims
+
+| Claim | Confidence | Evidence |
+|-------|------------|----------|
+| `devague plan deliverables` answers the end-state question read-only, never refusing (#70) | high | commit `b12db1a` · `tests/test_plan_deliverables.py` (22 tests, byte-identical-state proof) |
+| split-plan renders the four-column table + End state section (#69, #70) | high | commits `ba94f84`, `436d323` · `tests/test_assign_to_workforce_script.py` (end-to-end script runs) |
+| a dependency edge is removable and a task amendable without recreation (#68) | high | commit `d0b684f` · `tests/test_plan_escape_hatches.py` round-trip tests |
+| every demoting move names the flip on stdout alone (#67 hardening) | high | commit `d0b684f` · stdout-only capture test |
+| human-approved deviations are first-class, append-only records | high | commit `6b06ec7` · `tests/test_deviate.py` (44 tests) · live record `d1` produced during this run |
+| `devague summary` renders the eight-section skeleton with no overclaim | high | commit `1bcc8d0` · `tests/test_summary.py` (30 tests) · this artifact's own baseline |
+| the six-leg flow is documented end to end | high | commits `6934479`, `003d0c6`, `8e729e3` · files `.claude/skills/deviate/SKILL.md`, `docs/skill-sources.md`, `CLAUDE.md` |
+| the cicd lane works with `backend: claude` from this repo | unverified | pending the live `agex pr open` at gate 3 — not claimed done until the PR exists |
+| 0.18.0 publishes cleanly to PyPI | unverified | publish workflow runs post-merge — not claimed done |
+
+## Remaining Work / Follow-up
+
+- `t9` — complete acceptance criterion 2: open the release PR via
+  `agex pr open` (the live verification, risk `r1`) and record the result in
+  the PR body; then upgrade the corresponding claim above with the PR number
+  as evidence. Owner: operator, immediately after this commit.
+- `d1` — user decision pending: `devague deviate --confirm d1` (or
+  `--reject d1`). Owner: human.
+- Issues #66, #68, #69, #70 close on PR merge (close-keywords in the PR body).
+  Owner: human at gate 3.
+- guildmaster re-broadcast: four origin skills changed here (`deviate` new;
+  `assign-to-workforce`, `summarize-delivery` updated; `docs/skill-sources.md`
+  registry) — guildmaster pulls from devague post-merge. Owner: guildmaster.
+- Small follow-up found while dogfooding: the `devague summary` skeleton's
+  `baseline:` line renders `devague plan (<slug>)` rather than the SKILL.md
+  tier vocabulary (`devague summary skeleton`) — align the renderer's label
+  with the skill's three-tier names. Candidate issue for 0.18.x.

--- a/docs/plans/2026-07-14-execution-seam-and-deviate.md
+++ b/docs/plans/2026-07-14-execution-seam-and-deviate.md
@@ -1,0 +1,117 @@
+# Build Plan — execution seam and deviate
+
+slug: `execution-seam-and-deviate` · status: `exported` · from frame: `execution-seam-and-deviate`
+
+> devague closes the execution seam: a deliverables view answers what we have in the end at the go or no-go, the split plan renders the table humans actually approve, dependency edges can be removed without task recreation, and human-approved deviations become first-class records that connect the plan to the delivery summary
+
+## Tasks
+
+### t1 — plan-engine escape hatches and demotion visibility: `depend --remove`, new `amend` move, stdout flip echo
+
+- instruction: OWNS: devague/plan.py, devague/cli/_commands/plan.py, tests/test_plan_escape_hatches.py (new). Add Plan.remove_dep and an amend transition (summary edit; acceptance-criteria replace/remove by index). CLI: `depend <tN> --on <tM> --remove` cuts one edge; new `amend <tN> [--summary "<text>"] [--accept-replace <n> "<text>"] [--accept-remove <n>]`. Any demoting change (instruct, amend, depend remove) on a confirmed task flips it to proposed AND appends the flip to the stdout result line, e.g. `t1: instruction set (confirmed -> proposed; re-confirm)`; keep the stderr note and the flipped field in `--json`. TDD: write the stdout-only capture test first.
+- covers: c5, h5, c24, h15, c25, h16
+- acceptance:
+  - depend remove cuts exactly the named edge; the task keeps summary, acceptance criteria, covers, and instruction unchanged (round-trip test)
+  - amend edits the summary and replaces or removes acceptance criteria by index without touching deps, covers, or instruction
+  - each demoting move (`instruct`, `amend`, `depend --remove`) on a confirmed task flips it to proposed and names the flip in the stdout result line, asserted by a test that captures stdout alone
+  - converge stops reporting a removed edge; `--json` payloads carry the flipped field
+
+### t2 — read-only `devague plan deliverables` view with `--json` and not-converged banner
+
+- instruction: OWNS: devague/render/deliverables_md.py (new), devague/cli/_commands/plan.py (registration only), devague/plan.py (terminal-task helper), tests/test_plan_deliverables.py (new). Terminal tasks = active tasks no other active task depends on. Render from the live source frame: confirmed announcement / after_state / success_signal verbatim; terminal tasks with acceptance criteria; surviving frame parked vagueness plus non-blocking plan risks. Banner line when the plan has not converged; `--json` mirrors with a converged flag. Reuse the _md_safety helpers.
+- depends on: t1
+- covers: c2, h2
+- acceptance:
+  - on a converged plan, prints the confirmed announcement, after_state, and success_signal claims verbatim, terminal tasks with their acceptance criteria, and surviving parked items
+  - on an unconverged plan it renders with an explicit not-converged banner and converged false in `--json` — it never refuses
+  - two consecutive renders leave .devague/ byte-identical (read-only proof)
+
+### t3 — delivery store and the `devague deviate` move
+
+- instruction: OWNS: devague/delivery.py (new), devague/delivery_store.py (new), devague/cli/_commands/deviate.py (new), devague/cli/__init__.py (registration), tests/test_deviate.py (new). Store mirrors plan_store incl. the 0.17.0 version-stamping fix. Record `dN`: plan item ref, reason, affects (repeatable), origin, status proposed/approved/rejected, optional classification acceptable/risky/needs-follow-up (feeds the drift entry contract). CLI: `devague deviate "<what>" --task <tN> --reason "<text>" [--affects <ref> ...] [--classification <kind>] [--origin llm]`; `--confirm <dN>` / `--reject <dN>` are user-only; `--list [--json]` reads back.
+- covers: c7, h7, c12, h10
+- acceptance:
+  - a deviate record persists under `.devague/deliveries/<plan-slug>.json` with its own schema_version, fail-closed load, and upgrade-on-write
+  - llm-origin deviations land proposed; only user confirm marks them approved; user-origin records auto-approve; a record without a reason is refused with a hint
+  - the plan JSON is byte-identical before and after every deviate operation (test-asserted)
+
+### t4 — render-only `devague summary` verb with `--pr` PR-body mode
+
+- instruction: OWNS: devague/render/summary_md.py (new), devague/cli/_commands/summary.py (new), devague/cli/__init__.py (registration), tests/test_summary.py (new). Eight-section skeleton from state only: Intent quotes the frame announcement and after_state; Planned Work lists every task id and summary verbatim; Actual Delivery emits one row per task with `<fill: status>` and `<fill: what landed>` placeholders (backtick-safe); Mid-work Decisions and Drift From Plan pre-seed from approved deviation records by id; Evidence, Delivery Claims, Remaining Work stay placeholders; run status renders as the `<complete | partial | failed>` placeholder. `--pr` renders title, announcement, wave and task map, approved deviations, and a pointer to the docs/deliveries artifact. Reuse _md_safety.
+- depends on: t3
+- covers: c27, h17
+- acceptance:
+  - renders all eight sections: Intent and Planned Work pre-filled verbatim from frame and plan; Actual Delivery one row per task with explicit fill placeholders; drift and mid-work sections quote approved deviation ids
+  - no placeholder ever renders as a completed claim; the run status stays a placeholder; two renders are byte-identical and state is untouched
+  - `--pr` emits the condensed PR-body skeleton, asserted by a stdout-only test; output is markdownlint-safe
+
+### t5 — split-plan renders the four-column table with wave-listing markers
+
+- instruction: OWNS: .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh, tests/test_assign_to_workforce_script.py (new). Reshape the per-task table to exactly Wave, Task, Model, Task summary; model default sonnet (presentation only — the CLI stays model-agnostic per issue 20); truncate summaries past 72 chars with an ellipsis. Move the has-instruction marker and acceptance-criteria count into the wave-batch listing lines. Keep the go or no-go prompt and the fan-out steps.
+- covers: c4, h4
+- acceptance:
+  - split-plan prints exactly one per-task table with header Wave, Task, Model, Task summary, rows ordered by wave then task id
+  - the summary cell is the real task summary from the waves payload, truncated with an ellipsis when long — never a placeholder; the model cell defaults to sonnet per row
+  - the wave listing shows has-instruction and acceptance-count markers; the go or no-go prompt stays; a pytest drives the script end to end against a fixture plan
+
+### t6 — split-plan End state section quoting `plan deliverables`
+
+- instruction: OWNS: .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh (End state addition), .claude/skills/assign-to-workforce/SKILL.md. After the table, print an End state section produced by running `devague plan deliverables` and quoting its output verbatim — never composed freehand. Degrade gracefully on older devague versions (portable mesh script). Extend the t5 script test.
+- depends on: t2, t5
+- covers: c3, h3
+- acceptance:
+  - split-plan output ends with an End state section that is the verbatim output of `devague plan deliverables`
+  - with an older devague lacking the verb, the section degrades to a one-line hint naming the minimum version instead of failing
+  - SKILL.md tells the operator to present the deliverables view at the go or no-go
+
+### t7 — new sixth origin skill `/deviate`
+
+- instruction: OWNS: .claude/skills/deviate/SKILL.md (new), docs/skill-sources.md. Model the doc on scope and summarize-delivery at their birth: method-first, `type: command` frontmatter (the culture-backend gotcha), origin devague, guildmaster re-broadcasts. Method: when execution must diverge from the confirmed plan, STOP the run; present what, why, and what it affects (tasks, coverage targets, acceptance criteria); get explicit human approval; record via `devague deviate` (llm origin lands proposed, the user confirms); adjust the affected task briefs; resume. Deviations are never silently folded into drift after the fact.
+- depends on: t3
+- covers: c8, h8
+- acceptance:
+  - the skill file exists with type command frontmatter and the stop, approve, record, adjust, resume method
+  - hard rules forbid recording an unapproved deviation and continuing past a refused approval
+  - docs/skill-sources.md registers deviate as the sixth origin skill; markdownlint passes
+
+### t8 — summarize-delivery consumes deviation records and the summary skeleton
+
+- instruction: OWNS: .claude/skills/summarize-delivery/SKILL.md. Method step 1 becomes: start from the `devague summary` skeleton, falling back to hand-assembly from `plan show` / `plan waves --json` when the verb or store is absent — and say so in the baseline line. Drift and mid-work sections reference approved deviation records by `dN` id. Hard rules unchanged; the no-overclaim contract stays intact.
+- depends on: t3, t4
+- covers: c9, h9
+- acceptance:
+  - the baseline step starts from the `devague summary` skeleton and degrades loudly to hand-assembly when the verb or store is absent
+  - Drift From Plan and Mid-work Decisions quote approved deviation record ids when a delivery store exists
+  - the read-only moves table lists `devague summary` and `devague deviate --list`; markdownlint passes
+
+### t9 — culture.yaml backend reverts to claude with live agex verification
+
+- instruction: OWNS: culture.yaml. One-line change: backend claude-code becomes claude (the mesh standard). devex 0.30.0 maps claude onto claude-code (agex-cli issue 46, closed), so the cicd lane keeps working. Verification is live: the release PR opened via `agex pr open` IS the test — record the result in the PR body. Leave .claude/skills/cicd/scripts/workflow.sh alone: its claude-code default is agex-internal vocabulary.
+- covers: c6, h6
+- acceptance:
+  - culture.yaml declares backend claude; no other file changes in this task
+  - `agex pr open` succeeds live from this repo before the release PR merges, recorded in the PR body
+
+### t10 — close issues 62 and 67 with cited evidence
+
+- instruction: No repo files. Use gh issue comment + close (or the communicate skill). Sign as - devague (Claude). The 67 comment should paste the actual stdout/stderr split from the repro so the already-fixed claim is checkable.
+- covers: c17, h13
+- acceptance:
+  - issue 67 is closed with the 0.17.2 repro transcript (stderr note plus flipped true in `--json`, shipped 0.16.0 commit 92c60ca) and a pointer to the stdout-echo hardening in this release
+  - issue 62 is closed citing 0.17.0 (#63) and docs/deliveries/2026-07-09-sharper-end-to-end-method.md; both comments signed per convention
+
+### t11 — release closure: version bump, changelog, docs, coverage and boundary audit
+
+- instruction: OWNS: pyproject.toml, CHANGELOG.md, CLAUDE.md, README.md, docs/skills.md. Bump minor via /version-bump; the CHANGELOG entry names: deliverables view, four-column split plan plus End state, depend remove plus amend plus stdout flip echo, deviate move plus skill plus delivery store, summary verb plus `--pr`, culture.yaml revert, and the two evidence-based closures. Docs name the six-leg flow scope, think, spec-to-plan, assign-to-workforce, deviate, summarize-delivery.
+- depends on: t1, t2, t3, t4, t5, t6, t7, t8, t9, t10
+- covers: c1, h1, c15, h11, c16, h12, c18, h14
+- acceptance:
+  - version bumped to 0.18.0 with a CHANGELOG entry naming every leg of the release
+  - CLAUDE.md and README name the six-leg flow and the new verbs; the audience (operators driving the CLI, humans at the go or no-go and final-PR gates) is named
+  - `uv run pytest -n auto` is green with coverage at or above 95 percent
+  - the boundary audit finds no subprocess, network, or LLM call in the deliverables, deviate, or summary code paths
+
+## Risks
+
+- [unknown_nonblocking] the live agex pr verification can only run at PR-open time outside any task worktree — the release PR itself is the test vehicle (task t9)
+- [unknown_nonblocking] the v1 deviate record shape beyond the specced fields (classification, timestamps) is fixed by instruction rather than spec — dogfooding may revise it in a follow-up (task t3)

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -36,21 +36,22 @@ upstream repo are shared across all inbound rows.
 ## Origin skills (outbound)
 
 Not every skill here is inbound. The `scope`, `think`, `spec-to-plan`, `assign-to-workforce`,
-and `summarize-delivery` skills are **authored and maintained in this repo** —
-devague is their origin/upstream, not a downstream consumer. The devague agent
-dogfoods them to operate the devague CLI while improving the tool. The flow runs
-the *opposite* direction of the table above: `guildmaster` re-vendors them from
-here and re-broadcasts them to the mesh. (The skill names are `scope` / `think` /
-`spec-to-plan` / `assign-to-workforce` / `summarize-delivery`; the product/CLI they drive is `devague`.
-`think` was renamed from `devague` in 0.4.0 — when guildmaster re-vendors, it must
-relearn the new name.) Because devague is upstream, these are **not** re-vendored
+`deviate`, and `summarize-delivery` skills are **authored and maintained in
+this repo** — devague is their origin/upstream, not a downstream consumer. The
+devague agent dogfoods them to operate the devague CLI while improving the
+tool. The flow runs the *opposite* direction of the table above: `guildmaster`
+re-vendors them from here and re-broadcasts them to the mesh. (The skill names
+are `scope` / `think` / `spec-to-plan` / `assign-to-workforce` / `deviate` /
+`summarize-delivery`; the product/CLI they drive is `devague`. `think` was
+renamed from `devague` in 0.4.0 — when guildmaster re-vendors, it must relearn
+the new name.) Because devague is upstream, these are **not** re-vendored
 back from guildmaster's re-broadcast copies — doing so would be circular (see the
 issue #38 reply).
 
 As of 0.13.0 (#38) all origin skills carry `type: command` at the source, so
 guildmaster's re-broadcast copies (which had to add it on vendor for the
 culture/agex backend) match the source and need no patch. `scope` (new in
-0.15.0) shipped with it from day one.
+0.15.0) and `deviate` (new in 0.18.0) both shipped with it from day one.
 
 | Skill | Origin | Downstream | Notes |
 |-------|--------|------------|-------|
@@ -58,6 +59,7 @@ culture/agex backend) match the source and need no patch. `scope` (new in
 | `think` | **devague** (here: `.claude/skills/think/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **idea→spec** leg of the deterministic devague CLI: portable resolution, driving the flat `devague <move>` verbs (`status` is now a first-class CLI verb, not embedded Python). Renamed from `devague` in 0.4.0. `guildmaster` re-vendors it from `../devague/.claude/skills/think/` and broadcasts it to the mesh. |
 | `spec-to-plan` | **devague** (here: `.claude/skills/spec-to-plan/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **spec→plan** leg (`devague plan ...`): portable resolution over the plan convergence gate. New in 0.4.0. Re-vendor from `../devague/.claude/skills/spec-to-plan/`. |
 | `assign-to-workforce` | **devague** (here: `.claude/skills/assign-to-workforce/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **implementation** leg (fan out `devague plan waves` to parallel agents in isolated git worktrees, with TDD-gated merges by the main agent). Three human gates only: spec / implementation split plan / final PR. The devague CLI remains non-orchestrating (#20) — this skill is the convention + helper, not new CLI behavior. New in 0.7.0. Re-vendor from `../devague/.claude/skills/assign-to-workforce/`. |
+| `deviate` | **devague** (here: `.claude/skills/deviate/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **execution-time** leg: runs *during* an `/assign-to-workforce` fan-out, at the moment execution must diverge from the confirmed plan — stop the run, present what/why/what-it-affects, get explicit human approval, record via the deterministic `devague deviate` move (`--origin llm` lands proposed; only the user `--confirm`s), adjust the affected task briefs, resume. Not a fourth standing gate — the human owner of gate 2 (the implementation split plan) amending it mid-flight. Deviation records persist under `.devague/deliveries/<plan-slug>.json` (devague#53 esd t3) and are the connective tissue `/summarize-delivery` quotes by `dN` id instead of reconstructing drift from memory. New in 0.18.0 (devague#53 esd t7). Re-vendor from `../devague/.claude/skills/deviate/`. |
 | `summarize-delivery` | **devague** (here: `.claude/skills/summarize-delivery/`) | `guildmaster`, then the AgentCulture mesh | Operator for the **delivery-side closure** leg (runs after `/assign-to-workforce`). Method-only in v1 — `SKILL.md` + template; no entry-point script, no new CLI verb. New in 0.17.0. Re-vendor from `../devague/.claude/skills/summarize-delivery/`. |
 
 `cite, don't import` applies to both — downstream copies them, no
@@ -73,5 +75,5 @@ symlink/dependency. Written portable-first so they pass guildmaster's
 - **Diverge intentionally.** Record any divergence in the table above and
   in the downstream `SKILL.md` frontmatter `description`.
 - **Don't re-vendor devague-origin skills.** `scope` / `think` / `spec-to-plan` /
-  `assign-to-workforce` / `summarize-delivery` are authored here; pull fixes forward into this repo, not
-  back from guildmaster's re-broadcast copies.
+  `assign-to-workforce` / `deviate` / `summarize-delivery` are authored here; pull
+  fixes forward into this repo, not back from guildmaster's re-broadcast copies.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -137,13 +137,20 @@ A skill drives the deterministic CLI and adds no business logic of its own:
 
 ## The operator skills
 
+The **six-leg flow**, with the two audiences each leg serves — **operators**
+(the main agent driving the CLI move by move) and the **humans** who own the
+three standing gates (the exported spec, the go/no-go on the implementation
+split plan — including any mid-run deviation approved against it — and the
+final PR review):
+
 | Skill | Leg | What it drives |
 |-------|-----|----------------|
 | `scope` | idea → explored scope (the optional opening leg) | read-only exploration; findings land via existing `devague` moves |
 | `think` | idea → spec (working backwards) | the flat `devague <move>` verbs |
 | `spec-to-plan` | spec → plan (working forwards) | the `devague plan <move>` group |
-| `assign-to-workforce` | plan → parallel implementation | reads `devague plan waves` (read-only) |
-| `summarize-delivery` | execution → accountability artifact (the delivery-side closure leg) | method-only; reads plan / git / PR / test evidence (read-only) |
+| `assign-to-workforce` | plan → parallel implementation | reads `devague plan waves` and `devague plan deliverables` (read-only) |
+| `deviate` | execution-time — an in-flight fan-out diverges from the confirmed plan | the `devague deviate` move (`--list [--json]`, `--confirm`/`--reject`), backed by the delivery store |
+| `summarize-delivery` | execution → accountability artifact (the delivery-side closure leg) | starts from `devague summary` / `devague deviate --list`; reads plan / git / PR / test evidence (read-only) |
 
 ### `scope` — idea → explored scope (method-only)
 
@@ -200,11 +207,35 @@ worktrees**, with **main-agent TDD-gated merges** (the task's tests pass before
 *and* after the merge). Exactly three human gates; the final PR uses the `cicd`
 skill (`agex pr open`). Each subagent's brief quotes its task's fields verbatim
 from `plan show --json` / the exported plan-md — including the per-task
-`instruction` once #53 t5/t9 land — never an operator paraphrase.
+`instruction` — never an operator paraphrase. The `split-plan` subcommand
+renders the implementation split plan as a four-column Wave / Task / Model /
+Task summary table (real, editable model tokens; 72-character summary
+truncation, #69) with has-instruction and acceptance-criteria-count markers,
+and a trailing **End state** section quoting `devague plan deliverables`
+verbatim (#70) — so gate 2's go/no-go sees what the plan actually produces, not
+just its task map. Degrades gracefully to a one-line version hint on a
+`devague` too old to have the `deliverables` verb.
 
 - Source:
   [`.claude/skills/assign-to-workforce/`](https://github.com/agentculture/devague/blob/main/.claude/skills/assign-to-workforce/SKILL.md)
   (`SKILL.md` + `scripts/assign-to-workforce.sh`).
+
+### `deviate` — execution-time leg: an in-flight fan-out diverges from the plan
+
+Runs *during* an `/assign-to-workforce` run, at the moment execution must
+diverge from the confirmed plan: stop the run, present what/why/what-it-affects
+to the human, get explicit approval, then record the divergence via the
+deterministic `devague deviate` move before resuming. Not a fourth standing
+gate — the human owner of gate 2 (the implementation split plan) amending it
+mid-flight. `--origin llm` lands `proposed`; only the user
+`--confirm`s/`--reject`s. Deviation records persist as a first-class,
+append-only ledger in `.devague/deliveries/<plan-slug>.json` and are the
+connective tissue `/summarize-delivery` quotes by `dN` id instead of
+reconstructing drift from memory. New in 0.18.0.
+
+- Source:
+  [`.claude/skills/deviate/`](https://github.com/agentculture/devague/blob/main/.claude/skills/deviate/SKILL.md)
+  (`SKILL.md` only).
 
 ### `summarize-delivery` — execution run → accountability artifact
 
@@ -216,7 +247,11 @@ plan drift, and states every delivery claim with a confidence level and evidence
 pointers — a claim without evidence is marked `unverified`, never asserted as
 done. Method-only in v1 (a `SKILL.md` + an eight-section template; no
 entry-point script and no new CLI verb — the deterministic CLI surface is
-unchanged, #20). New in 0.17.0.
+unchanged, #20). New in 0.17.0. As of 0.18.0 it starts from the
+`devague summary` (optionally `--pr`) skeleton and quotes every approved
+`/deviate` record by its `dN` id as recorded ground truth for Drift From Plan
+and Mid-work Decisions, instead of reconstructing execution-time drift from
+memory.
 
 - Source:
   [`.claude/skills/summarize-delivery/`](https://github.com/agentculture/devague/blob/main/.claude/skills/summarize-delivery/SKILL.md)

--- a/docs/spec-contract.md
+++ b/docs/spec-contract.md
@@ -455,11 +455,6 @@ or hand-edited delivery file (an embedded `plan_slug` that disagrees with the
 requested slug, or a `schema_version` that is not an integer); a delivery
 whose `schema_version` is too new.
 
-> **Coordination note.** The `--task` / `--affects` resolution checks and the
-> `--confirm` / `--reject` exclusivity and transition checks above are a
-> validation tightening landing alongside this contract update (PR #72); they
-> are the contract this document holds `devague deviate` to going forward.
-
 ### `summary`
 
 `devague summary` renders the eight-section delivery-summary skeleton the

--- a/docs/spec-contract.md
+++ b/docs/spec-contract.md
@@ -3,7 +3,10 @@
 The durable, reloadable artifact model that turns a vague idea into a
 claim-based, pressure-tested, buildable spec — and the moves that operate on it.
 This document is the **source of truth** for the entity model, the vocabulary,
-the convergence verdict, and the per-move I/O contract (issue #5).
+the convergence verdict, and the per-move I/O contract (issue #5) — across all
+three engines: the **Frame** (idea→spec), its structural peer the **Plan**
+(spec→plan), and the Plan's execution-side companion, the **delivery ledger**
+(`devague deviate` / `devague summary` — see *The delivery peer* below).
 
 The CLI is deterministic and move-driven: the assisting LLM chooses moves, the
 CLI tracks state. Every move accepts and emits JSON (`--json`), with a strict
@@ -253,6 +256,12 @@ changing one on an already-confirmed item demotes it back to `proposed` (see
 *Instructions* above) — content changes route through the user exactly like
 new proposals.
 
+It also extends to deviation records (see *The delivery peer* below): an
+`llm`-origin deviation lands `proposed` and requires an explicit user
+`--confirm` / `--reject`; nothing auto-approves an LLM-authored deviation, and
+`set_status` only ever accepts a transition **from** `proposed` — it never lets
+`--confirm` or `--reject` silently overwrite an already-resolved record.
+
 ## Worked example
 
 `docs/examples/contract-example.json` is a real, converged frame exercising the
@@ -271,6 +280,61 @@ see *Instructions* above), and PlanRisks. It reuses the same structured
 convergence result, serialized under `ready_for_plan`. See
 `docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md`.
 
+### Moves
+
+All plan moves take `--json` and `--plan <slug>` (default: the current plan).
+Mutating moves persist immediately and echo the changed entity; `converge` /
+`export` / `status` additionally re-evaluate against the **live** source
+frame, so a frame that regressed below its own convergence after the plan was
+seeded surfaces as a clean error (frame drift) rather than a stale pass.
+
+| Move | Input | Output (JSON) | Transition |
+|---|---|---|---|
+| `new --frame <slug> [--title]` | source frame slug, optional title | `{slug, frame, targets}` | creates a plan from a **converged** frame; derives coverage targets; refuses an unconverged frame or a plan that already exists |
+| `task "<summary>" [--accept … --dep … --covers … --origin --instruction]` | summary, origin, optional acceptance/deps/covers/instruction | `{id, status, acceptance, deps, covers, instruction}` | adds a task (`llm` → `proposed`, else `confirmed`) |
+| `instruct <tN> "<text>"` | task id, instruction text | `{id, instruction, status, flipped}` | sets/replaces the task's instruction; flips a **confirmed** task back to `proposed` (see *The re-confirm rule* below) |
+| `accept <tN> "<text>"` | task id, criterion text | `{id, acceptance}` | appends an acceptance criterion; does not change `status` |
+| `amend <tN> [--summary "<text>"] [--accept-replace <n> "<text>" …] [--accept-remove <n> …]` | task id, optional summary replacement, index-addressed acceptance-criterion edits | `{id, summary, acceptance_criteria, status, flipped}` | edits the summary and/or acceptance criteria in place; flips a **confirmed** task back to `proposed`; refuses outright on a **rejected** task |
+| `depend <tN> --on <tM>` | dependent task id, dependency task id | `{id, deps}` | appends a dependency edge; does not change `status` |
+| `depend <tN> --on <tM> --remove` | dependent task id, dependency task id | `{id, deps, status, flipped}` | cuts exactly that one edge; flips a **confirmed** task back to `proposed`; refuses if the task did not depend on `<tM>` |
+| `cover <tN> --target <c*\|h*>` | task id, coverage target id | `{id, covers}` | marks a task as covering a coverage target; does not change `status` |
+| `confirm <tN>` / `reject <tN>` | task id | `{id, status}` | the **only** path to `confirmed` / `rejected` — user-only |
+| `risk "<text>" --kind K [--task <tN>]` | risk text, vagueness kind, optional task ref | `{id, kind, task}` | records a first-class PlanRisk |
+| `converge` | — | the convergence result (`ready_for_plan`) | promotes/demotes plan `status`; re-evaluates against the live source frame |
+| `export [--format plan-md]` | — | `{path, format}` | writes the buildable plan; requires `ready_for_plan` |
+| `waves [--json]` | — | `{plan, waves, tasks}` | none — read-only, convergence-agnostic (see below) |
+| `deliverables [--json]` | — | `{plan, converged, announcement, after_state, success_signal, terminal_tasks, open_items}` | none — read-only, convergence-agnostic (see below) |
+| `status` / `show` / `list` | — | status verdict / plan dict / slug list | none |
+| `learn` / `explain <move>` | — | method / move help | none |
+
+**Validation errors** (all raise a clean `DevagueError`, exit code 1): an
+unknown task id on `instruct` / `accept` / `amend` / `depend` / `cover` /
+`confirm` / `reject`; an unknown coverage target on `cover` or
+`task --covers`; `amend` called against a **rejected** task, or with neither
+`--summary` nor an acceptance edit, or with an out-of-range acceptance index;
+`depend --remove` naming an edge the task does not have; an unsound
+dependency graph (a cycle, or a dependency on a missing/rejected task) on
+`waves`; `new` against an unconverged frame or over an existing plan; a
+source frame that has regressed below its own convergence on `converge` /
+`export` / `status` (frame drift); an invalid `--plan` / `--frame` slug; a
+missing plan; a malformed or hand-edited plan file; a plan whose
+`schema_version` is too new.
+
+### The re-confirm rule
+
+Three moves **demote** an already-`confirmed` task back to `proposed`:
+`instruct` (changing the verbatim instruction — see *Instructions* above),
+`amend` (editing the summary or acceptance criteria), and `depend --remove`
+(cutting a dependency edge). Each is content, not metadata, so the same
+anti-fabrication guarantee applies: the user re-confirms it exactly like any
+other proposed content. `accept`, `depend` (adding an edge), `cover`, and
+`task --covers` never flip status — they only add.
+
+The flip is echoed on **stdout itself**, not only on `stderr` and in
+`--json` (`flipped: true`) — e.g. `t1: instruction set (confirmed ->
+proposed; re-confirm)` — because a harness reading only stdout must still see
+the demotion (issue #67 hardening, #53-esd t1).
+
 `plan waves` emits the plan's dependency graph as deterministic, machine-readable
 scheduling metadata — `{plan, waves}`, where `waves` is an ordered list of task-id
 batches (wave 0 has no unsatisfied dependency; each later wave depends only on
@@ -281,6 +345,18 @@ plan-convergence dependency blockers. The boundary is deliberate (issue #20):
 Devague *describes* the parallelizable graph; an external operator (Culture,
 codexd, …) decides how — or whether — to execute it. Devague does not spawn
 subagents, manage worktrees, mark tasks done, or choose a backend.
+
+`plan deliverables` is the read-only "what do we have in the end?" view
+(issue #70): the live source frame's confirmed `announcement` /
+`after_state` / `success_signal` claims verbatim, the plan's **terminal
+tasks** (active tasks no other active task depends on) with their acceptance
+criteria, and surviving open items (the frame's non-blocking parked
+vagueness plus the plan's non-blocking risks). Like `waves` it never mutates
+state and is **not** gated on convergence — an unconverged plan still
+renders, with an explicit not-converged banner (text) / `converged: false`
+(JSON) instead of a refusal, because previewing the end state is exactly
+what is useful *before* convergence, at the assign-to-workforce go/no-go
+(issue #20: Devague describes state, it does not gate the human's decision).
 
 Plans carry the same persistence contract as frames. Every plan has an integer
 `schema_version` (currently `2`, `PLAN_SCHEMA_VERSION`), written on save and
@@ -301,3 +377,133 @@ across the frame and plan persistence twins.
 
 > **v2 (#53 t2).** `PLAN_SCHEMA_VERSION` bumped to add `Task.instruction`. A v1
 > plan predates it and loads with every task's `instruction` defaulted to `""`.
+
+## The delivery peer
+
+The delivery ledger (`devague deviate` / `devague summary`) is the plan's
+**execution-side companion**, the smallest deterministic slice of a parked
+delivery engine (#53-esd t3): where a Plan is the contract the user confirmed, a
+Delivery records where execution actually diverged from it. It never touches
+the plan itself — **the plan JSON stays byte-identical through every
+`deviate` operation** (test-asserted) — and it has no independent identity of
+its own: a delivery's key is its source plan's slug verbatim, so there is no
+separate "current delivery" pointer; every move that reads or writes one
+resolves the plan first.
+
+### Delivery
+
+- `plan_slug` — the source plan's slug, verbatim.
+- `schema_version` — integer; see *Schema versioning* below.
+- `created`, `updated` — ISO-8601 UTC timestamps, stamped on save.
+- `deviations` — list of DeviationRecord.
+
+### DeviationRecord
+
+- `id` — `d1`, `d2`, …
+- `what` — what deviated, verbatim.
+- `task_ref` — the plan item this deviation relates to (e.g. `t3`); must
+  resolve to a task id on the resolved plan — an unknown `--task` is refused.
+- `reason` — required; a deviation without a reason is refused with a hint —
+  never fabricated.
+- `affects` — repeatable list of plan-item/coverage refs this deviation also
+  touches; defaults to `[]`. An id-shaped ref (one that looks like a plan
+  task id, a coverage-target id, or a source-frame claim/honesty-condition
+  id) must resolve in plan tasks ∪ coverage targets ∪ the source frame's
+  claim/honesty ids; a free-text ref that is not id-shaped is accepted as-is.
+- `origin` — `user` | `llm` (who proposed it).
+- `status` — `proposed` | `approved` | `rejected`; see *Status transitions*
+  below.
+- `classification` — optional, one of `acceptable` | `risky` |
+  `needs-follow-up` (`CLASSIFICATIONS`); feeds the drift-entry contract the
+  `summarize-delivery` skill consumes.
+
+### Status transitions
+
+A user-authored deviation (the default) **auto-approves**: it lands directly
+as `approved`, since a user-authored record already carries the human
+approval the ledger exists to capture. An `llm`-authored deviation
+(`--origin llm`) lands `proposed` and requires explicit user resolution — the
+same anti-fabrication rule as claims and tasks: nothing auto-confirms an LLM
+proposal.
+
+`--confirm <dN>` and `--reject <dN>` are the **only** way a `proposed` record
+is resolved (user-only), and are mutually exclusive within a single `deviate`
+invocation. Both moves — and `set_status` underneath them — only accept the
+transition **from `proposed`** to `approved` or `rejected`: resolving a
+record that is not currently `proposed` (already `approved`, already
+`rejected`, or an auto-approved user record) is refused as a user error
+rather than silently overwritten.
+
+### Moves
+
+| Move | Input | Output (JSON) | Transition |
+|---|---|---|---|
+| `deviate "<what>" --task <tN> --reason "<text>" [--affects <ref> …] [--classification K] [--origin]` | what, task ref, reason, affects, classification, origin | `{id, what, task, reason, affects, origin, status, classification}` | appends a DeviationRecord (`llm` → `proposed`, else auto-`approved`) |
+| `deviate --confirm <dN>` / `deviate --reject <dN>` | deviation id | `{id, status}` | the only path to `approved` / `rejected` — user-only; mutually exclusive with each other; refused unless the record is currently `proposed` |
+| `deviate --list [--plan]` / bare `deviate` | — | `{plan, deviations: […]}` | none (default action) |
+| `summary [--pr] [--json]` | — | eight-section skeleton dict, or the condensed PR-body skeleton dict under `--pr` | none — read-only, never persists |
+
+**Validation errors** (all raise a clean `DevagueError`, exit code 1): missing
+`--reason`; missing `--task`; an unknown `--task` (not a task id on the
+resolved plan); an id-shaped `--affects` ref that fails to resolve in plan
+tasks ∪ coverage targets ∪ source-frame claim/honesty ids; an unknown
+`classification` or `origin` (rejected at construction); an unknown deviation
+id on `--confirm` / `--reject`; passing both `--confirm` and `--reject` in the
+same invocation; `--confirm` / `--reject` against a deviation that is not
+currently `proposed`; no plan selected; an invalid `--plan` slug; a malformed
+or hand-edited delivery file (an embedded `plan_slug` that disagrees with the
+requested slug, or a `schema_version` that is not an integer); a delivery
+whose `schema_version` is too new.
+
+> **Coordination note.** The `--task` / `--affects` resolution checks and the
+> `--confirm` / `--reject` exclusivity and transition checks above are a
+> validation tightening landing alongside this contract update (PR #72); they
+> are the contract this document holds `devague deviate` to going forward.
+
+### `summary`
+
+`devague summary` renders the eight-section delivery-summary skeleton the
+`summarize-delivery` skill starts from, pre-filled from state alone — the
+plan, its live source frame, and the delivery store — and nothing else.
+Section names and order are pinned to the template in
+`.claude/skills/summarize-delivery/SKILL.md`: Intent, Planned Work, Actual
+Delivery, Mid-work Decisions, Drift From Plan, Evidence, Delivery Claims,
+Remaining Work / Follow-up. Only two of the eight are pre-filled from
+delivery state beyond the plan's own task list — **Mid-work Decisions** and
+**Drift From Plan** — and both quote only **`approved`** deviation records by
+id; a `proposed` deviation is never rendered as if it were a decision — it
+surfaces, if at all, as an explicit "pending approval" line, never folded
+into an approved list. Everything else that cannot be mechanically derived
+(run status, per-task delivery status, evidence, delivery claims, remaining
+work) renders as an explicit backticked `` `<fill: …>` `` placeholder —
+literal code spans, never inline HTML, so no placeholder is ever mistaken for
+a completed claim. `--pr` swaps in a condensed PR-body skeleton — title,
+announcement, the wave/task map, approved deviations, and a pointer to the
+`docs/deliveries/<date>-<slug>.md` artifact this skeleton seeds. Both modes
+are pure functions of `(Plan, Optional[Frame], Delivery)`: read-only, no I/O
+beyond the initial loads, and deterministic — rendering twice yields
+byte-identical output.
+
+### Schema versioning
+
+Deliveries carry the same persistence contract as frames and plans. Every
+delivery has an integer `schema_version` (currently `1`,
+`DELIVERY_SCHEMA_VERSION`), written on save and checked on load:
+`delivery_store.load` **fails closed** with a clean `DevagueError` when a
+delivery declares a `schema_version` newer than this devague supports. A
+pre-field delivery loads silently as the current schema. `save()` always
+stamps the schema version this binary actually writes (the 0.17.0
+upgrade-on-write fix, applied here) rather than re-emitting a loaded/older
+label, so a delivery loaded under an older label and then mutated with newer
+fields is never rewritten under that stale label — the same guard that
+protects frames and plans. `load` also rejects a file whose embedded
+`plan_slug` disagrees with the requested slug (a tampered file can't
+silently redirect a later `save`), symmetric with the frame/plan persistence
+twins.
+
+The delivery store lives at `.devague/deliveries/<plan-slug>.json` (the peer
+of `.devague/plans/<slug>.json`). It is never written by any frame or plan
+move, and no `deviate` / `summary` move ever writes to `.devague/frames/` or
+`.devague/plans/` — the delivery store is the plan's execution-side
+companion, not a mutation of it: **the plan JSON stays byte-identical through
+every `deviate` operation.**

--- a/docs/specs/2026-07-14-execution-seam-and-deviate.md
+++ b/docs/specs/2026-07-14-execution-seam-and-deviate.md
@@ -1,0 +1,93 @@
+# execution seam and deviate
+
+> devague closes the execution seam: a deliverables view answers what we have in the end at the go or no-go, the split plan renders the table humans actually approve, dependency edges can be removed without task recreation, and human-approved deviations become first-class records that connect the plan to the delivery summary
+
+## Audience
+
+- devague operators (the main agent driving the CLI) and the humans at the go or no-go and final-PR gates
+
+## Before → After
+
+- After: after this ships: the go or no-go presents what exists once every task completes, sourced from state alone; deviations from the confirmed plan are recorded with reason, impact, and human approval, and the delivery summary quotes them instead of reconstructing drift from memory; a wrong dependency edge costs one move to fix instead of a task-recreation cascade; and issues 62, 66, and 67 are closed with cited evidence
+
+## Why it matters
+
+- the plan is a contract: without an end-state view the human approves a workforce without seeing the world after the work; without recorded deviations the delivery summary rebuilds drift from unrecorded memory; without edge removal an honest one-word correction costs an unbounded rewrite of dependent tasks
+
+## Requirements
+
+- new read-only `devague plan deliverables` view (name pending q-decision) answers what exists once every task completes, synthesized only from existing state: the frames confirmed announcement, `after_state`, and `success_signal` claims, terminal tasks (tasks no active task depends on) with their acceptance criteria, and surviving parked vagueness; `--json` emits the same structured payload; no mutation, no LLM calls (issues 70 and 20)
+  - honesty: verifiable by inspection and test: the deliverables code path performs zero store writes and zero subprocess or network calls; a test renders the view twice and the state files stay byte-identical
+- the assign-to-workforce split-plan presentation gains an End state section sourced from the deliverables view, and the skill doc gains one line telling the operator to include it at the go or no-go (issue 70)
+  - honesty: the End state section is produced by quoting the CLI deliverables output verbatim, never composed freehand by the operator; the skill doc names the exact move to run
+- split-plan renders one markdown table with exactly the columns Wave, Task, Model, Task summary, ordered by wave then task id, real verbatim summaries (truncated when long), and an honest per-row model default instead of the constant cheaper/faster; the go or no-go prompt and the wave listing stay (issue 69)
+  - honesty: the rendered table matches the issue 69 ask verbatim: header Wave, Task, Model, Task summary; rows ordered by wave then task id; asserted by a script-level test
+- a dependency edge can be removed without recreating tasks; smallest shape is a remove flag on `devague plan depend` (final shape pending q-decision), and removing an edge on a confirmed task flips it to proposed with the same visible note the instruct move prints (issue 68)
+  - honesty: after removing an edge the task keeps its summary, acceptance criteria, covers, and instruction unchanged, and converge no longer reports the removed edge; round-trip covered by a test
+- culture.yaml declares backend claude, the mesh standard; unblocked because agex-cli issue 46 is closed and devex 0.30.0 maps claude onto claude-code; the agex pr lane is re-verified after the edit (issue 66)
+  - honesty: agex pr open succeeds from this repo with backend claude in culture.yaml, verified live before the PR carrying the change merges
+- new deterministic `devague deviate` move records a human-approved deviation from the confirmed plan at the moment it happens: the plan item it deviates from, the reason, what it affects, and the approval; llm-recorded deviations land proposed until the user confirms them, per the standing anti-fabrication contract
+  - honesty: a deviate record without the explicit approval marker is refused; an llm-origin deviation lands proposed and never counts as approved until the user confirms it
+- new sixth origin skill `/deviate`, the execution-time leg in the flow scope, think, spec-to-plan, assign-to-workforce, deviate, summarize: when execution must diverge from the plan it stops the run, gets explicit human approval, records the deviation via the CLI move, and adjusts the affected task briefs
+  - honesty: the skill hard rules make the stop-and-get-approval step unskippable: no deviation is recorded that the human did not approve, mirroring the confirm-is-user-only contract
+- the summarize-delivery skill consumes recorded deviations: its Drift From Plan and Mid-work Decisions sections quote deviation records verbatim instead of reconstructing drift from memory, making deviate records the connective tissue between the confirmed plan and the delivery summary
+  - honesty: the summarize-delivery template names deviation record ids in its Drift From Plan rows, so every drift entry traces to a recorded, approved deviation whenever one exists
+- new `devague plan amend` move edits a task summary and replaces or removes acceptance criteria; amending a confirmed task flips it to proposed with the visible re-confirm note (issue 68, resolved q1)
+  - honesty: amend round-trips: the summary and criteria change exactly as asked, everything else on the task is untouched, and the flip note appears when the task was confirmed; covered by tests
+- moves that demote a confirmed task (`instruct`, `amend`, `depend --remove`) name the confirmed-to-proposed flip on the stdout result line, not only on stderr and in JSON (issue 67 hardening, resolved q4)
+  - honesty: a harness reading only stdout still sees the flip: asserted by a test that captures stdout alone
+- new deterministic `devague summary [--pr] [--json]` renders a wrap-up from existing state only: the eight-section delivery-summary skeleton pre-filled verbatim from the frame (announcement, after state), the plan (every task id and summary), and approved deviation records, with explicit fill-me placeholders for run status, per-task delivery status, evidence, and claims — nothing ever renders as done from state alone; `--pr` emits a condensed PR-body skeleton for the cicd lane; the summarize-delivery skill starts from this skeleton instead of hand-assembling the baseline (resolves q6)
+  - honesty: the skeleton is deterministic and fabrication-free: rendering twice yields identical output, every pre-filled line traces verbatim to frame, plan, or deviation state, no placeholder ever renders as a completed claim, and the PR mode is covered by a stdout-only test
+
+## Honesty conditions
+
+- holds only if every leg the announcement names ships in the same release: deliverables view, four-column split-plan table, dependency-edge removal, the deviate move and skill, and the three evidence-based issue closures
+- deliverables performs no mutation at all; deviate mutates only its own record; grepping the new code paths finds no agent spawning, no worktree management, no merge gating, and no LLM call
+- matches the three-reader model already shipped in the summarize-delivery skill: the operator, the human at the gates, and the later reader who never watched the run
+- every element of the after state is checkable from committed artifacts: the view output, the deviation records, a passing edge-removal test, and the issue timelines
+- each pain it names traces to a filed issue: 70 for the missing end-state view, 62 plus the deviate gap for drift-from-memory, 68 for the recreation cascade
+- the numbers are measurable as written: six of six issues closed on the tracker, zero LLM calls verified by inspection, coverage read from the CI gate at or above 95 percent
+
+## Success signals
+
+- 6 of 6 bundled issues end closed (3 by shipped code, 3 by cited evidence); the deliverables and deviate code paths ship with 0 LLM calls and 0 orchestration, verified by inspection; test coverage stays at or above 95%
+
+## Scope / boundaries
+
+- the CLI stays deterministic and non-orchestrating (issue 20): deliverables and deviate record and describe state; they never spawn agents, mark tasks done, gate merges, or call an LLM
+
+## Non-goals
+
+- no full delivery engine in this release: the third structural peer parked in the summarize-delivery skill stays parked; deviate records are the smallest slice of execution-side state, and where they persist is a pending question
+
+## Assumptions
+
+- persisting deviations or removable edges on the plan JSON bumps PLAN_SCHEMA_VERSION from 2 to 3; the 0.17.0 upgrade-on-write fix means older binaries refuse the newer file instead of silently dropping fields
+
+## Scope exploration
+
+- `s1` — `devague/plan.py + devague/plan_convergence.py`: add_dep is append-only, no removal move exists anywhere in the plan verb set, reject does not prune inbound edges, and dependency_blockers reports depends-on-rejected as an integrity failure, so the issue 68 reject-and-recreate cascade is real; terminal tasks are computable from Task.deps alone, no new state needed
+  - seeds: `c5`, `c14`
+- `s2` — `devague/cli/_commands/plan.py cmd_plan_instruct + scratchpad repro on 0.17.2`: instruct already prints the flip note on stderr and emits flipped true in JSON, shipped in 0.16.0 commit 92c60ca; an end-to-end repro on 0.17.2 (converged frame, confirmed task, instruct) shows both streams, so issue 67 came from a harness that dropped stderr, not from current code
+  - seeds: `c10`
+- `s3` — `devague/frame.py CLAIM_KINDS`: announcement, after_state, and success_signal are first-class claim kinds already, so the deliverables view synthesizes from existing frame state with no schema change on the frame side
+  - seeds: `c2`
+- `s4` — `.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan`: split-plan already renders verbatim task summaries from the enriched waves payload since 0.16.0 t13, so the placeholder half of issue 69 is fixed; the remaining delta is table shape: eight columns today with the model column hardcoded to cheaper/faster
+  - seeds: `c3`, `c4`
+- `s5` — `.claude/skills/summarize-delivery/SKILL.md`: all six issue 62 acceptance criteria are met by the shipped 0.17.0 skill; a future delivery engine is explicitly parked in the doc; the Drift From Plan and Mid-work Decisions sections are the natural consumers of recorded deviations
+  - seeds: `c7`, `c8`, `c9`, `c11`, `c13`
+- `s6` — `culture.yaml + devex 0.30.0 core/backend.py + closed agex-cli issue 46`: backend claude-code was a stopgap for an agex rejection that upstream has since fixed: devex 0.30.0 maps claude onto claude-code with an explicit comment naming the culture.yaml standard, so the mesh-standard value now works end to end
+  - seeds: `c6`
+- `s7` — `issue 20 + CLAUDE.md non-orchestration boundary`: the deterministic non-orchestrating contract covers both new moves cleanly: deliverables reads and renders, deviate records state the human approved; neither executes anything
+  - seeds: `c12`
+
+## Decisions
+
+- issue 67 is already fixed: plan instruct has warned on the confirmed-to-proposed flip since 0.16.0 (stderr note plus flipped true in JSON), verified empirically on 0.17.2; close it with the repro evidence (whether to also echo the flip on stdout is a pending question)
+- issue 62 is already delivered: the summarize-delivery skill shipped in 0.17.0 meeting all six acceptance criteria, with the dogfood artifact docs/deliveries/2026-07-09-sharper-end-to-end-method.md; close it citing the release
+- issue 68 ships as two explicit moves: a remove flag on `devague plan depend` to cut a single edge, plus a new `devague plan amend` move to edit a task summary and replace or remove acceptance criteria; reject does not auto-prune edges — every transition stays visible (resolves q1)
+- the deliverables view ships as the read-only verb `devague plan deliverables` with `--json`, peer of waves and status; on an unconverged plan it renders with an explicit not-converged banner rather than refusing (resolves q2)
+- deviation state lives in a new delivery store under `.devague/deliveries/` keyed by plan slug — the first deterministic slice of the parked delivery engine; the plan JSON stays byte-identical through execution (resolves q3)
+- issue 67 closes with the repro evidence plus a one-line hardening: the stdout result line itself names the confirmed-to-proposed flip, because the report proves agent harnesses drop stderr (resolves q4)
+- the split-plan table renders strictly Wave, Task, Model, Task summary; the wave-batch listing above it gains per-task has-instruction and acceptance-criteria-count markers (resolves q5)
+- this release ships a render-only `devague summary` verb at the top level, pairing with `devague deviate` as the two execution-side verbs over the delivery store; the full delivery engine (delivery-record moves plus a no-overclaim gate) stays parked per the standing non-goal (resolves q6)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.17.2"
+version = "0.18.0"
 
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"

--- a/tests/test_assign_to_workforce_script.py
+++ b/tests/test_assign_to_workforce_script.py
@@ -1,0 +1,206 @@
+"""#69 t5 integration test: assign-to-workforce.sh split-plan's 4-column table.
+
+A human reviewing a 13-task fan-out rewrote the split-plan table by hand as
+Wave, Task, Model, Task summary — and that hand-rewrite is what got approved
+(agentculture/devague#69). This test drives the real script end to end
+(``bash assign-to-workforce.sh split-plan``) against a fixture plan built via
+the actual ``devague`` / ``devague plan`` CLI (more robust than hand-writing
+``.devague`` JSON), and asserts the table the human actually approves comes
+out: exactly one four-column table (Wave | Task | Model | Task summary),
+rows ordered by wave then task id, real (never placeholder) summaries
+truncated with an ellipsis past 72 chars, a `sonnet` default model, the
+has-instruction/acceptance-count markers moved onto the wave-listing lines,
+and the go/no-go prompt + fan-out steps still present.
+
+The script resolves its own ``devague`` binary (mesh-first: whatever is on
+PATH, falling back to `uv run` inside a devague checkout). To make this test
+hermetic — exercising *this* worktree's code rather than whatever `devague`
+happens to be installed globally — a small PATH shim forwards to
+``uv run --project <this-repo> devague`` regardless of cwd.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # noqa: S404 - dev-tooling integration check, not shipped code
+from pathlib import Path
+
+import pytest
+
+from devague import store
+from devague.cli import main
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = (
+    _REPO_ROOT / ".claude" / "skills" / "assign-to-workforce" / "scripts" / "assign-to-workforce.sh"
+)
+
+_BASH = shutil.which("bash")
+_UV = shutil.which("uv")
+
+pytestmark = pytest.mark.skipif(
+    _BASH is None or _UV is None,
+    reason="bash/uv not on PATH (the script + this test's local-devague shim both need them)",
+)
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+
+# Deliberately > 72 chars, to exercise ellipsis truncation in the summary cell.
+_LONG_SUMMARY = (
+    "Reshape the per-task split-plan table to exactly Wave, Task, Model, and "
+    "Task summary columns for human review"
+)
+assert len(_LONG_SUMMARY) > 72
+
+_MAX_SUMMARY_LEN = 72
+_ELLIPSIS = "..."
+_EXPECTED_TRUNCATED = _LONG_SUMMARY[:_MAX_SUMMARY_LEN] + _ELLIPSIS
+
+
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame that passes the frame gate; return its slug."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the split-plan table"])
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    frame = store.load(store.current_slug())
+    for c in frame.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _fixture_plan(monkeypatch, tmp_path) -> str:
+    """An in-progress plan (waves are read-only + convergence-agnostic, #20):
+
+    - t1: short summary, an instruction, 2 acceptance criteria, no deps -> wave 1.
+    - t3: short summary, no instruction, 1 acceptance criterion, no deps -> wave 1
+      (created after t2 so wave-1 ordering — t1 before t3 — matches id order too).
+    - t2: a >72-char summary, no instruction, 0 acceptance criteria, depends on
+      t1 -> wave 2.
+    """
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(
+        [
+            "plan",
+            "task",
+            "Wire the login form",
+            "--instruction",
+            "verify via `pytest`",
+            "--accept",
+            "form submits",
+            "--accept",
+            "errors render",
+        ]
+    )
+    main(["plan", "task", _LONG_SUMMARY, "--dep", "t1"])
+    main(["plan", "task", "Send the welcome email", "--accept", "email delivered"])
+    return slug
+
+
+def _devague_shim(tmp_path: Path) -> Path:
+    """A `devague` PATH shim that always runs *this* worktree's checkout via
+    `uv run`, regardless of cwd — so the script under test exercises this
+    branch's code, never a possibly stale globally installed `devague`.
+    """
+    bin_dir = tmp_path / "_bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "devague"
+    shim.write_text(
+        "#!/usr/bin/env bash\n" f'exec "{_UV}" run --project "{_REPO_ROOT}" devague "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    return bin_dir
+
+
+def _run_split_plan(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    bin_dir = _devague_shim(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [_BASH, str(_SCRIPT), "split-plan"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_split_plan_renders_expected_table(tmp_path, monkeypatch) -> None:
+    _fixture_plan(monkeypatch, tmp_path)
+    result = _run_split_plan(tmp_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    out = result.stdout
+    lines = out.splitlines()
+
+    def _cells(line: str) -> list[str]:
+        # "| 1    | t1   | sonnet | ... |" -> ["1", "t1", "sonnet", "..."]
+        return [c.strip() for c in line.strip().strip("|").split("|")]
+
+    # ── exactly one table, with the exact 4-column header ───────────────────
+    # Column widths pad to the widest cell (e.g. "sonnet" > "Model"), so match
+    # on the parsed header cells rather than a hard-coded spacing literal.
+    header_indices = [
+        i
+        for i, line in enumerate(lines)
+        if line.startswith("|") and _cells(line) == ["Wave", "Task", "Model", "Task summary"]
+    ]
+    assert len(header_indices) == 1
+    header_idx = header_indices[0]
+    sep_idx = header_idx + 1
+    assert set(lines[sep_idx].replace("|", "").strip()) <= {"-", " "}
+
+    # ── rows ordered by wave then task id ────────────────────────────────────
+    def _row_idx(task_id: str) -> int:
+        return next(
+            i
+            for i, line in enumerate(lines)
+            if i > header_idx and line.startswith("|") and _cells(line)[1] == task_id
+        )
+
+    t1_idx, t3_idx, t2_idx = _row_idx("t1"), _row_idx("t3"), _row_idx("t2")
+    assert header_idx < t1_idx < t3_idx < t2_idx
+
+    # ── real summaries, never a placeholder; sonnet default per row ─────────
+    assert _cells(lines[t1_idx])[3] == "Wire the login form"
+    assert _cells(lines[t3_idx])[3] == "Send the welcome email"
+    assert "(no summary recorded)" not in out
+    for idx in (t1_idx, t3_idx, t2_idx):
+        assert _cells(lines[idx])[2] == "sonnet"
+    assert _cells(lines[t1_idx])[0] == "1"
+    assert _cells(lines[t3_idx])[0] == "1"
+    assert _cells(lines[t2_idx])[0] == "2"
+
+    # ── truncation with ellipsis for the >72-char summary ────────────────────
+    assert _LONG_SUMMARY not in out
+    assert _cells(lines[t2_idx])[3] == _EXPECTED_TRUNCATED
+
+    # ── wave-listing markers (moved off the table, #69) ──────────────────────
+    assert "t1 [instruction: yes, accept: 2]" in out
+    assert "t3 [instruction: no, accept: 1]" in out
+    assert "t2 [instruction: no, accept: 0]" in out
+    assert "Wave 1: [t1 [instruction: yes, accept: 2], t3 [instruction: no, accept: 1]]" in out
+    assert "Wave 2: [t2 [instruction: no, accept: 0]]" in out
+
+    # ── go/no-go prompt + fan-out steps survive ──────────────────────────────
+    assert "Go/no-go" in out
+    assert "Approved — assign to workforce" in out
+    assert "Create one git worktree per task" in out
+
+    # ── operator guidance to edit the Model cell to a real model token ───────
+    assert "haiku" in out and "sonnet" in out and "opus" in out and "fable" in out
+    assert "colleague" in out or "codex" in out
+
+
+def test_split_plan_table_has_no_agent_type_or_scope_note_columns(tmp_path, monkeypatch) -> None:
+    """The old 8-column shape (Agent type / Scope note, etc.) must be gone."""
+    _fixture_plan(monkeypatch, tmp_path)
+    result = _run_split_plan(tmp_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    out = result.stdout
+    assert "Agent type" not in out
+    assert "Scope note" not in out
+    assert "cheaper/faster" not in out

--- a/tests/test_assign_to_workforce_script.py
+++ b/tests/test_assign_to_workforce_script.py
@@ -175,7 +175,12 @@ def test_split_plan_renders_expected_table(tmp_path, monkeypatch) -> None:
     assert _cells(lines[t2_idx])[0] == "2"
 
     # ── truncation with ellipsis for the >72-char summary ────────────────────
-    assert _LONG_SUMMARY not in out
+    # The table truncates; the End state section (#70 t6) below it quotes
+    # `devague plan deliverables` verbatim, which legitimately reproduces the
+    # full untruncated summary for a terminal task — so this check is scoped
+    # to the split-plan table's own region of the output, not the full text.
+    table_out = out[: out.index(_END_STATE_HEADER)] if _END_STATE_HEADER in out else out
+    assert _LONG_SUMMARY not in table_out
     assert _cells(lines[t2_idx])[3] == _EXPECTED_TRUNCATED
 
     # ── wave-listing markers (moved off the table, #69) ──────────────────────
@@ -204,3 +209,94 @@ def test_split_plan_table_has_no_agent_type_or_scope_note_columns(tmp_path, monk
     assert "Agent type" not in out
     assert "Scope note" not in out
     assert "cheaper/faster" not in out
+
+
+# ── End state section: `devague plan deliverables`, verbatim (#70 t6) ───────
+#
+# At the go/no-go, the human should see what the plan actually produces —
+# `devague plan deliverables` synthesizes that "what do we have in the end?"
+# view from live frame/plan state (confirmed after-state claims, terminal
+# tasks, surviving open items). split-plan quotes it verbatim, never composing
+# it freehand, and degrades to a one-line hint on a `devague` too old to have
+# the verb — never failing the script.
+
+_END_STATE_HEADER = "End state (from `devague plan deliverables`):"
+_DEGRADED_HINT = "hint: End state view requires devague >= 0.18.0 (devague plan deliverables)"
+
+
+def _devague_shim_without_deliverables(tmp_path: Path) -> Path:
+    """A `devague` PATH shim that behaves like this worktree's checkout for
+    every verb except `plan deliverables`, which it rejects with a non-zero
+    exit — simulating an older devague that predates the deliverables view
+    (#70), to exercise split-plan's graceful degradation.
+    """
+    bin_dir = tmp_path / "_bin_old"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "devague"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "plan" ] && [ "$2" = "deliverables" ]; then\n'
+        "    exit 2\n"
+        "fi\n"
+        f'exec "{_UV}" run --project "{_REPO_ROOT}" devague "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    return bin_dir
+
+
+def test_split_plan_ends_with_end_state_section(tmp_path, monkeypatch) -> None:
+    """split-plan's output ends with an End state section that is exactly the
+    verbatim `devague plan deliverables` output for the same fixture plan."""
+    _fixture_plan(monkeypatch, tmp_path)
+    result = _run_split_plan(tmp_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    out = result.stdout
+
+    bin_dir = _devague_shim(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    deliverables = subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [str(bin_dir / "devague"), "plan", "deliverables"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert deliverables.returncode == 0, deliverables.stderr
+
+    assert _END_STATE_HEADER in out
+    # It is the LAST section split-plan prints — after the go/no-go + fan-out
+    # steps, never before them.
+    header_idx = out.index(_END_STATE_HEADER)
+    assert header_idx > out.index("Create one git worktree per task")
+    tail = out[header_idx + len(_END_STATE_HEADER) :]
+    assert tail.strip("\n") == deliverables.stdout.rstrip("\n")
+
+
+def test_split_plan_degrades_gracefully_without_deliverables_verb(tmp_path, monkeypatch) -> None:
+    """On an older devague lacking `plan deliverables`, split-plan still exits
+    0 and prints a one-line hint naming the minimum version instead of
+    failing."""
+    _fixture_plan(monkeypatch, tmp_path)
+    bin_dir = _devague_shim_without_deliverables(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [_BASH, str(_SCRIPT), "split-plan"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    out = result.stdout
+
+    assert _DEGRADED_HINT in out
+    assert _END_STATE_HEADER not in out
+    # The rest of the split plan still renders — degradation must not take
+    # down the whole command.
+    assert "Go/no-go" in out
+    assert "Create one git worktree per task" in out

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -40,7 +40,21 @@ def test_learn_json_includes_assign_to_workforce_section(
     assert "assign_to_workforce" in payload or "assign-to-workforce" in str(payload).lower()
 
 
-SKILL_NAMES = ("think", "spec-to-plan", "assign-to-workforce")
+# The six origin skills, in six-leg workflow order (devague#53 esd).
+SKILL_NAMES = (
+    "scope",
+    "think",
+    "spec-to-plan",
+    "assign-to-workforce",
+    "deviate",
+    "summarize-delivery",
+)
+
+# Method-only skills ship a SKILL.md and NO scripts/<name>.sh resolver — they
+# invoke the devague CLI directly. The other three are CLI-driving and DO ship
+# a scripts/<name>.sh resolver.
+METHOD_ONLY_NAMES = ("scope", "deviate", "summarize-delivery")
+CLI_DRIVING_NAMES = ("think", "spec-to-plan", "assign-to-workforce")
 
 
 def test_bare_learn_includes_skills_authoring_section(
@@ -61,7 +75,7 @@ def test_bare_learn_includes_skills_authoring_section(
 def test_learn_skills_teaches_authoring_recipe(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`learn skills` emits the recipe, the consent rules, and all three skills."""
+    """`learn skills` emits the recipe, the consent rules, and all six skills."""
     rc = main(["learn", "skills"])
     assert rc == 0
     out = capsys.readouterr().out
@@ -75,27 +89,55 @@ def test_learn_skills_teaches_authoring_recipe(
     assert "overwrite" in lower or "clobber" in lower
     for name in SKILL_NAMES:
         assert name in out
+    # The method-only structural nuance is taught, not silently dropped.
+    assert "method-only" in lower
+
+
+def test_learn_skills_no_stale_three_wording(capsys: pytest.CaptureFixture[str]) -> None:
+    """The recipe no longer claims devague ships three operator skills."""
+    rc = main(["learn", "skills"])
+    assert rc == 0
+    out = capsys.readouterr().out.lower()
+    assert "driven by three operator skills" not in out
+    assert "the three skills:" not in out
+    assert "source urls of all three" not in out
+    # All six names are present somewhere in the rendered text.
+    for name in SKILL_NAMES:
+        assert name in out
 
 
 def test_learn_skills_all_lists_canonical_source_urls(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`learn skills:all` lists every skill with its canonical source URLs."""
+    """`learn skills:all` lists every skill with its canonical source URLs —
+    CLI-driving skills get a script URL, method-only skills do not.
+    """
     rc = main(["learn", "skills:all"])
     assert rc == 0
     out = capsys.readouterr().out
     for name in SKILL_NAMES:
         assert f"/{name}/SKILL.md" in out
+    for name in CLI_DRIVING_NAMES:
         assert f"/{name}/scripts/{name}.sh" in out
+    for name in METHOD_ONLY_NAMES:
+        assert f"/{name}/scripts/{name}.sh" not in out
+    assert "method-only" in out.lower()
 
 
 @pytest.mark.parametrize("name", SKILL_NAMES)
 def test_learn_skills_one_is_focused(name: str, capsys: pytest.CaptureFixture[str]) -> None:
-    """`learn skills:<name>` focuses on a single skill and shows its source."""
+    """`learn skills:<name>` focuses on a single skill and shows its source
+    (a script URL for CLI-driving skills, none for method-only skills).
+    """
     rc = main(["learn", f"skills:{name}"])
     assert rc == 0
     out = capsys.readouterr().out
     assert f"/{name}/SKILL.md" in out
+    if name in METHOD_ONLY_NAMES:
+        assert f"/{name}/scripts/{name}.sh" not in out
+        assert "method-only" in out.lower()
+    else:
+        assert f"/{name}/scripts/{name}.sh" in out
     # The other skills' source blocks are not emitted.
     others = [n for n in SKILL_NAMES if n != name]
     for other in others:
@@ -122,10 +164,21 @@ def test_learn_unknown_skill_errors(capsys: pytest.CaptureFixture[str]) -> None:
         assert name in err
 
 
-@pytest.mark.parametrize("topic", ["skills", "skills:all", "skills:think"])
+@pytest.mark.parametrize(
+    "topic",
+    [
+        "skills",
+        "skills:all",
+        "skills:think",
+        "skills:scope",
+        "skills:deviate",
+        "skills:summarize-delivery",
+    ],
+)
 def test_learn_skills_json_payload(topic: str, capsys: pytest.CaptureFixture[str]) -> None:
     """`learn skills* --json` carries a structured authoring payload, and shares
     the bare payload's tool/version identity (one schema across the family).
+    Method-only skills carry no `script_raw` key; CLI-driving skills do.
     """
     rc = main(["learn", topic, "--json"])
     assert rc == 0
@@ -136,13 +189,20 @@ def test_learn_skills_json_payload(topic: str, capsys: pytest.CaptureFixture[str
     assert payload["topic"] == topic
     assert "consent" in payload and payload["consent"]
     assert "authoring" in payload
-    # Each skill carries its canonical raw-source URLs.
+    # Each skill carries its canonical raw-source URLs; method-only skills
+    # carry no script_raw (there is no script to link to).
     for s in payload["operator_skills"]:
         assert s["skill_md_raw"].endswith(f"/{s['name']}/SKILL.md")
+        if s["name"] in METHOD_ONLY_NAMES:
+            assert s.get("method_only") is True
+            assert "script_raw" not in s
+        else:
+            assert s.get("method_only") is False
+            assert s["script_raw"].endswith(f"/{s['name']}/scripts/{s['name']}.sh")
 
 
 def test_bare_learn_json_has_skills_key(capsys: pytest.CaptureFixture[str]) -> None:
-    """The bare `learn --json` payload now carries a `skills` section too."""
+    """The bare `learn --json` payload now carries a `skills` section with all six."""
     rc = main(["learn", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_deviate.py
+++ b/tests/test_deviate.py
@@ -11,6 +11,11 @@ move itself (:mod:`devague.cli._commands.deviate`). Acceptance criteria:
    approved; user-origin records auto-approve; a record without a reason is
    refused with a hint
 3. the plan JSON is byte-identical before and after every deviate operation
+4. ``--task``/``--affects`` refs are validated for referential integrity
+   (PR #72 review, Q2); ``--confirm``/``--reject``/positional-record/``--list``
+   conflicts are refused rather than silently resolved by precedence (Q3);
+   an invalid or dishonest status transition is refused (Q4); a broken
+   delivery ledger is translated into an actionable error (Q5)
 """
 
 from __future__ import annotations
@@ -19,7 +24,7 @@ import json
 
 import pytest
 
-from devague import delivery_store, plan_store
+from devague import delivery_store, plan_store, store
 from devague.cli import main
 from devague.delivery import (
     CLASSIFICATIONS,
@@ -29,7 +34,8 @@ from devague.delivery import (
     from_dict,
     to_dict,
 )
-from devague.plan import Plan
+from devague.frame import Frame
+from devague.plan import Plan, targets_from_frame
 
 
 def _plan(slug: str = "demo") -> Plan:
@@ -41,6 +47,28 @@ def _plan(slug: str = "demo") -> Plan:
 def _seed_plan(monkeypatch, tmp_path, slug: str = "demo") -> Plan:
     monkeypatch.chdir(tmp_path)
     plan = _plan(slug)
+    plan_store.save(plan)
+    return plan
+
+
+def _seed_plan_with_frame(monkeypatch, tmp_path, slug: str = "demo") -> Plan:
+    """Seed a plan whose live source frame has TWO confirmed claims: c1 (an
+    ``announcement`` — spec-affecting, so it lands in the plan's coverage
+    targets) and c2 (an ``assumption`` — confirmed, but NOT spec-affecting, so
+    it is NOT a coverage target). This mirrors the committed evidence ledger
+    ``.devague/deliveries/execution-seam-and-deviate.json``, whose record d1
+    affects ``["c14"]`` — c14 there is exactly this shape: a confirmed frame
+    claim that never became a plan coverage target (the CRITICAL regression
+    guard for Q2's ``--affects`` validation).
+    """
+    monkeypatch.chdir(tmp_path)
+    frame = Frame(slug=slug, title="Demo Frame")
+    frame.add_claim("announcement", "ship the thing", origin="user")  # c1 -> coverage target
+    frame.add_claim("assumption", "background assumption", origin="user")  # c2 -> not a target
+    store.save(frame)
+    plan = Plan(slug=slug, title="Demo Plan", frame_slug=slug)
+    plan.targets = targets_from_frame(frame)
+    plan.add_task("first task")  # t1
     plan_store.save(plan)
     return plan
 
@@ -118,6 +146,17 @@ def test_set_status_transitions_and_reports_unknown() -> None:
     assert d.set_status("d1", "rejected") is True
     assert d.find_deviation("d1").status == "rejected"
     assert d.set_status("dX", "approved") is False
+
+
+def test_set_status_rejects_unknown_status_without_mutating() -> None:
+    # Q4: set_status must fail closed on a typo'd/unknown status *before*
+    # mutating the record -- an invalid status must never brick the ledger on
+    # the next fail-closed load.
+    d = _delivery()
+    before = d.find_deviation("d1").status
+    with pytest.raises(ValueError):
+        d.set_status("d1", "not-a-status")
+    assert d.find_deviation("d1").status == before
 
 
 def test_classification_kinds_include_expected_values() -> None:
@@ -269,6 +308,18 @@ def test_load_legacy_delivery_without_schema_version(tmp_path, monkeypatch) -> N
     assert delivery_store.load("demo").schema_version == DELIVERY_SCHEMA_VERSION
 
 
+def test_set_status_invalid_value_never_persists(tmp_path, monkeypatch) -> None:
+    # Q4: an invalid status raises before any mutation, so a caller that
+    # (correctly) saves only after set_status succeeds never persists it.
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    d = delivery_store.load("demo")
+    with pytest.raises(ValueError):
+        d.set_status("d1", "bogus")
+    reloaded = delivery_store.load("demo")
+    assert reloaded.deviations[0].status == "approved"
+
+
 # ── CLI: recording ───────────────────────────────────────────────────────────
 
 
@@ -302,7 +353,11 @@ def test_deviate_llm_origin_lands_proposed_end_to_end(tmp_path, monkeypatch) -> 
 
 
 def test_deviate_affects_repeatable(tmp_path, monkeypatch) -> None:
-    _seed_plan(monkeypatch, tmp_path)
+    # --affects is repeatable; each ref must independently resolve (Q2), so
+    # this uses two real plan task ids rather than fabricated ones.
+    plan = _seed_plan(monkeypatch, tmp_path)
+    plan.add_task("second task")  # t2
+    plan_store.save(plan)
     rc = main(
         [
             "deviate",
@@ -312,13 +367,13 @@ def test_deviate_affects_repeatable(tmp_path, monkeypatch) -> None:
             "--reason",
             "why",
             "--affects",
-            "t2",
+            "t1",
             "--affects",
-            "c3",
+            "t2",
         ]
     )
     assert rc == 0
-    assert delivery_store.load("demo").deviations[0].affects == ["t2", "c3"]
+    assert delivery_store.load("demo").deviations[0].affects == ["t1", "t2"]
 
 
 def test_deviate_classification_flag(tmp_path, monkeypatch) -> None:
@@ -376,6 +431,117 @@ def test_deviate_json_shape_on_record(tmp_path, monkeypatch, capsys) -> None:
     }
 
 
+# ── CLI: --task / --affects referential integrity (Q2) ───────────────────────
+
+
+def test_deviate_unknown_task_ref_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--task", "t99", "--reason", "why"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "t99" in err
+    assert "devague plan show" in err
+    assert "hint:" in err
+    assert not delivery_store.path_for("demo").exists()
+
+
+def test_deviate_affects_unknown_id_shaped_ref_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    plan = _seed_plan_with_frame(monkeypatch, tmp_path)
+    rc = main(
+        [
+            "deviate",
+            "swap",
+            "--task",
+            "t1",
+            "--reason",
+            "why",
+            "--affects",
+            "c99",
+            "--plan",
+            plan.slug,
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "c99" in err
+    assert "hint:" in err
+    assert not delivery_store.path_for(plan.slug).exists()
+
+
+def test_deviate_affects_accepts_plan_task_id(tmp_path, monkeypatch) -> None:
+    plan = _seed_plan_with_frame(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--affects", "t1"])
+    assert rc == 0
+    assert delivery_store.load(plan.slug).deviations[0].affects == ["t1"]
+
+
+def test_deviate_affects_accepts_plan_coverage_target_id(tmp_path, monkeypatch) -> None:
+    plan = _seed_plan_with_frame(monkeypatch, tmp_path)
+    assert plan.find_target("c1") is not None  # c1 (announcement) IS a coverage target
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--affects", "c1"])
+    assert rc == 0
+    assert delivery_store.load(plan.slug).deviations[0].affects == ["c1"]
+
+
+def test_deviate_affects_accepts_frame_claim_not_a_coverage_target(tmp_path, monkeypatch) -> None:
+    """CRITICAL regression guard (Q2): the committed real ledger
+    ``.devague/deliveries/execution-seam-and-deviate.json`` has record d1
+    with ``affects: ["c14"]``, where c14 is a confirmed frame *assumption*
+    claim that never became a plan coverage target. Validation must accept a
+    real frame claim id even when it isn't a coverage target -- only a ref
+    that resolves nowhere at all is refused.
+    """
+    plan = _seed_plan_with_frame(monkeypatch, tmp_path)
+    assert plan.find_target("c2") is None  # c2 (assumption) is confirmed, NOT a target
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--affects", "c2"])
+    assert rc == 0
+    assert delivery_store.load(plan.slug).deviations[0].affects == ["c2"]
+
+
+def test_deviate_affects_accepts_frame_honesty_condition_id(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    frame = Frame(slug="demo", title="Demo Frame")
+    c = frame.add_claim("announcement", "ship it", origin="user")
+    frame.add_honesty(c, "must hold", origin="user")  # h1, confirmed (origin=user)
+    store.save(frame)
+    plan = Plan(slug="demo", title="Demo Plan", frame_slug="demo")
+    plan.targets = targets_from_frame(frame)
+    plan.add_task("first task")
+    plan_store.save(plan)
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--affects", "h1"])
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].affects == ["h1"]
+
+
+def test_deviate_affects_allows_non_id_shaped_free_text(tmp_path, monkeypatch) -> None:
+    plan = _seed_plan_with_frame(monkeypatch, tmp_path)
+    rc = main(
+        [
+            "deviate",
+            "swap",
+            "--task",
+            "t1",
+            "--reason",
+            "why",
+            "--affects",
+            "the auth subsystem",
+        ]
+    )
+    assert rc == 0
+    assert delivery_store.load(plan.slug).deviations[0].affects == ["the auth subsystem"]
+
+
+def test_deviate_affects_frame_missing_degrades_to_plan_ids_only(tmp_path, monkeypatch) -> None:
+    plan = _seed_plan_with_frame(monkeypatch, tmp_path)
+    store.path_for(plan.slug).unlink()  # the source frame is now gone
+    # A plan-task id ref still resolves without the frame.
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--affects", "t1"])
+    assert rc == 0
+    # A frame-only id (c2) can no longer be validated once the frame is gone.
+    rc2 = main(["deviate", "swap2", "--task", "t1", "--reason", "why2", "--affects", "c2"])
+    assert rc2 == 1
+
+
 # ── CLI: confirm / reject (user-only) ────────────────────────────────────────
 
 
@@ -402,6 +568,104 @@ def test_deviate_confirm_unknown_id_errors(tmp_path, monkeypatch, capsys) -> Non
     assert rc == 1
     err = capsys.readouterr().err
     assert "no such deviation" in err
+    assert "hint:" in err
+
+
+# ── CLI: honest transitions only (Q4) ─────────────────────────────────────────
+
+
+def test_deviate_confirm_already_approved_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why"])  # user origin -> approved
+    capsys.readouterr()
+    rc = main(["deviate", "--confirm", "d1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "already approved" in err
+    assert "hint:" in err
+    assert delivery_store.load("demo").deviations[0].status == "approved"
+
+
+def test_deviate_reject_already_rejected_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why", "--origin", "llm"])
+    main(["deviate", "--reject", "d1"])
+    capsys.readouterr()
+    rc = main(["deviate", "--reject", "d1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "already rejected" in err
+    assert delivery_store.load("demo").deviations[0].status == "rejected"
+
+
+def test_deviate_double_confirm_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why", "--origin", "llm"])
+    main(["deviate", "--confirm", "d1"])
+    capsys.readouterr()
+    rc = main(["deviate", "--confirm", "d1"])
+    assert rc == 1
+    assert "already approved" in capsys.readouterr().err
+
+
+def test_deviate_reject_after_approve_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    # An approved record cannot be flipped to rejected either -- only a
+    # *proposed* record may be resolved at all.
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why"])  # auto-approved
+    capsys.readouterr()
+    rc = main(["deviate", "--reject", "d1"])
+    assert rc == 1
+    assert "already approved" in capsys.readouterr().err
+
+
+# ── CLI: conflicting flags are refused, never silently resolved (Q3) ─────────
+
+
+def test_deviate_confirm_and_reject_are_mutually_exclusive(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        main(["deviate", "--confirm", "d1", "--reject", "d1"])
+    assert exc.value.code == 1
+
+
+def test_deviate_confirm_and_list_are_mutually_exclusive(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        main(["deviate", "--confirm", "d1", "--list"])
+    assert exc.value.code == 1
+
+
+def test_deviate_reject_and_list_are_mutually_exclusive(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        main(["deviate", "--reject", "d1", "--list"])
+    assert exc.value.code == 1
+
+
+def test_deviate_confirm_with_positional_what_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--confirm", "d1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot combine --confirm/--reject" in err
+    assert "hint:" in err
+
+
+def test_deviate_reject_with_positional_what_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--reject", "d1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot combine --confirm/--reject" in err
+
+
+def test_deviate_list_with_positional_what_is_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--list"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot combine --list" in err
     assert "hint:" in err
 
 
@@ -501,3 +765,65 @@ def test_deviate_deterministic_no_subprocess_or_llm(tmp_path, monkeypatch) -> No
     monkeypatch.setattr(subprocess, "run", _guard)
     main(["deviate", "no subprocess used", "--task", "t1", "--reason", "why"])
     assert called["n"] == 0
+
+
+# ── CLI: broken delivery ledger errors are translated (Q5) ───────────────────
+
+
+def test_deviate_delivery_schema_too_new_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    delivery_store.save(_delivery())
+    p = delivery_store.path_for("demo")
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["schema_version"] = DELIVERY_SCHEMA_VERSION + 99
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    capsys.readouterr()
+    rc = main(["deviate", "--list"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "upgrade devague" in err
+    assert "hint:" in err
+
+
+def test_deviate_delivery_malformed_json_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    p = delivery_store.path_for("demo")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not valid json", encoding="utf-8")
+    capsys.readouterr()
+    rc = main(["deviate", "--list"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "malformed" in err
+    assert "repair or remove" in err
+    assert "hint:" in err
+
+
+def test_deviate_delivery_slug_mismatch_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    delivery_store.save(_delivery())
+    p = delivery_store.path_for("demo")
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["plan_slug"] = "other"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    capsys.readouterr()
+    rc = main(["deviate", "--list"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "malformed" in err
+    assert "hint:" in err
+
+
+def test_deviate_record_also_translates_broken_delivery_ledger(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    # Q5's resolve_delivery() is wired into _record too, not just _list/confirm.
+    _seed_plan(monkeypatch, tmp_path)
+    p = delivery_store.path_for("demo")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not valid json", encoding="utf-8")
+    capsys.readouterr()
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "malformed" in err

--- a/tests/test_deviate.py
+++ b/tests/test_deviate.py
@@ -1,0 +1,503 @@
+"""Tests for the delivery store + ``devague deviate`` move (esd t3).
+
+Covers three layers: the ``Delivery``/``DeviationRecord`` domain model
+(:mod:`devague.delivery`), its persistence (:mod:`devague.delivery_store`,
+the plan_store peer including the 0.17.0 upgrade-on-write fix), and the CLI
+move itself (:mod:`devague.cli._commands.deviate`). Acceptance criteria:
+
+1. a deviate record persists under ``.devague/deliveries/<plan-slug>.json``
+   with its own schema_version, fail-closed load, and upgrade-on-write
+2. llm-origin deviations land proposed; only user confirm marks them
+   approved; user-origin records auto-approve; a record without a reason is
+   refused with a hint
+3. the plan JSON is byte-identical before and after every deviate operation
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devague import delivery_store, plan_store
+from devague.cli import main
+from devague.delivery import (
+    CLASSIFICATIONS,
+    DELIVERY_SCHEMA_VERSION,
+    Delivery,
+    DeviationRecord,
+    from_dict,
+    to_dict,
+)
+from devague.plan import Plan
+
+
+def _plan(slug: str = "demo") -> Plan:
+    p = Plan(slug=slug, title="Demo", frame_slug=slug)
+    p.add_task("first task")
+    return p
+
+
+def _seed_plan(monkeypatch, tmp_path, slug: str = "demo") -> Plan:
+    monkeypatch.chdir(tmp_path)
+    plan = _plan(slug)
+    plan_store.save(plan)
+    return plan
+
+
+def _delivery() -> Delivery:
+    d = Delivery(plan_slug="demo")
+    d.add_deviation("skipped a step", "t1", "ran out of time", origin="user")
+    return d
+
+
+# ── domain model ─────────────────────────────────────────────────────────────
+
+
+def test_next_allocates_sequential_ids() -> None:
+    d = Delivery(plan_slug="demo")
+    r1 = d.add_deviation("first", "t1", "reason one")
+    r2 = d.add_deviation("second", "t1", "reason two")
+    assert (r1.id, r2.id) == ("d1", "d2")
+
+
+def test_user_origin_auto_approves() -> None:
+    d = Delivery(plan_slug="demo")
+    rec = d.add_deviation("did x instead", "t1", "reason", origin="user")
+    assert rec.status == "approved"
+
+
+def test_llm_origin_lands_proposed() -> None:
+    d = Delivery(plan_slug="demo")
+    rec = d.add_deviation("did x instead", "t1", "reason", origin="llm")
+    assert rec.status == "proposed"
+
+
+def test_add_deviation_without_reason_raises() -> None:
+    d = Delivery(plan_slug="demo")
+    with pytest.raises(ValueError):
+        d.add_deviation("did x instead", "t1", "")
+
+
+def test_add_deviation_affects_repeatable_and_defaults_empty() -> None:
+    d = Delivery(plan_slug="demo")
+    rec = d.add_deviation("x", "t1", "reason", affects=["t2", "c3"])
+    assert rec.affects == ["t2", "c3"]
+    rec2 = d.add_deviation("y", "t1", "reason")
+    assert rec2.affects == []
+
+
+def test_add_deviation_classification_optional() -> None:
+    d = Delivery(plan_slug="demo")
+    rec = d.add_deviation("x", "t1", "reason")
+    assert rec.classification is None
+    rec2 = d.add_deviation("y", "t1", "reason", classification="risky")
+    assert rec2.classification == "risky"
+
+
+def test_add_deviation_rejects_unknown_classification() -> None:
+    d = Delivery(plan_slug="demo")
+    with pytest.raises(ValueError):
+        d.add_deviation("x", "t1", "reason", classification="not-a-kind")
+
+
+def test_add_deviation_rejects_unknown_origin() -> None:
+    d = Delivery(plan_slug="demo")
+    with pytest.raises(ValueError):
+        d.add_deviation("x", "t1", "reason", origin="robot")
+
+
+def test_find_deviation() -> None:
+    d = _delivery()
+    assert d.find_deviation("d1") is not None
+    assert d.find_deviation("nope") is None
+
+
+def test_set_status_transitions_and_reports_unknown() -> None:
+    d = _delivery()
+    assert d.set_status("d1", "rejected") is True
+    assert d.find_deviation("d1").status == "rejected"
+    assert d.set_status("dX", "approved") is False
+
+
+def test_classification_kinds_include_expected_values() -> None:
+    assert set(CLASSIFICATIONS) == {"acceptable", "risky", "needs-follow-up"}
+
+
+def test_delivery_carries_schema_version() -> None:
+    d = Delivery(plan_slug="demo")
+    assert d.schema_version == DELIVERY_SCHEMA_VERSION
+    assert to_dict(d)["schema_version"] == DELIVERY_SCHEMA_VERSION
+
+
+def test_to_dict_from_dict_roundtrip() -> None:
+    d = _delivery()
+    d.deviations[0].classification = "acceptable"
+    restored = from_dict(to_dict(d))
+    assert restored.plan_slug == d.plan_slug
+    assert restored.deviations[0] == d.deviations[0]
+
+
+def test_from_dict_defaults_missing_schema_version_to_current() -> None:
+    restored = from_dict({"plan_slug": "demo", "deviations": []})
+    assert restored.schema_version == DELIVERY_SCHEMA_VERSION
+
+
+def test_from_dict_rebuilds_deviation_record_fields() -> None:
+    raw = {
+        "plan_slug": "demo",
+        "schema_version": DELIVERY_SCHEMA_VERSION,
+        "deviations": [
+            {
+                "id": "d1",
+                "what": "swapped approach",
+                "task_ref": "t1",
+                "reason": "faster path",
+                "affects": ["t2"],
+                "origin": "llm",
+                "status": "proposed",
+                "classification": "needs-follow-up",
+            }
+        ],
+    }
+    restored = from_dict(raw)
+    rec = restored.deviations[0]
+    assert isinstance(rec, DeviationRecord)
+    assert rec.what == "swapped approach"
+    assert rec.task_ref == "t1"
+    assert rec.affects == ["t2"]
+    assert rec.classification == "needs-follow-up"
+
+
+# ── delivery_store ───────────────────────────────────────────────────────────
+
+
+def test_save_load_roundtrip(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    loaded = delivery_store.load("demo")
+    assert loaded.plan_slug == "demo"
+    assert loaded.deviations[0].what == "skipped a step"
+    assert loaded.created and loaded.updated
+
+
+def test_load_missing_raises(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        delivery_store.load("nope")
+
+
+def test_load_or_new_creates_empty_delivery_when_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    d = delivery_store.load_or_new("demo")
+    assert d.plan_slug == "demo"
+    assert d.deviations == []
+    assert not delivery_store.path_for("demo").exists()
+
+
+def test_load_or_new_loads_existing(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    d = delivery_store.load_or_new("demo")
+    assert len(d.deviations) == 1
+
+
+def test_path_for_rejects_unsafe_slug() -> None:
+    with pytest.raises(ValueError):
+        delivery_store.path_for("../../escape")
+
+
+def test_save_writes_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    raw = json.loads(delivery_store.path_for("demo").read_text(encoding="utf-8"))
+    assert raw["schema_version"] == DELIVERY_SCHEMA_VERSION
+
+
+def test_load_rejects_newer_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    p = delivery_store.path_for("demo")
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["schema_version"] = DELIVERY_SCHEMA_VERSION + 99
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(delivery_store.IncompatibleDeliverySchemaError, match="schema_version"):
+        delivery_store.load("demo")
+
+
+def test_load_rejects_tampered_internal_plan_slug(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    p = delivery_store.path_for("demo")
+    p.write_text(
+        p.read_text().replace('"plan_slug": "demo"', '"plan_slug": "../../escape"', 1),
+        "utf-8",
+    )
+    with pytest.raises(ValueError):
+        delivery_store.load("demo")
+
+
+def test_load_rejects_slug_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.save(_delivery())
+    p = delivery_store.path_for("demo")
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["plan_slug"] = "other"
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(ValueError, match="mismatch"):
+        delivery_store.load("demo")
+
+
+def test_save_upgrades_stale_schema_version_on_write(tmp_path, monkeypatch) -> None:
+    # The 0.17.0 fix pattern (frame/plan stores): save() must stamp the CURRENT
+    # schema_version rather than re-emitting a loaded/older one, or the fail-closed
+    # load gate (schema_version > DELIVERY_SCHEMA_VERSION) is defeated.
+    monkeypatch.chdir(tmp_path)
+    d = _delivery()
+    d.schema_version = 0
+    delivery_store.save(d)
+    raw = json.loads(delivery_store.path_for("demo").read_text(encoding="utf-8"))
+    assert raw["schema_version"] == DELIVERY_SCHEMA_VERSION
+    assert delivery_store.load("demo").schema_version == DELIVERY_SCHEMA_VERSION
+
+
+def test_load_legacy_delivery_without_schema_version(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    delivery_store.DELIVERIES_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {"plan_slug": "demo", "deviations": []}
+    delivery_store.path_for("demo").write_text(json.dumps(legacy), encoding="utf-8")
+    assert delivery_store.load("demo").schema_version == DELIVERY_SCHEMA_VERSION
+
+
+# ── CLI: recording ───────────────────────────────────────────────────────────
+
+
+def test_deviate_records_entry_round_trip(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "used a different library", "--task", "t1", "--reason", "faster"])
+    assert rc == 0
+    delivery = delivery_store.load("demo")
+    assert len(delivery.deviations) == 1
+    rec = delivery.deviations[0]
+    assert rec.id == "d1"
+    assert rec.what == "used a different library"
+    assert rec.task_ref == "t1"
+    assert rec.reason == "faster"
+    assert rec.affects == []
+    assert rec.classification is None
+
+
+def test_deviate_user_origin_auto_approves_end_to_end(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why"])
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].status == "approved"
+
+
+def test_deviate_llm_origin_lands_proposed_end_to_end(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--origin", "llm"])
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].status == "proposed"
+
+
+def test_deviate_affects_repeatable(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(
+        [
+            "deviate",
+            "swap",
+            "--task",
+            "t1",
+            "--reason",
+            "why",
+            "--affects",
+            "t2",
+            "--affects",
+            "c3",
+        ]
+    )
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].affects == ["t2", "c3"]
+
+
+def test_deviate_classification_flag(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(
+        [
+            "deviate",
+            "swap",
+            "--task",
+            "t1",
+            "--reason",
+            "why",
+            "--classification",
+            "risky",
+        ]
+    )
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].classification == "risky"
+
+
+def test_deviate_missing_reason_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--task", "t1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--reason" in err
+    assert "hint:" in err
+    assert not delivery_store.path_for("demo").exists()
+
+
+def test_deviate_missing_task_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "swap", "--reason", "why"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--task" in err
+    assert "hint:" in err
+
+
+def test_deviate_json_shape_on_record(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "id": "d1",
+        "what": "swap",
+        "task": "t1",
+        "reason": "why",
+        "affects": [],
+        "origin": "user",
+        "status": "approved",
+        "classification": None,
+    }
+
+
+# ── CLI: confirm / reject (user-only) ────────────────────────────────────────
+
+
+def test_deviate_confirm_marks_approved(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why", "--origin", "llm"])
+    assert delivery_store.load("demo").deviations[0].status == "proposed"
+    rc = main(["deviate", "--confirm", "d1"])
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].status == "approved"
+
+
+def test_deviate_reject_marks_rejected(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why", "--origin", "llm"])
+    rc = main(["deviate", "--reject", "d1"])
+    assert rc == 0
+    assert delivery_store.load("demo").deviations[0].status == "rejected"
+
+
+def test_deviate_confirm_unknown_id_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    rc = main(["deviate", "--confirm", "d99"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no such deviation" in err
+    assert "hint:" in err
+
+
+# ── CLI: list ────────────────────────────────────────────────────────────────
+
+
+def test_deviate_list_text_output_empty(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    capsys.readouterr()
+    rc = main(["deviate", "--list"])
+    assert rc == 0
+    assert "no deviations recorded yet" in capsys.readouterr().out
+
+
+def test_deviate_bare_invocation_lists(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why"])
+    capsys.readouterr()
+    rc = main(["deviate"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "d1" in out and "swap" in out
+
+
+def test_deviate_list_json_shape(tmp_path, monkeypatch, capsys) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    main(["deviate", "first", "--task", "t1", "--reason", "r1"])
+    main(["deviate", "second", "--task", "t1", "--reason", "r2"])
+    capsys.readouterr()
+    rc = main(["deviate", "--list", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["plan"] == "demo"
+    assert [d["id"] for d in payload["deviations"]] == ["d1", "d2"]
+
+
+def test_deviate_plan_flag_targets_named_plan(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    plan_store.save(_plan("first-plan"))
+    plan_store.save(_plan("second-plan"))
+    rc = main(
+        [
+            "deviate",
+            "swap",
+            "--task",
+            "t1",
+            "--reason",
+            "why",
+            "--plan",
+            "first-plan",
+        ]
+    )
+    assert rc == 0
+    assert len(delivery_store.load("first-plan").deviations) == 1
+    assert not delivery_store.path_for("second-plan").exists()
+
+
+def test_deviate_no_plan_selected_errors(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["deviate", "swap", "--task", "t1", "--reason", "why"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no plan selected" in err
+
+
+# ── acceptance criterion 3: plan JSON is byte-identical ──────────────────────
+
+
+def test_deviate_never_mutates_the_plan_json(tmp_path, monkeypatch) -> None:
+    _seed_plan(monkeypatch, tmp_path)
+    plan_path = plan_store.path_for("demo")
+    before = plan_path.read_bytes()
+
+    main(["deviate", "used a workaround", "--task", "t1", "--reason", "blocked upstream"])
+    main(["deviate", "swap", "--task", "t1", "--reason", "why", "--origin", "llm"])
+    main(["deviate", "--confirm", "d2"])
+    main(["deviate", "--reject", "d1"])
+    main(["deviate", "--list"])
+    main(["deviate", "--list", "--json"])
+
+    after = plan_path.read_bytes()
+    assert before == after
+
+
+def test_deviate_deterministic_no_subprocess_or_llm(tmp_path, monkeypatch) -> None:
+    # Guard against scope creep: recording must never shell out.
+    import subprocess
+
+    _seed_plan(monkeypatch, tmp_path)
+    called = {"n": 0}
+    real_run = subprocess.run
+
+    def _guard(*args, **kwargs):
+        called["n"] += 1
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _guard)
+    main(["deviate", "no subprocess used", "--task", "t1", "--reason", "why"])
+    assert called["n"] == 0

--- a/tests/test_plan_deliverables.py
+++ b/tests/test_plan_deliverables.py
@@ -1,0 +1,357 @@
+"""Tests for #53-esd t2: the read-only ``devague plan deliverables`` view (#70).
+
+Answers "what do we have in the end?" at the assign-to-workforce go/no-go, sourced
+only from existing frame/plan state: the live source frame's confirmed
+``announcement`` / ``after_state`` / ``success_signal`` claims (verbatim), the
+plan's terminal tasks (active tasks no other active task depends on) with their
+acceptance criteria, and surviving open items (the frame's non-blocking parked
+vagueness plus the plan's non-blocking risks). Covers all three acceptance criteria:
+
+1. a converged plan prints the world-after claims, terminal tasks + acceptance
+   criteria, and surviving parked items — in both text and ``--json``.
+2. an unconverged plan renders with an explicit not-converged banner / ``converged:
+   false`` — it never refuses.
+3. two consecutive renders leave ``.devague/`` byte-identical (read-only proof).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from devague import store
+from devague.cli import main
+from devague.plan import Plan, Task, terminal_tasks
+from devague.render.deliverables_md import NOT_CONVERGED_BANNER, render_deliverables
+from tests.test_render import assert_blanks_around_headings_and_lists
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+_ALL_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+# ── pure unit tests: terminal_tasks (devague/plan.py) ────────────────────────
+def _task(tid: str, deps: list[str] | None = None, status: str = "confirmed") -> Task:
+    return Task(id=tid, summary=f"summary {tid}", status=status, deps=list(deps or []))
+
+
+def test_terminal_tasks_empty() -> None:
+    assert terminal_tasks([]) == []
+
+
+def test_terminal_tasks_single_task_with_no_deps_is_terminal() -> None:
+    t1 = _task("t1")
+    assert terminal_tasks([t1]) == [t1]
+
+
+def test_terminal_tasks_excludes_a_task_something_else_depends_on() -> None:
+    t1 = _task("t1")
+    t2 = _task("t2", deps=["t1"])
+    assert terminal_tasks([t1, t2]) == [t2]
+
+
+def test_terminal_tasks_diamond_only_the_sink_is_terminal() -> None:
+    t1 = _task("t1")
+    t2 = _task("t2", deps=["t1"])
+    t3 = _task("t3", deps=["t1"])
+    t4 = _task("t4", deps=["t2", "t3"])
+    assert terminal_tasks([t1, t2, t3, t4]) == [t4]
+
+
+def test_terminal_tasks_rejected_dependent_frees_its_dependency() -> None:
+    # t2 depends on t1 but is itself rejected — t2 is never terminal (rejected is
+    # excluded), and it no longer "uses up" t1's terminal status either.
+    t1 = _task("t1")
+    t2 = _task("t2", deps=["t1"], status="rejected")
+    assert terminal_tasks([t1, t2]) == [t1]
+
+
+def test_terminal_tasks_stable_stored_order() -> None:
+    t1 = _task("t1")
+    t2 = _task("t2")
+    t3 = _task("t3")
+    assert terminal_tasks([t3, t1, t2]) == [t3, t1, t2]
+
+
+# ── pure unit tests: render_deliverables (devague/render/deliverables_md.py) ──
+def _frame_with_world_after():
+    from devague.frame import Frame
+
+    f = Frame(slug="demo", title="Demo")
+    f.add_claim("announcement", "We shipped X", origin="user")
+    f.add_claim("after_state", "Users can do Y", origin="user")
+    f.add_claim("success_signal", "95% success rate", origin="user")
+    f.add_claim("audience", "operators", origin="user")  # NOT part of the world-after view
+    f.add_vagueness("scale unknown", "unknown_nonblocking")
+    f.add_vagueness("a real blocker", "unknown_blocking")  # must never survive
+    return f
+
+
+def _plan_with_tasks() -> Plan:
+    p = Plan(slug="demo", title="Demo", frame_slug="demo")
+    t1 = p.add_task("foundation")
+    p.add_acceptance(t1, "core lands")
+    t2 = p.add_task("on top")
+    p.add_dep(t2, "t1")
+    p.add_acceptance(t2, "integration works")
+    p.add_risk("perf unknown", "unknown_nonblocking", task_id="t2")
+    p.add_risk("a blocking risk", "unknown_blocking", task_id="t2")  # must never survive
+    return p
+
+
+def test_render_deliverables_converged_has_no_banner() -> None:
+    out = render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=True)
+    assert NOT_CONVERGED_BANNER not in out
+
+
+def test_render_deliverables_world_after_verbatim() -> None:
+    out = render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=True)
+    assert "## Announcement" in out and "We shipped X" in out
+    assert "## After state" in out and "Users can do Y" in out
+    assert "## Success signals" in out and "95% success rate" in out
+    assert "operators" not in out  # audience is not one of the three world-after kinds
+
+
+def test_render_deliverables_terminal_tasks_only() -> None:
+    out = render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=True)
+    assert "## Terminal tasks" in out
+    assert "`t2`" in out and "on top" in out
+    assert "integration works" in out
+    assert "`t1`" not in out  # t1 is not terminal — t2 depends on it
+    assert "foundation" not in out
+
+
+def test_render_deliverables_open_items_excludes_blocking() -> None:
+    out = render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=True)
+    assert "## Open items" in out
+    assert "[unknown_nonblocking] scale unknown" in out
+    assert "[unknown_nonblocking] perf unknown" in out
+    assert "a real blocker" not in out
+    assert "a blocking risk" not in out
+
+
+def test_render_deliverables_banner_when_not_converged() -> None:
+    out = render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=False)
+    lines = out.splitlines()
+    assert lines[0] == "# Deliverables — Demo"
+    assert lines[1] == ""
+    assert lines[2] == NOT_CONVERGED_BANNER
+
+
+def test_render_deliverables_omits_empty_sections() -> None:
+    from devague.frame import Frame
+
+    out = render_deliverables(
+        Plan(slug="d", title="D", frame_slug="d"), Frame(slug="d", title="D"), converged=True
+    )
+    assert "## Announcement" not in out
+    assert "## After state" not in out
+    assert "## Success signals" not in out
+    assert "## Terminal tasks" not in out
+    assert "## Open items" not in out
+
+
+def test_render_deliverables_markdownlint_clean() -> None:
+    assert_blanks_around_headings_and_lists(
+        render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=False)
+    )
+
+
+# ── CLI fixtures ──────────────────────────────────────────────────────────────
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame that passes the frame gate; return its slug."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the deliverables view"])  # c1 announcement
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _converged_plan_with_terminal_split(monkeypatch, tmp_path, capsys) -> str:
+    """A converged plan with two tasks (t2 depends on t1, so only t2 is terminal),
+    a surviving non-blocking parked frame vagueness, and a surviving non-blocking
+    plan risk.
+    """
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["park", "scale unknown", "--kind", "unknown_nonblocking"])
+    main(["plan", "new", "--frame", slug])
+    half, rest = _ALL_TARGETS[:6], _ALL_TARGETS[6:]
+    args1 = ["plan", "task", "foundation work", "--accept", "foundation criteria met"]
+    for tid in half:
+        args1 += ["--covers", tid]
+    main(args1)  # t1
+    args2 = [
+        "plan",
+        "task",
+        "integration work",
+        "--accept",
+        "integration criteria met",
+        "--dep",
+        "t1",
+    ]
+    for tid in rest:
+        args2 += ["--covers", tid]
+    main(args2)  # t2, depends on t1
+    main(["plan", "risk", "perf unknown", "--kind", "unknown_nonblocking"])
+    capsys.readouterr()
+    return slug
+
+
+def _devague_snapshot(root: Path) -> dict[str, bytes]:
+    base = root / ".devague"
+    if not base.exists():
+        return {}
+    return {
+        str(p.relative_to(base)): p.read_bytes() for p in sorted(base.rglob("*")) if p.is_file()
+    }
+
+
+# ── acceptance criterion 1: converged plan, text + json ──────────────────────
+def test_deliverables_converged_text(tmp_path, monkeypatch, capsys) -> None:
+    _converged_plan_with_terminal_split(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "deliverables"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert NOT_CONVERGED_BANNER not in out
+    assert "Ship the deliverables view" in out  # announcement, verbatim
+    assert "after_state text" in out
+    assert "success_signal text" in out
+    assert "audience text" not in out  # audience is not a world-after kind
+    assert "before_state text" not in out
+    assert "boundary text" not in out
+    assert "## Terminal tasks" in out
+    assert "integration work" in out and "integration criteria met" in out
+    assert "foundation work" not in out  # t1 is not terminal (t2 depends on it)
+    assert "## Open items" in out
+    assert "scale unknown" in out
+    assert "perf unknown" in out
+
+
+def test_deliverables_converged_json(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan_with_terminal_split(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "deliverables", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["plan"] == slug
+    assert payload["converged"] is True
+    assert payload["announcement"] == ["Ship the deliverables view"]
+    assert payload["after_state"] == ["after_state text"]
+    assert payload["success_signal"] == ["success_signal text"]
+    ids = {t["id"] for t in payload["terminal_tasks"]}
+    assert ids == {"t2"}
+    (terminal_entry,) = payload["terminal_tasks"]
+    assert terminal_entry["summary"] == "integration work"
+    assert terminal_entry["acceptance_criteria"] == ["integration criteria met"]
+    open_pairs = {(i["kind"], i["text"]) for i in payload["open_items"]}
+    assert ("unknown_nonblocking", "scale unknown") in open_pairs
+    assert ("unknown_nonblocking", "perf unknown") in open_pairs
+
+
+# ── acceptance criterion 2: unconverged plan renders, never refuses ──────────
+def test_deliverables_not_converged_renders_banner_and_never_refuses(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])  # no tasks yet — plan gate fails
+    capsys.readouterr()
+
+    rc = main(["plan", "deliverables"])
+    assert rc == 0  # never refuses
+    out = capsys.readouterr().out
+    assert NOT_CONVERGED_BANNER in out
+    assert "Ship the deliverables view" in out  # world-after still shows
+    assert "## Terminal tasks" not in out  # no tasks at all
+
+    rc = main(["plan", "deliverables", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["converged"] is False
+    assert payload["announcement"] == ["Ship the deliverables view"]
+    assert payload["terminal_tasks"] == []
+
+
+def test_deliverables_excludes_blocking_items(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    # Park the blocker on the frame *after* seeding the plan — parking a blocking
+    # vagueness un-converges the frame itself, which would otherwise refuse
+    # `plan new` (deliverables must still survive this, per the frame-regression
+    # test below, but there is no need to entangle the two here).
+    main(["park", "a real blocker", "--kind", "unknown_blocking"])
+    main(["plan", "risk", "a blocking risk", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["plan", "deliverables", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    texts = {i["text"] for i in payload["open_items"]}
+    assert "a real blocker" not in texts
+    assert "a blocking risk" not in texts
+
+
+def test_deliverables_survives_frame_regression(tmp_path, monkeypatch, capsys) -> None:
+    # Unlike `plan status`/`plan converge`/`plan export`, deliverables must not
+    # refuse even when the source frame itself has regressed below its own
+    # convergence gate — it is a preview, not a gated move (#20).
+    _converged_plan_with_terminal_split(monkeypatch, tmp_path, capsys)
+    main(["reject", "c2"])  # drop a required confirmed claim -> frame un-converges
+    capsys.readouterr()
+    rc = main(["plan", "deliverables"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Ship the deliverables view" in out
+
+
+def test_deliverables_missing_source_frame_still_errors(tmp_path, monkeypatch, capsys) -> None:
+    # There is nothing at all to synthesize from — a different failure than
+    # "not converged yet", so this is the one case deliverables does refuse.
+    slug = _converged_plan_with_terminal_split(monkeypatch, tmp_path, capsys)
+    store.path_for(slug).unlink()
+    capsys.readouterr()
+    rc = main(["plan", "deliverables"])
+    assert rc == 1
+    assert "no longer exists" in capsys.readouterr().err
+
+
+def test_deliverables_registered_in_learn_and_explain(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "learn", "--json"]) == 0
+    moves = json.loads(capsys.readouterr().out)["moves"]
+    assert "deliverables" in moves
+    assert main(["plan", "explain", "deliverables", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["move"] == "deliverables"
+
+
+# ── acceptance criterion 3: .devague/ stays byte-identical (read-only proof) ──
+def test_deliverables_never_mutates_devague_state(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_plan_with_terminal_split(monkeypatch, tmp_path, capsys)
+    before = _devague_snapshot(tmp_path)
+    assert before  # sanity: there IS state to protect
+
+    main(["plan", "deliverables"])
+    main(["plan", "deliverables", "--json"])
+    main(["plan", "deliverables"])
+    main(["plan", "deliverables", "--json"])
+
+    after = _devague_snapshot(tmp_path)
+    assert before == after
+    from devague import plan_store
+
+    assert plan_store.load(slug).status == "drafting"  # converge was never persisted
+
+
+def test_deliverables_never_mutates_devague_state_when_not_converged(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    before = _devague_snapshot(tmp_path)
+
+    main(["plan", "deliverables"])
+    main(["plan", "deliverables", "--json"])
+
+    after = _devague_snapshot(tmp_path)
+    assert before == after

--- a/tests/test_plan_escape_hatches.py
+++ b/tests/test_plan_escape_hatches.py
@@ -1,0 +1,390 @@
+"""Tests for #53-esd t1: plan-engine escape hatches and demotion visibility.
+
+Covers ``depend <tN> --on <tM> --remove`` (cut one dependency edge without task
+recreation), the new ``amend <tN>`` move (edit a task's summary and/or
+replace/remove acceptance criteria by index), and the stdout hardening shared by
+every demoting move (``instruct``, ``amend``, ``depend --remove``): a harness that
+reads only stdout must still see the confirmed -> proposed flip, not just the
+stderr diagnostic (issue #67).
+"""
+
+from __future__ import annotations
+
+import json
+
+from devague import plan_store, store
+from devague.cli import main
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+
+
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame that passes the frame gate; return its slug."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the escape hatches"])  # c1 announcement
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _seeded_plan(monkeypatch, tmp_path, capsys) -> str:
+    """A plan with no tasks yet, seeded from a converged frame."""
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    return slug
+
+
+# ── the stdout-only capture test (write this first, per the TDD instruction) ──
+def test_all_demoting_moves_name_the_flip_on_stdout_alone(tmp_path, monkeypatch, capsys) -> None:
+    """Issue #67 hardening: a harness that reads only stdout must still see the
+    confirmed -> proposed demotion, exactly as spelled in the plan instruction:
+    ``t1: instruction set (confirmed -> proposed; re-confirm)``.
+    """
+    _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "alpha"])  # t1, confirmed
+    main(["plan", "task", "beta"])  # t2, confirmed
+    main(["plan", "task", "gamma", "--dep", "t1"])  # t3, confirmed, depends on t1
+    capsys.readouterr()  # drain the three 'added ...' lines before capturing below
+
+    rc = main(["plan", "instruct", "t1", "how to verify"])
+    assert rc == 0
+    out = capsys.readouterr().out  # stdout ONLY — .err is never read in this test
+    assert out.strip() == "t1: instruction set (confirmed -> proposed; re-confirm)"
+
+    rc = main(["plan", "amend", "t2", "--summary", "beta, revised"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip() == "t2: amended (confirmed -> proposed; re-confirm)"
+
+    rc = main(["plan", "depend", "t3", "--on", "t1", "--remove"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip() == "t3 no longer depends on t1 (confirmed -> proposed; re-confirm)"
+
+
+# ── depend --remove ───────────────────────────────────────────────────────────
+def test_depend_remove_round_trip_preserves_other_fields(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "root"])  # t1
+    main(
+        [
+            "plan",
+            "task",
+            "core",
+            "--origin",
+            "llm",  # stays proposed, isolating this test from the flip rule
+            "--dep",
+            "t1",
+            "--accept",
+            "criterion one",
+            "--covers",
+            "c1",
+            "--instruction",
+            "verify via `pytest`",
+        ]
+    )  # t2
+    capsys.readouterr()
+    rc = main(["plan", "depend", "t2", "--on", "t1", "--remove", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["deps"] == []
+    assert payload["flipped"] is False
+    task = plan_store.load(slug).find_task("t2")
+    assert task.deps == []
+    assert task.summary == "core"
+    assert task.acceptance_criteria == ["criterion one"]
+    assert task.covers == ["c1"]
+    assert task.instruction == "verify via `pytest`"
+    assert task.status == "proposed"
+
+
+def test_depend_remove_unknown_edge_errors_with_hint(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "a"])
+    main(["plan", "task", "b"])
+    capsys.readouterr()
+    rc = main(["plan", "depend", "t2", "--on", "t1", "--remove"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "does not depend on" in err
+    assert "hint:" in err
+    assert plan_store.load(slug).find_task("t2").deps == []
+
+
+def test_depend_remove_unknown_task_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seeded_plan(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "depend", "tX", "--on", "t1", "--remove"])
+    assert rc == 1
+    assert "no such task" in capsys.readouterr().err
+
+
+def test_depend_remove_flips_confirmed_task_json(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "root"])  # t1, confirmed
+    main(["plan", "task", "core", "--dep", "t1"])  # t2, confirmed, depends on t1
+    capsys.readouterr()
+    rc = main(["plan", "depend", "t2", "--on", "t1", "--remove", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "proposed"
+    assert payload["flipped"] is True
+    task = plan_store.load(slug).find_task("t2")
+    assert task.status == "proposed"
+    assert task.deps == []
+
+
+def test_depend_remove_on_proposed_task_no_flip(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "root"])  # t1
+    main(["plan", "task", "core", "--dep", "t1", "--origin", "llm"])  # t2, proposed
+    capsys.readouterr()
+    rc = main(["plan", "depend", "t2", "--on", "t1", "--remove", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "proposed"
+    assert payload["flipped"] is False
+    assert plan_store.load(slug).find_task("t2").status == "proposed"
+
+
+def test_depend_remove_flip_emits_stderr_note_in_text_mode(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "root"])  # t1
+    main(["plan", "task", "core", "--dep", "t1"])  # t2, confirmed
+    capsys.readouterr()
+    rc = main(["plan", "depend", "t2", "--on", "t1", "--remove"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "proposed" in err
+    assert plan_store.load(slug).find_task("t2").status == "proposed"
+
+
+def test_converge_stops_reporting_removed_edge(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "a"])  # t1
+    main(["plan", "task", "b", "--dep", "ghost"])  # t2, dangles on an unknown task
+    capsys.readouterr()
+
+    rc = main(["plan", "converge", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert any("depends on unknown task ghost" in b for b in payload["blockers"])
+
+    rc = main(["plan", "depend", "t2", "--on", "ghost", "--remove"])
+    assert rc == 0
+    capsys.readouterr()
+
+    rc = main(["plan", "converge", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert not any("depends on unknown task ghost" in b for b in payload["blockers"])
+    assert plan_store.load(slug).find_task("t2").deps == []
+
+
+# ── amend ─────────────────────────────────────────────────────────────────────
+def test_amend_does_not_touch_deps_covers_instruction(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "root"])  # t1
+    main(
+        [
+            "plan",
+            "task",
+            "core",
+            "--origin",
+            "llm",
+            "--dep",
+            "t1",
+            "--accept",
+            "one",
+            "--accept",
+            "two",
+            "--covers",
+            "c1",
+            "--instruction",
+            "verify via `pytest`",
+        ]
+    )  # t2
+    capsys.readouterr()
+    rc = main(
+        [
+            "plan",
+            "amend",
+            "t2",
+            "--summary",
+            "core, revised",
+            "--accept-replace",
+            "2",
+            "TWO",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"] == "core, revised"
+    assert payload["acceptance_criteria"] == ["one", "TWO"]
+    assert payload["flipped"] is False
+    task = plan_store.load(slug).find_task("t2")
+    assert task.summary == "core, revised"
+    assert task.acceptance_criteria == ["one", "TWO"]
+    assert task.deps == ["t1"]
+    assert task.covers == ["c1"]
+    assert task.instruction == "verify via `pytest`"
+
+
+def test_amend_replace_and_remove_indices_refer_to_pre_call_list(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(
+        [
+            "plan",
+            "task",
+            "core",
+            "--accept",
+            "one",
+            "--accept",
+            "two",
+            "--accept",
+            "three",
+        ]
+    )  # t1, confirmed, 3 criteria
+    capsys.readouterr()
+    rc = main(
+        [
+            "plan",
+            "amend",
+            "t1",
+            "--accept-replace",
+            "2",
+            "TWO",
+            "--accept-remove",
+            "1",
+            "--accept-remove",
+            "3",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["acceptance_criteria"] == ["TWO"]
+    task = plan_store.load(slug).find_task("t1")
+    assert task.acceptance_criteria == ["TWO"]
+
+
+def test_amend_out_of_range_index_errors_without_mutating(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core", "--accept", "one"])  # t1
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1", "--accept-replace", "1", "ONE", "--accept-remove", "5"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "out of range" in err
+    assert "hint:" in err
+    task = plan_store.load(slug).find_task("t1")
+    # Validation happens before any mutation — a bad index anywhere in the batch
+    # leaves the whole call a no-op, including the otherwise-valid replace.
+    assert task.acceptance_criteria == ["one"]
+
+
+def test_amend_non_integer_index_errors_cleanly(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core", "--accept", "one"])  # t1
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1", "--accept-replace", "abc", "text"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "must be an integer" in err
+    assert plan_store.load(slug).find_task("t1").acceptance_criteria == ["one"]
+
+
+def test_amend_no_args_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1"])
+    assert rc == 1
+    assert "nothing to amend" in capsys.readouterr().err
+
+
+def test_amend_unknown_task_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seeded_plan(monkeypatch, tmp_path, capsys)
+    rc = main(["plan", "amend", "tX", "--summary", "x"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no such task" in err
+    assert "hint:" in err
+
+
+def test_amend_refuses_on_rejected_task(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])  # t1, confirmed
+    main(["plan", "reject", "t1"])
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1", "--summary", "new summary"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "rejected" in err
+    assert "hint:" in err
+    task = plan_store.load(slug).find_task("t1")
+    assert task.summary == "core"  # untouched — refused, not silently applied
+
+
+def test_amend_on_proposed_task_no_flip(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core", "--origin", "llm"])  # t1, proposed
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1", "--summary", "revised", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "proposed"
+    assert payload["flipped"] is False
+    assert plan_store.load(slug).find_task("t1").summary == "revised"
+
+
+def test_amend_flips_confirmed_task_json(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])  # t1, confirmed
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1", "--summary", "revised", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "proposed"
+    assert payload["flipped"] is True
+    task = plan_store.load(slug).find_task("t1")
+    assert task.status == "proposed"
+    assert task.summary == "revised"
+
+
+def test_amend_flip_emits_stderr_note_in_text_mode(tmp_path, monkeypatch, capsys) -> None:
+    slug = _seeded_plan(monkeypatch, tmp_path, capsys)
+    main(["plan", "task", "core"])  # t1, confirmed
+    capsys.readouterr()
+    rc = main(["plan", "amend", "t1", "--summary", "revised"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "proposed" in err
+    assert plan_store.load(slug).find_task("t1").status == "proposed"
+
+
+# ── discoverability ───────────────────────────────────────────────────────────
+def test_amend_and_depend_remove_registered_in_learn_and_explain(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert main(["plan", "learn", "--json"]) == 0
+    moves = json.loads(capsys.readouterr().out)["moves"]
+    assert "amend" in moves
+    assert "depend" in moves
+
+    assert main(["plan", "explain", "amend", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["move"] == "amend"
+    assert "rejected" in payload["description"]
+
+    assert main(["plan", "explain", "depend", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["move"] == "depend"
+    assert "--remove" in payload["description"]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,442 @@
+"""Tests for ``devague summary`` and :mod:`devague.render.summary_md` (#53-esd t4).
+
+Covers the render module directly (``render_summary`` / ``render_pr_summary`` /
+``summary_data`` / ``pr_data``) and the CLI move end to end. Acceptance criteria:
+
+1. renders all eight sections in the SKILL.md order; Intent and Planned Work
+   pre-filled verbatim from frame and plan; Actual Delivery has one row per task
+   with explicit fill placeholders; Mid-work Decisions and Drift From Plan quote
+   approved deviation ids, never a proposed one as if it were approved
+2. no placeholder ever renders as a completed claim; run status stays a
+   placeholder; two renders are byte-identical; state is untouched
+3. ``--pr`` emits the condensed PR-body skeleton (stdout-only tested);
+   markdownlint-safe output
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess  # noqa: S404 - dev-tooling integration check only, not shipped code
+from pathlib import Path
+
+import pytest
+
+from devague import delivery_store, plan_store, store
+from devague.cli import main
+from devague.delivery import Delivery
+from devague.plan import Plan
+from devague.render import summary_md
+from tests.test_render import assert_markdownlint_clean
+
+_KINDS = ("audience", "after_state", "before_state", "boundary", "success_signal")
+_SECTIONS_IN_ORDER = [
+    "## Intent",
+    "## Planned Work",
+    "## Actual Delivery",
+    "## Mid-work Decisions",
+    "## Drift From Plan",
+    "## Evidence",
+    "## Delivery Claims",
+    "## Remaining Work / Follow-up",
+]
+
+_MARKDOWNLINT = shutil.which("markdownlint-cli2")
+_CONFIG = Path(__file__).resolve().parent.parent / ".markdownlint-cli2.yaml"
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+def _converged_frame(monkeypatch, tmp_path) -> str:
+    """Seed a frame that passes the frame gate; return its slug."""
+    monkeypatch.chdir(tmp_path)
+    main(["new", "Ship the execution seam"])  # c1 announcement
+    for kind in _KINDS:
+        main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"])
+    f = store.load(store.current_slug())
+    for c in f.claims:
+        main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"])
+    return store.current_slug()
+
+
+def _plan_with_two_tasks(monkeypatch, tmp_path, capsys) -> str:
+    """Seed a converged frame + plan with two tasks (t1, t2); return the plan slug."""
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "task", "first task", "--accept", "criterion one", "--covers", "c1"])
+    main(
+        [
+            "plan",
+            "task",
+            "second task",
+            "--dep",
+            "t1",
+            "--accept",
+            "criterion two",
+            "--covers",
+            "c2",
+        ]
+    )
+    capsys.readouterr()
+    return slug
+
+
+def _bare_plan_and_frame() -> tuple[Plan, None]:
+    p = Plan(slug="demo", title="Demo Plan", frame_slug="demo")
+    p.add_task("first task")
+    p.add_task("second task")
+    return p, None
+
+
+def _run_markdownlint(*paths: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [_MARKDOWNLINT, "--config", str(_CONFIG), *(str(p) for p in paths)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ── render module: section shape ─────────────────────────────────────────────
+def test_render_summary_has_all_eight_sections_in_order() -> None:
+    plan, frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
+    positions = [out.index(h) for h in _SECTIONS_IN_ORDER]
+    assert positions == sorted(positions)
+    assert out.startswith("# Delivery Summary — Demo Plan")
+
+
+def test_render_summary_run_status_is_placeholder() -> None:
+    plan, frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
+    assert "run: `<complete | partial | failed>`" in out
+    # never any of the real values standing in for the placeholder
+    assert "run: `complete`" not in out
+    assert "run: `partial`" not in out
+    assert "run: `failed`" not in out
+
+
+def test_planned_work_lists_every_task_id_and_summary_verbatim() -> None:
+    plan, frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
+    planned = out.split("## Planned Work")[1].split("## Actual Delivery")[0]
+    assert "`t1` — first task" in planned
+    assert "`t2` — second task" in planned
+
+
+def test_actual_delivery_has_one_row_per_task_with_fill_placeholders() -> None:
+    plan, frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
+    actual = out.split("## Actual Delivery")[1].split("## Mid-work Decisions")[0]
+    for tid in ("t1", "t2"):
+        assert f"| `{tid}` | `<fill: status>` | `<fill: what landed>` |" in actual
+
+
+def test_no_placeholder_ever_looks_like_a_completed_claim() -> None:
+    plan, frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
+    # every `<fill: ...>` marker lives inside a backtick code span (never bare
+    # '<' that could be mistaken for real inline HTML / an actual completed
+    # value) — strip every code span and confirm no "<fill:" text survives
+    # outside one.
+    outside_code_spans = re.sub(r"`[^`]*`", "", out)
+    assert "<fill:" not in outside_code_spans
+    # "delivered"/"complete" only ever appear as fill-me prompt text inside a
+    # backticked placeholder (e.g. "`<fill: what was delivered>`") — never as a
+    # bare claim asserting something actually happened.
+    assert "delivered" not in outside_code_spans.lower()
+    assert "complete" not in outside_code_spans.lower()
+
+
+def test_double_render_is_byte_identical() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    first = summary_md.render_summary(plan, frame, delivery)
+    second = summary_md.render_summary(plan, frame, delivery)
+    assert first == second
+
+
+def test_render_summary_degrades_gracefully_with_no_frame() -> None:
+    plan, _frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, None, Delivery(plan_slug=plan.slug))
+    assert "No source frame available" in out
+    assert "## Intent" in out
+
+
+def test_empty_plan_shows_no_tasks_placeholder_text() -> None:
+    plan = Plan(slug="empty", title="Empty Plan", frame_slug="empty")
+    out = summary_md.render_summary(plan, None, Delivery(plan_slug=plan.slug))
+    assert "(no tasks recorded on this plan)" in out
+
+
+# ── deviation records: drift + mid-work ──────────────────────────────────────
+def test_approved_deviation_appears_in_drift_and_mid_work() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation(
+        "used a workaround", "t1", "blocked upstream", origin="user", classification="risky"
+    )
+    out = summary_md.render_summary(plan, frame, delivery)
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    mid_work = out.split("## Mid-work Decisions")[1].split("## Drift From Plan")[0]
+    assert "`d1`" in drift
+    assert "`t1`" in drift
+    assert "`risky`" in drift
+    assert "`d1`" in mid_work
+    assert "used a workaround" in mid_work
+
+
+def test_proposed_deviation_never_rendered_as_approved() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("llm proposed swap", "t1", "reason", origin="llm")  # -> proposed
+    out = summary_md.render_summary(plan, frame, delivery)
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    mid_work = out.split("## Mid-work Decisions")[1].split("## Drift From Plan")[0]
+    # never quoted as approved drift
+    assert "`d1`" not in drift
+    assert "no approved deviation records yet" in drift
+    # surfaces in mid-work only under an explicit pending marker
+    assert "`d1`" in mid_work
+    assert "pending approval" in mid_work
+    assert "llm proposed swap" not in drift
+
+
+def test_rejected_deviation_omitted_everywhere() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("bad idea", "t1", "reason", origin="llm")
+    delivery.set_status("d1", "rejected")
+    out = summary_md.render_summary(plan, frame, delivery)
+    assert "d1" not in out
+    assert "bad idea" not in out
+
+
+def test_missing_classification_on_approved_deviation_is_a_fill_placeholder() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "reason", origin="user")  # approved, no classification
+    out = summary_md.render_summary(plan, frame, delivery)
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    assert "`<fill: classification>`" in drift
+
+
+def test_no_deviations_recorded_yet_empty_state() -> None:
+    plan, frame = _bare_plan_and_frame()
+    out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
+    assert "(no deviations recorded yet)" in out
+
+
+# ── markdown safety ───────────────────────────────────────────────────────────
+def test_render_summary_is_markdownlint_clean_hand_rolled() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "reason", origin="user", classification="acceptable")
+    out = summary_md.render_summary(plan, frame, delivery)
+    assert_markdownlint_clean(out)
+
+
+def test_render_pr_summary_is_markdownlint_clean_hand_rolled() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "reason", origin="user", classification="acceptable")
+    out = summary_md.render_pr_summary(plan, frame, delivery)
+    assert_markdownlint_clean(out)
+
+
+@pytest.mark.skipif(
+    _MARKDOWNLINT is None,
+    reason="markdownlint-cli2 not on PATH (dev tooling; not installed by this repo's CI)",
+)
+def test_render_summary_passes_real_markdownlint_cli2(tmp_path) -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "reason", origin="user", classification="acceptable")
+    out = summary_md.render_summary(plan, frame, delivery)
+    pr_out = summary_md.render_pr_summary(plan, frame, delivery)
+    summary_path = tmp_path / "summary.md"
+    pr_path = tmp_path / "pr.md"
+    summary_path.write_text(out, encoding="utf-8")
+    pr_path.write_text(pr_out, encoding="utf-8")
+    result = _run_markdownlint(summary_path, pr_path)
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+# ── --pr mode ─────────────────────────────────────────────────────────────────
+def test_pr_data_shape() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "reason", origin="user", classification="acceptable")
+    data = summary_md.pr_data(plan, frame, delivery)
+    assert data["plan"] == plan.slug
+    assert data["title"] == plan.title
+    # _bare_plan_and_frame's two tasks carry no dependency, so both land in wave 0.
+    assert data["waves"] == [["t1", "t2"]]
+    assert data["tasks"] == {"t1": "first task", "t2": "second task"}
+    assert data["approved_deviations"] == [
+        {"id": "d1", "task": "t1", "what": "swap", "reason": "reason"}
+    ]
+    assert data["deliveries_pointer"].startswith("docs/deliveries/")
+    assert data["deliveries_pointer"].endswith(f"-{plan.slug}.md")
+
+
+def test_render_pr_summary_renders_title_announcement_waves_and_pointer() -> None:
+    plan, _frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "reason", origin="user")
+    out = summary_md.render_pr_summary(plan, None, delivery)
+    assert out.startswith("# Demo Plan")
+    assert "## Wave / Task Map" in out
+    assert "`t1` — first task" in out
+    assert "## Approved Deviations" in out
+    assert "`d1`" in out
+    assert "Delivery summary: `docs/deliveries/" in out
+
+
+# ── CLI: text / json / --pr / degrade / no plan ──────────────────────────────
+def test_cli_summary_text_mode_prints_all_sections(tmp_path, monkeypatch, capsys) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    rc = main(["summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    for h in _SECTIONS_IN_ORDER:
+        assert h in out
+    assert "`t1` — first task" in out
+    assert "`t2` — second task" in out
+
+
+def test_cli_summary_json_mode_shape(tmp_path, monkeypatch, capsys) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    rc = main(["summary", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_status"] == "<complete | partial | failed>"
+    ids = [t["id"] for t in payload["sections"]["planned_work"]]
+    assert ids == ["t1", "t2"]
+    assert payload["sections"]["intent"]["announcement"] == "Ship the execution seam"
+
+
+def test_cli_summary_pr_mode_stdout_only(tmp_path, monkeypatch, capsys) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    rc = main(["summary", "--pr"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out.startswith("#")
+    assert "## Wave / Task Map" in captured.out
+    assert "Delivery summary: `docs/deliveries/" in captured.out
+
+
+def test_cli_summary_pr_json_mode(tmp_path, monkeypatch, capsys) -> None:
+    slug = _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    rc = main(["summary", "--pr", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["plan"] == slug
+    assert payload["waves"] == [["t1"], ["t2"]]
+
+
+def test_cli_summary_degrades_when_frame_deleted(tmp_path, monkeypatch, capsys) -> None:
+    slug = _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    store.path_for(slug).unlink()
+    rc = main(["summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "No source frame available" in out
+
+
+def test_cli_summary_no_plan_selected_errors(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = main(["summary"])
+    assert rc == 1
+    assert "no plan selected" in capsys.readouterr().err
+
+
+def test_cli_summary_plan_flag_selects_named_plan(tmp_path, monkeypatch, capsys) -> None:
+    slug = _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    rc = main(["summary", "--plan", slug])
+    assert rc == 0
+    assert "first task" in capsys.readouterr().out
+
+
+# ── deviation records quoted end-to-end via the real CLI + delivery store ────
+def test_cli_summary_quotes_approved_deviation_recorded_via_deviate(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    main(["deviate", "used a workaround", "--task", "t1", "--reason", "blocked upstream"])
+    capsys.readouterr()
+    rc = main(["summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    assert "`d1`" in drift
+    assert "blocked upstream" in drift
+
+
+def test_cli_summary_proposed_deviation_not_quoted_as_drift(tmp_path, monkeypatch, capsys) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    main(
+        [
+            "deviate",
+            "llm swap",
+            "--task",
+            "t1",
+            "--reason",
+            "reason",
+            "--origin",
+            "llm",
+        ]
+    )
+    capsys.readouterr()
+    rc = main(["summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    assert "d1" not in drift
+
+
+# ── no mutation / determinism / no subprocess ────────────────────────────────
+def test_summary_never_mutates_plan_frame_or_delivery_state(tmp_path, monkeypatch, capsys) -> None:
+    slug = _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why"])
+    capsys.readouterr()
+
+    plan_before = plan_store.path_for(slug).read_bytes()
+    frame_before = store.path_for(slug).read_bytes()
+    delivery_before = delivery_store.path_for(slug).read_bytes()
+
+    main(["summary"])
+    main(["summary", "--json"])
+    main(["summary", "--pr"])
+    main(["summary", "--pr", "--json"])
+
+    assert plan_store.path_for(slug).read_bytes() == plan_before
+    assert store.path_for(slug).read_bytes() == frame_before
+    assert delivery_store.path_for(slug).read_bytes() == delivery_before
+
+
+def test_cli_summary_double_render_byte_identical(tmp_path, monkeypatch, capsys) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    main(["deviate", "swap", "--task", "t1", "--reason", "why"])
+    capsys.readouterr()
+    main(["summary"])
+    first = capsys.readouterr().out
+    main(["summary"])
+    second = capsys.readouterr().out
+    assert first == second
+
+
+def test_summary_deterministic_no_subprocess_or_llm(tmp_path, monkeypatch, capsys) -> None:
+    _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    called = {"n": 0}
+    real_run = subprocess.run
+
+    def _guard(*args, **kwargs):
+        called["n"] += 1
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", _guard)
+    main(["summary"])
+    main(["summary", "--pr"])
+    assert called["n"] == 0

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -11,10 +11,18 @@ Covers the render module directly (``render_summary`` / ``render_pr_summary`` /
    placeholder; two renders are byte-identical; state is untouched
 3. ``--pr`` emits the condensed PR-body skeleton (stdout-only tested);
    markdownlint-safe output
+4. a broken delivery ledger is translated into an actionable
+   :class:`DevagueError` instead of falling through as "unexpected" (Q5); a
+   raw ``|`` or newline in a deviation's ``reason`` cannot corrupt the Drift
+   From Plan table (Q2); ``cmd_summary`` has a single return path
+   (SonarCloud S3516) and the "no tasks" literal is a single shared constant
+   (SonarCloud S1192)
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
 import re
 import shutil
@@ -25,7 +33,8 @@ import pytest
 
 from devague import delivery_store, plan_store, store
 from devague.cli import main
-from devague.delivery import Delivery
+from devague.cli._commands import summary as summary_cmd
+from devague.delivery import DELIVERY_SCHEMA_VERSION, Delivery
 from devague.plan import Plan
 from devague.render import summary_md
 from tests.test_render import assert_markdownlint_clean
@@ -169,6 +178,19 @@ def test_empty_plan_shows_no_tasks_placeholder_text() -> None:
     assert "(no tasks recorded on this plan)" in out
 
 
+def test_no_tasks_placeholder_is_a_single_shared_constant() -> None:
+    # SonarCloud python:S1192 — "(no tasks recorded on this plan)" was
+    # duplicated 3x (Planned Work / Actual Delivery / --pr wave-task-map);
+    # one module-level constant must back every occurrence.
+    assert summary_md.NO_TASKS_PLACEHOLDER == "(no tasks recorded on this plan)"
+    plan = Plan(slug="empty", title="Empty Plan", frame_slug="empty")
+    delivery = Delivery(plan_slug=plan.slug)
+    summary_out = summary_md.render_summary(plan, None, delivery)
+    pr_out = summary_md.render_pr_summary(plan, None, delivery)
+    assert summary_out.count(summary_md.NO_TASKS_PLACEHOLDER) == 2  # Planned Work + Actual Delivery
+    assert summary_md.NO_TASKS_PLACEHOLDER in pr_out  # --pr wave/task map
+
+
 # ── deviation records: drift + mid-work ──────────────────────────────────────
 def test_approved_deviation_appears_in_drift_and_mid_work() -> None:
     plan, frame = _bare_plan_and_frame()
@@ -225,6 +247,35 @@ def test_no_deviations_recorded_yet_empty_state() -> None:
     plan, frame = _bare_plan_and_frame()
     out = summary_md.render_summary(plan, frame, Delivery(plan_slug=plan.slug))
     assert "(no deviations recorded yet)" in out
+
+
+# ── drift table safety: a raw '|'/newline in `reason` cannot break the table (Q2) ──
+
+
+def test_drift_lines_escapes_pipe_in_reason_to_protect_table_structure() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "blocked | upstream | vendor", origin="user")
+    out = summary_md.render_summary(plan, frame, delivery)
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    row = next(ln for ln in drift.splitlines() if ln.startswith("| `t1`"))
+    # the raw pipes from the reason were escaped, not left as live separators
+    assert "\\|" in row
+    # splitting on an *unescaped* pipe must still yield exactly 5 fields:
+    # leading '', 3 columns, trailing ''
+    cells = re.split(r"(?<!\\)\|", row)
+    assert len(cells) == 5
+
+
+def test_drift_lines_flattens_newline_in_reason() -> None:
+    plan, frame = _bare_plan_and_frame()
+    delivery = Delivery(plan_slug=plan.slug)
+    delivery.add_deviation("swap", "t1", "line one\nline two", origin="user")
+    out = summary_md.render_summary(plan, frame, delivery)
+    drift = out.split("## Drift From Plan")[1].split("## Evidence")[0]
+    row = next(ln for ln in drift.splitlines() if ln.startswith("| `t1`"))
+    assert "\n" not in row
+    assert "line one line two" in row
 
 
 # ── markdown safety ───────────────────────────────────────────────────────────
@@ -294,6 +345,20 @@ def test_render_pr_summary_renders_title_announcement_waves_and_pointer() -> Non
 
 
 # ── CLI: text / json / --pr / degrade / no plan ──────────────────────────────
+def test_cmd_summary_has_a_single_return_statement() -> None:
+    # SonarCloud python:S3516 ("Refactor this method to not always return the
+    # same value"): cmd_summary had two separate `return 0` branches (--pr and
+    # non---pr), each always returning the literal 0. `_dispatch` treats a
+    # `None` return as success too, so the fix folds the branches down to one
+    # return path instead of duplicating the literal.
+    src = inspect.getsource(summary_cmd.cmd_summary)
+    tree = ast.parse(src)
+    func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef)
+    returns = [n for n in ast.walk(func) if isinstance(n, ast.Return)]
+    assert len(returns) <= 1
+
+
 def test_cli_summary_text_mode_prints_all_sections(tmp_path, monkeypatch, capsys) -> None:
     _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
     rc = main(["summary"])
@@ -357,6 +422,43 @@ def test_cli_summary_plan_flag_selects_named_plan(tmp_path, monkeypatch, capsys)
     rc = main(["summary", "--plan", slug])
     assert rc == 0
     assert "first task" in capsys.readouterr().out
+
+
+# ── broken delivery ledger errors are translated, not "unexpected" (Q5) ──────
+
+
+def test_cli_summary_delivery_schema_too_new_errors_with_hint(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slug = _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    delivery_store.save(Delivery(plan_slug=slug))
+    p = delivery_store.path_for(slug)
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    raw["schema_version"] = DELIVERY_SCHEMA_VERSION + 99
+    p.write_text(json.dumps(raw), encoding="utf-8")
+    capsys.readouterr()
+    rc = main(["summary"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "upgrade devague" in err
+    assert "hint:" in err
+    assert "unexpected" not in err
+
+
+def test_cli_summary_delivery_malformed_json_errors_with_hint(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slug = _plan_with_two_tasks(monkeypatch, tmp_path, capsys)
+    p = delivery_store.path_for(slug)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not valid json", encoding="utf-8")
+    capsys.readouterr()
+    rc = main(["summary"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "malformed" in err
+    assert "repair or remove" in err
+    assert "unexpected" not in err
 
 
 # ── deviation records quoted end-to-end via the real CLI + delivery store ────

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.17.1"
+version = "0.18.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
> devague closes the execution seam: a deliverables view answers what we have in the end at the go or no-go, the split plan renders the table humans actually approve, dependency edges can be removed without task recreation, and human-approved deviations become first-class records that connect the plan to the delivery summary

Full devague arc, end to end: `/scope` → `/think` (spec, 27 claims / 17 honesty conditions) → `/spec-to-plan` (11 tasks, 4 waves, 34 coverage targets) → `/assign-to-workforce` (one agent per task, isolated worktrees, TDD-gated merges) → `/deviate` (dogfooded live: record `d1`) → `/summarize-delivery` (committed artifact). Spec: `docs/specs/2026-07-14-execution-seam-and-deviate.md` · Plan: `docs/plans/2026-07-14-execution-seam-and-deviate.md` · **Review map: `docs/deliveries/2026-07-14-execution-seam-and-deviate.md`**.

## What ships (0.18.0)

- **`devague plan deliverables [--json]`** (#70) — read-only end-state view: confirmed announcement / after-state / success-signal verbatim, terminal tasks + acceptance criteria, surviving open items; not-converged banner, never refuses.
- **assign-to-workforce split-plan** (#69, #70) — one four-column table (`Wave | Task | Model | Task summary`, real model tokens — model + harness when it matters — 72-char truncation), has-instruction/accept-count markers on the wave listing, and a trailing **End state** section quoting `plan deliverables` verbatim (graceful hint on older devague).
- **`devague plan depend --remove` + new `plan amend` move** (#68) — cut a single edge / edit a summary / replace-remove acceptance criteria by index; no more reject-and-recreate cascades.
- **stdout flip echo** (#67 hardening) — every demoting move names the confirmed→proposed flip on the stdout result line itself (harnesses that drop stderr still see it).
- **`devague deviate`** — first-class, append-only deviation records in a new delivery store (`.devague/deliveries/<plan-slug>.json`, schema v1, fail-closed load, upgrade-on-write); llm-origin lands proposed, user-only confirm/reject.
- **New sixth origin skill `/deviate`** — stop the run, get explicit human approval, record, adjust, resume; rides gate 2, not a fourth gate.
- **`devague summary [--pr] [--json]`** — render-only eight-section delivery-summary skeleton (this PR body's own skeleton came from `--pr`); no-overclaim placeholders throughout.
- **summarize-delivery skill** starts from the skeleton and quotes approved deviations by `dN` id.
- **`culture.yaml` backend → `claude`** (#66) — the mesh standard, unblocked by closed agex-cli#46. **This PR is the live verification**: it was opened via `agex pr open` with `backend: claude` in place (plan risk r1 named the release PR as the test vehicle).
- Issues #62 and #67 closed with cited evidence (comments on the issues).

## Wave / Task Map

- wave 1: `t1` (escape hatches + flip echo) · `t3` (delivery store + deviate) · `t5` (4-column table) · `t9` (culture.yaml) · `t10` (issue closures)
- wave 2: `t2` (deliverables view) · `t4` (summary verb) · `t7` (/deviate skill)
- wave 3: `t6` (End state section) · `t8` (summarize-delivery update)
- wave 4: `t11` (release closure 0.18.0)

## Verification

- `uv run pytest -n auto` — **577 passed**; coverage **97.85 %** (gate ≥ 95 %)
- `flake8` / `black` / `isort` clean per task and post-merge; `markdownlint-cli2` clean on all touched docs
- Boundary audit (#20): zero subprocess / network / LLM usages in the deliverables, deviate, and summary code paths
- One deviation recorded, **pending user decision**: `d1` — no `PLAN_SCHEMA_VERSION` bump was needed for `depend --remove`/`amend` (frame assumption c14's antecedent didn't hold). Confirm or reject with `devague deviate --confirm d1` / `--reject d1`.

Closes #66. Closes #68. Closes #69. Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VexbPuzipZ6SUXtGWHKe3V

- devague (Claude)
