### PR TITLE
fix(assign-to-workforce): keep truncate() within MAX_SUMMARY_LEN (#77)

### DIFF
--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -171,9 +171,14 @@ def marker(task_id):
 
 
 def truncate(summary):
-    if len(summary) > MAX_SUMMARY_LEN:
-        return summary[:MAX_SUMMARY_LEN] + ELLIPSIS
-    return summary
+    if len(summary) <= MAX_SUMMARY_LEN:
+        return summary
+    # Reserve room for the ellipsis so the rendered width (ellipsis included)
+    # never exceeds MAX_SUMMARY_LEN (issue #77). The trailing clamp keeps the
+    # contract intact even in the degenerate MAX_SUMMARY_LEN <= len(ELLIPSIS)
+    # case (PR #78 review), where the reserved slice would otherwise underflow.
+    slice_len = max(0, MAX_SUMMARY_LEN - len(ELLIPSIS))
+    return (summary[:slice_len] + ELLIPSIS)[:MAX_SUMMARY_LEN]
 
 
 print(f"Implementation split plan — plan: {plan_slug}")

--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,7 @@ __marimo__/
 
 # claude agent worktrees (transient; harness-managed)
 .claude/worktrees/
+
+# eidetic: local memory store (canonical store lives at ~/.eidetic; a repo-local
+# .eidetic/ is stray runtime state and must never be committed)
+.eidetic/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-07-15
+
+### Fixed
+
+- assign-to-workforce split-plan: `truncate()` no longer overshoots `MAX_SUMMARY_LEN` by the 3-char ellipsis — the rendered Task summary cell now stays within the 72-char cap (ellipsis included), so the table width control means what the constant says (#77).
+
 ## [0.19.0] - 2026-07-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.19.0"
+version = "0.19.1"
 
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"

--- a/tests/test_assign_to_workforce_script.py
+++ b/tests/test_assign_to_workforce_script.py
@@ -8,7 +8,7 @@ the actual ``devague`` / ``devague plan`` CLI (more robust than hand-writing
 ``.devague`` JSON), and asserts the table the human actually approves comes
 out: exactly one four-column table (Wave | Task | Model | Task summary),
 rows ordered by wave then task id, real (never placeholder) summaries
-truncated with an ellipsis past 72 chars, a `sonnet` default model, the
+truncated with an ellipsis to within 72 chars, a `sonnet` default model, the
 has-instruction/acceptance-count markers moved onto the wave-listing lines,
 and the go/no-go prompt + fan-out steps still present.
 
@@ -55,7 +55,10 @@ assert len(_LONG_SUMMARY) > 72
 
 _MAX_SUMMARY_LEN = 72
 _ELLIPSIS = "..."
-_EXPECTED_TRUNCATED = _LONG_SUMMARY[:_MAX_SUMMARY_LEN] + _ELLIPSIS
+# The rendered cell (ellipsis included) stays within MAX_SUMMARY_LEN — the
+# ellipsis eats into the slice rather than overshooting the cap (issue #77).
+_EXPECTED_TRUNCATED = _LONG_SUMMARY[: _MAX_SUMMARY_LEN - len(_ELLIPSIS)] + _ELLIPSIS
+assert len(_EXPECTED_TRUNCATED) == _MAX_SUMMARY_LEN
 
 
 def _converged_frame(monkeypatch, tmp_path) -> str:
@@ -181,7 +184,10 @@ def test_split_plan_renders_expected_table(tmp_path, monkeypatch) -> None:
     # to the split-plan table's own region of the output, not the full text.
     table_out = out[: out.index(_END_STATE_HEADER)] if _END_STATE_HEADER in out else out
     assert _LONG_SUMMARY not in table_out
-    assert _cells(lines[t2_idx])[3] == _EXPECTED_TRUNCATED
+    truncated_cell = _cells(lines[t2_idx])[3]
+    assert truncated_cell == _EXPECTED_TRUNCATED
+    # The rendered cell never overshoots the cap by the ellipsis length (#77).
+    assert len(truncated_cell) <= _MAX_SUMMARY_LEN
 
     # ── wave-listing markers (moved off the table, #69) ──────────────────────
     assert "t1 [instruction: yes, accept: 2]" in out

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Fixes #77 — `truncate()` in `assign-to-workforce.sh`'s split-plan renderer
returned a string `len(ELLIPSIS)` (3) chars **longer** than `MAX_SUMMARY_LEN`
whenever it truncated:

```python
return summary[:MAX_SUMMARY_LEN] + ELLIPSIS   # 72 + 3 = 75 chars
```

Because the table's column widths are computed from actual cell content
(`max(len(...))`), a truncated Task-summary cell widened the rendered table to
75 chars — overshooting the 72-char budget the constant is meant to enforce.
Presentation-only, but it made `MAX_SUMMARY_LEN` mean something other than what
it says.

## Fix

Reserve room for the ellipsis so the rendered cell (ellipsis included) stays
within the cap:

```python
return summary[:MAX_SUMMARY_LEN - len(ELLIPSIS)] + ELLIPSIS   # 69 + 3 = 72
```

- `tests/test_assign_to_workforce_script.py` previously **pinned the buggy
  75-char expectation** — updated to the corrected slice, plus a module-level
  `len(_EXPECTED_TRUNCATED) == 72` guard and an inline
  `len(truncated_cell) <= MAX_SUMMARY_LEN` assertion that locks the contract so
  a future regression fails loudly. Stale docstring wording ("past 72 chars")
  corrected to "to within 72 chars".
- Patch version bump `0.19.0 → 0.19.1` + CHANGELOG entry.

## Verification

- `uv run pytest -n auto` — 616 passed.
- `flake8` / `black --check` / `isort --check-only` clean; `markdownlint-cli2`
  clean on `CHANGELOG.md`; `agex pr lint` — no violations.

## Propagation note

`assign-to-workforce` is a devague **origin** skill (broadcast to the
AgentCulture mesh via guildmaster, cite-don't-import). Fixing at source means
downstream verbatim copies (rollout-cli, etc.) pick this up on their next
refresh rather than being patched per-copy — exactly as the reporter intended
by filing here. No sibling follow-up PR needed.

- devague (Claude)
