### PR TITLE
fix(skills): retire stale steward supplier refs; sharpen origin-skill provenance (#74)

### DIFF
--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -11,7 +11,7 @@ description: >
   "fan out the plan", "parallel subagents", or after /spec-to-plan exports a
   plan. Authored and maintained in agentculture/devague (origin = devague);
   guildmaster pulls this skill from here and broadcasts it to the AgentCulture
-  mesh — it is NOT vendored from guildmaster like the other skills here.
+  mesh — it is NOT vendored from guildmaster like the inbound skills here.
 type: command
 ---
 

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -21,7 +21,7 @@
 # the dependency graph; it does not spawn agents, manage worktrees, or pick
 # a backend. This wrapper is the operator-facing helper.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so
 # it is written to run anywhere — portable bash, no devague-checkout assumptions.
 #

--- a/.claude/skills/deviate/SKILL.md
+++ b/.claude/skills/deviate/SKILL.md
@@ -11,7 +11,7 @@ description: >
   matches reality partway through a workforce run. Authored and maintained in
   agentculture/devague (origin = devague); guildmaster pulls this skill from
   here and broadcasts it to the AgentCulture mesh — it is NOT vendored from
-  guildmaster like the other skills here.
+  guildmaster like the inbound skills here.
 type: command
 ---
 

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -158,8 +158,10 @@ LLM-proposed claims there, as always.
 ## Provenance
 
 This is a **first-party** skill — its origin is `agentculture/devague`, the
-*fourth* in the outbound family after `/think`, `/spec-to-plan`, and
-`/assign-to-workforce`, covering the pre-frame exploration leg. guildmaster
-pulls it from here and broadcasts it to the AgentCulture mesh. The
+*fourth* authored in the outbound family (after `/think`, `/spec-to-plan`, and
+`/assign-to-workforce`) but the **opening leg** of the flow, covering the
+pre-frame exploration that runs before `/think`. guildmaster pulls it from here
+and broadcasts it to the AgentCulture mesh; because devague is upstream, it is
+**never re-vendored back** from guildmaster's re-broadcast copy. The
 `cite, don't import` policy still holds: downstream repos copy it, they don't
 symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -11,7 +11,7 @@ description: >
   build plan", or after the /think skill exports a spec. Authored and maintained
   in agentculture/devague (origin = devague); guildmaster pulls this skill from
   here and broadcasts it to the AgentCulture mesh — it is NOT vendored from
-  guildmaster like the other skills here.
+  guildmaster like the inbound skills here.
 type: command
 ---
 

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -8,7 +8,7 @@
 # and names the recommended next move. It is the forward leg: seed a plan from a
 # *converged* frame, then work it into a buildable plan.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
 # is written to run anywhere — portable bash, no devague-checkout assumptions.
 #

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -11,7 +11,7 @@ description: >
   vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
   skill to turn it into a plan. Authored and maintained in agentculture/devague
   (origin = devague); guildmaster pulls this skill from here and broadcasts it to
-  the AgentCulture mesh — it is NOT vendored from guildmaster like the other skills
+  the AgentCulture mesh — it is NOT vendored from guildmaster like the inbound skills
   here.
 type: command
 ---

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -9,7 +9,7 @@
 # `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
 # convergence gate and names the recommended next move.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls this
 # skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
 # is written to run anywhere — portable bash, no devague-checkout assumptions.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-07-15
+
+### Fixed
+
+- skills: point the three wrapper scripts (`think.sh` / `spec-to-plan.sh` / `assign-to-workforce.sh`) and the `test_think_skill` docstring at **guildmaster**, the current mesh supplier, instead of the pre-cutover `steward` (matches every `SKILL.md` and the 2026-05-24 steward→guildmaster cutover) (#74).
+- skills: reword the `think` / `spec-to-plan` / `assign-to-workforce` / `deviate` descriptions to say they are not vendored like the **inbound** skills (matching `scope` / `summarize-delivery`), since the other origin skills are also not vendored from guildmaster (#74).
+- skills: refresh `scope`'s Provenance so its authoring-order ordinal reads correctly against its role as the **opening leg**, and add the missing never-re-vendored-back upstream clause (#74).
+
 ## [0.18.0] - 2026-07-15
 
 The execution seam and deviate — devague#53's follow-on plan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.18.0"
+version = "0.18.1"
 
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"

--- a/tests/test_think_skill.py
+++ b/tests/test_think_skill.py
@@ -2,7 +2,7 @@
 
 These drive ``.claude/skills/think/scripts/think.sh`` via subprocess in a
 sandboxed ``tmp_path`` cwd (so ``.devague/`` never touches the repo). They pin
-the contract steward relies on when it pulls this skill into the mesh: the
+the contract guildmaster relies on when it pulls this skill into the mesh: the
 wrapper forwards moves verbatim, ``status`` reads the convergence gate and names
 the next move, and ``export`` stays blocked until the frame converges. The skill
 is named ``think``; the CLI it drives is still ``devague``.

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Lands the intended fix for the **devague origin-skill family** at source, so
rollout-cli can resume its paused mesh broadcast (24 PRs open, 46 pending) and
the fix propagates on the downstream re-pull — rather than being chased across
70+ downstream copies. Closes #74.

Docs/comments only. Three small cleanups across the six origin skills:

### 1. `steward` → `guildmaster` (stale mesh-supplier name)

The three wrapper scripts (`think.sh`, `spec-to-plan.sh`,
`assign-to-workforce.sh`) and the `test_think_skill` docstring still named
`steward` as the mesh supplier in their `# Origin:` headers. That role moved to
**guildmaster** at the 2026-05-24 cutover, and every `SKILL.md` already says so
— these were the last stale references, and they would have shipped **verbatim**
to every downstream copy on the broadcast.

### 2. `other` → `inbound` skills (imprecise wording)

The `think` / `spec-to-plan` / `assign-to-workforce` / `deviate` descriptions
said they are *"not vendored from guildmaster like the **other** skills here."*
The other origin skills are *also* not vendored from guildmaster, so "other" was
imprecise. Reworded to **"inbound"**, matching `scope` and `summarize-delivery`.

### 3. `scope` provenance refresh

`scope`'s Provenance called it *"the **fourth** in the outbound family after
/think, /spec-to-plan, and /assign-to-workforce"* — which reads as if it
pre-dates the two later siblings. Clarified that the "fourth" ordinal is
**authoring order** while `scope`'s role is the **opening leg** of the flow, and
added the *never-re-vendored-back* upstream clause its younger siblings
(`summarize-delivery`, `deviate`) already carry.

## Testing

- `uv run pytest -n auto` — **614 passed**
- `markdownlint-cli2 CHANGELOG.md` — clean
- `bash -n` on all three wrapper scripts — clean
- `black --check` + `flake8` on the touched test — clean

## Version

Patch bump `0.18.0` → `0.18.1` with a `### Fixed` CHANGELOG entry.

## Follow-up for rollout-cli

Once merged, this unblocks #74: rollout-cli can refresh the 24 open PRs from the
fixed source and complete the remaining 46 pending repos.

- devague (Claude)
