### PR TITLE
spec: resolve parked vagueness and scope findings (0.19.2, #45 #55 #57 #60)

### DIFF
--- a/.devague/frames/resolve-parked-vagueness-and-scope-findings.json
+++ b/.devague/frames/resolve-parked-vagueness-and-scope-findings.json
@@ -1,0 +1,481 @@
+{
+  "slug": "resolve-parked-vagueness-and-scope-findings",
+  "title": "resolve parked vagueness and scope findings",
+  "schema_version": 2,
+  "status": "exported",
+  "created": "2026-07-17T09:06:11Z",
+  "updated": "2026-07-17T09:11:24Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "Parked vagueness and recorded scope findings in devague now have close-out moves: once the user decides an open unknown, a single move records the resolution, keeps the item in the frame as evidence, and stops it blocking convergence \u2014 and a stale scope finding can be amended in place. No more hand-editing .devague state JSON.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "The #57 reproduction runs verbatim and converges with zero edits to `.devague/frames/<slug>.json`; the operator never needs a text editor to unblock a decided unknown.",
+          "status": "confirmed",
+          "instruction": ""
+        },
+        {
+          "id": "h2",
+          "text": "This frame's own spec re-exports lint-clean using `scope --amend` alone \u2014 no replay, no hand-edit. The bug that forced this very frame's replay is gone.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Verify by running the #57 reproduction verbatim against the shipped build: park an `unknown_blocking`, decide it, resolve it, and confirm `converge` passes with no edit to `.devague` state."
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "devague operators (the main agent driving the CLI move by move) and the humans who own the spec gate \u2014 plus the three reporting repos that hit this hole in practice: colleague (#45, #55), devague itself (#57), and league-of-agents (#60).",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "Each of the four issues (#45, #55, #57, #60) is answered by the shipped surface \u2014 #45's downgrade by `--kind`, #55/#57/#60's close-out by the bare form \u2014 and each can be closed citing this spec.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Check the exported spec names both audiences; the four issues are the evidence trail, not a guess."
+    },
+    {
+      "id": "c3",
+      "kind": "before_state",
+      "text": "`park` is append-only (`Frame.add_vagueness`) and `v*` ids are unaddressable \u2014 `set_status` routes only `c*`/`h*`, and `confirm`/`reject` accept only those. A decided `unknown_blocking` therefore blocks `converge` forever; operators recover by hand-editing `.devague/frames/<slug>.json` (evidenced in league-of-agents commit 0c71282) or by replaying the frame \u2014 exactly the out-of-band state mutation the move-driven design exists to prevent.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "No existing move can address a `v*` id today: verified against `set_status` (frame.py line 226), `confirm`, and `reject` \u2014 all route `c*`/`h*` only.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Verify against `devague/frame.py` `set_status` (line 226) and the #57 reproduction; both confirm no `v*` path exists."
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "Scope entries carry the identical hole: `add_scope_entry` only appends and `scope` exposes no edit or remove, so an `s*` id is unaddressable by any move. A scope finding recorded with a typo \u2014 or with an unbackticked token that fails the repo's markdownlint on export \u2014 can only be corrected by hand-editing state JSON or replaying the whole frame.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "No existing move can address an `s*` id today: `scope` exposes only `--finding`/`--seeds`/`--list`, and `add_scope_entry` appends unconditionally.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Verify `devague scope --help` exposes only `--finding`/`--seeds`/`--list`, and that `add_scope_entry` appends unconditionally."
+    },
+    {
+      "id": "c5",
+      "kind": "after_state",
+      "text": "A decided parked vagueness is closed out by a single deterministic move that records the resolution text, keeps the item in the frame as evidence rather than deleting it, and excludes it from the convergence gate \u2014 and `converge`'s hint names that actually-executable move.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "A resolved unknown_blocking no longer appears in `converge`'s blockers, while a still-open one still does \u2014 the gate keeps meaning something.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Run the #57 reproduction end-to-end and confirm it converges with no edit to state JSON."
+    },
+    {
+      "id": "c6",
+      "kind": "after_state",
+      "text": "A recorded scope finding can be corrected in place through a move: `scope --amend <sN> --finding \"<text>\"` replaces the finding text (and optionally its `--seeds`), so a stale or lint-breaking entry never forces a hand-edit or a frame replay.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "Amending a scope finding changes its text and nothing else: the `sN` id and surface are stable, and no other frame state moves.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Amend a scope entry, re-export, and confirm the corrected text lands with no state-JSON edit."
+    },
+    {
+      "id": "c7",
+      "kind": "why_it_matters",
+      "text": "Hand-editing state JSON bypasses every state-transition rule, schema validation, and `--json` echo the CLI exists to enforce \u2014 the drift the method forbids. Four issues from three repos over five weeks (2026-06-03 to 2026-07-07) report the same hole, and `converge` actively recommends a move that cannot be executed.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "After this ships, no documented path to unblocking convergence requires editing state JSON \u2014 the `learn` operating rules' ban on hand-editing becomes honest rather than aspirational.",
+          "status": "confirmed",
+          "instruction": ""
+        },
+        {
+          "id": "h9",
+          "text": "This frame is itself evidence: it had to avoid parking any `unknown_blocking`, because doing so would trap it in the same unresolvable state the fix addresses \u2014 dogfooding the bug while speccing it.",
+          "status": "confirmed",
+          "instruction": ""
+        },
+        {
+          "id": "h10",
+          "text": "This frame is evidence twice over: its first export failed markdownlint on scope-entry text that no move could repair, forcing the replay recorded in c16 \u2014 the `s*` half of the bug, hit while speccing the `v*` half.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Cite `convergence.py` line 188 as the mis-hint and the four issue numbers as the demand evidence."
+    },
+    {
+      "id": "c8",
+      "kind": "boundary",
+      "text": "Not a general frame editor. In scope: resolving/re-kinding a `v*` and amending an `s*` finding \u2014 the two append-only surfaces with no close-out path. Out of scope: claim-text editing (the frame-side half of #60), deleting vagueness or scope entries, reverting a converged frame to drafting, and any LLM judgment on whether an unknown is genuinely resolved \u2014 resolving stays a user-only decision, mirroring `confirm`.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "The shipped surface adds exactly one flat verb plus one flag on an existing verb, and no LLM call inside the CLI; claim-text editing and frame-to-drafting reversion remain absent.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Check no new move accepts `--origin llm` for the resolve transition, and that no claim-text edit path ships."
+    },
+    {
+      "id": "c9",
+      "kind": "non_goal",
+      "text": "The plan-side half of issue #60 (a task-text edit verb) is not in scope: `devague plan amend` shipped it in 0.18.0 (#68), covering summary and acceptance-criteria edits with a confirmed-task demotion. #60 is closed on that half by what already exists.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Confirm `devague/cli/_commands/plan.py` `cmd_plan_amend` covers the `plan edit <tN> --summary` ask in #60 before closing #60."
+    },
+    {
+      "id": "c10",
+      "kind": "success_signal",
+      "text": "All four issues (#45, #55, #57, #60) close against this release; the verbatim reproduction in #57 converges without touching state JSON; this frame's own spec re-exports lint-clean through `scope --amend` alone; test coverage stays >= 95% and all linters pass.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "`uv run pytest -n auto` passes with coverage >= 95%, and flake8 / black / isort / markdownlint all pass.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Run the #57 repro as an integration test; amend a scope entry and re-export; check coverage with `uv run pytest -n auto`."
+    },
+    {
+      "id": "c11",
+      "kind": "decision",
+      "text": "The move is a new flat verb: `devague resolve <vN> \"<resolution text>\"` \u2014 a peer of `confirm`/`reject`/`park`, matching the language `converge` already uses in its hint, and the shape 2 of the 4 issues (#55, #60) proposed.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c12",
+      "kind": "decision",
+      "text": "One move, two situations: bare `resolve <vN> \"<text>\"` closes out an answered unknown (#55/#57/#60); `resolve <vN> \"<text>\" --kind <vagueness-kind>` additionally re-kinds it, so a downgraded dependency stops blocking yet stays tracked under its new kind (#45). Both paths mark the item resolved and record the resolution text.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c13",
+      "kind": "decision",
+      "text": "The decision-claim link is optional: `resolve <vN> \"<text>\" [--claim <cN>]`. Never required \u2014 forcing a claim to satisfy the gate would invite fabricating one, which the method forbids. An unknown claim id is refused with a hint (the `scope --seeds` precedent).",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c14",
+      "kind": "decision",
+      "text": "`SCHEMA_VERSION` bumps 2 -> 3. `Vagueness` deserializes via strict kwargs, so without a bump an older devague hits a raw `TypeError` on the new field; with it, `store.load` refuses cleanly with an upgrade hint \u2014 the fail-closed contract from #5 (h15). New devague still reads schema-2 frames (missing keys take defaults).",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c15",
+      "kind": "decision",
+      "text": "The spec widens beyond the four issues to cover scope entries (`s*`) alongside vagueness (`v*`): one release closes the whole unaddressable-id class rather than leaving an identical trap one surface over. Claim-text editing stays out, so the boundary against a general frame editor holds.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c16",
+      "kind": "decision",
+      "text": "This frame was replayed from its move history (rather than hand-edited) to fix lint-breaking scope text \u2014 the #57 recovery, and the only path that uses moves alone. Previously confirmed claim and honesty texts were reproduced verbatim so prior user confirmations stay honest; changed and new items went back to the user as proposed.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c17",
+      "kind": "requirement",
+      "text": "Resolving is a user-only transition, mirroring `confirm`: the `resolve` move takes no `--origin llm` path and the agent must never resolve a vagueness on the user's behalf.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "The `resolve` parser exposes no `--origin` flag, so an agent cannot mark a resolution as user-originated.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Check the resolve parser exposes no `--origin` flag; assert in tests that resolution records origin user."
+    },
+    {
+      "id": "c18",
+      "kind": "requirement",
+      "text": "A resolved vagueness stays in the frame with its resolution text \u2014 history, not deletion. This is the explicit contrast with the hand-edit evidenced in league-of-agents 0c71282, which had to DELETE v4 to unblock.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h14",
+          "text": "`open_vagueness` still contains the item after resolve; nothing in the move deletes from the list.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Assert the item is still present in `open_vagueness` after resolve, with resolution text intact."
+    },
+    {
+      "id": "c19",
+      "kind": "requirement",
+      "text": "`converge` excludes a resolved vagueness from its blockers: `_missing_open_uncertainty` blocks only on an `unknown_blocking` that is NOT resolved, and `_parked_items` reports resolved items distinctly from still-open non-blocking ones.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h15",
+          "text": "A resolved unknown_blocking yields `ready_for_spec`; an unresolved one still blocks; a resolved item is not silently dropped from the frame's reported parked items.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Extend `devague/convergence.py` line 102 with the resolved predicate; test that a resolved `unknown_blocking` yields `ready_for_spec`."
+    },
+    {
+      "id": "c20",
+      "kind": "requirement",
+      "text": "`converge`'s `suggest_move` hint for a blocking vagueness names the new executable move \u2014 replacing the current line 188 hint, whose two suggested moves cannot clear a `vN` and are the mis-hint all four issues cite.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h16",
+          "text": "The new hint text, pasted verbatim into a shell, executes successfully against the frame it was emitted for.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Assert `suggest_move` for a blocking vagueness returns a `devague resolve` invocation."
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "Frames round-trip: save then load yields an identical frame, including resolved vagueness, its resolution text, its optional claim link, and any re-kind \u2014 and a schema-2 frame still loads under schema 3 with defaults.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h17",
+          "text": "A schema-2 frame fixture committed before this change still loads and round-trips under schema 3.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Test round-trip on a resolved frame plus a schema-2 fixture; this is the #5 h15 contract."
+    },
+    {
+      "id": "c22",
+      "kind": "requirement",
+      "text": "Errors follow the existing output contract: an unknown `vN`, an unknown `--claim` id, and an already-resolved `vN` are each refused to stderr with a `hint:` line and a non-zero exit; results and `--json` go to stdout.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h18",
+          "text": "Each refusal exits non-zero with a `hint:` on stderr and writes nothing to stdout.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Mirror the refusal style of `scope --seeds` for the unknown-id cases."
+    },
+    {
+      "id": "c23",
+      "kind": "requirement",
+      "text": "`show` and `status` surface resolved vagueness distinctly from open vagueness, so the evidence trail is readable without `--json` \u2014 and the exported spec-md renders a resolved item as resolved, with its resolution text.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h19",
+          "text": "An exported spec containing a resolved vagueness passes `markdownlint-cli2`.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Check `render/spec_md.py` and `render/frame_md.py`; markdownlint the exported spec."
+    },
+    {
+      "id": "c24",
+      "kind": "requirement",
+      "text": "`scope --amend <sN> --finding \"<text>\" [--seeds <claim-id> ...]` replaces a recorded finding's text in place, refusing an unknown `sN` or an unknown seed id with a `hint:` on stderr. It mirrors the existing `scope` contract, adds no new store, and \u2014 like `resolve` \u2014 takes no `--origin` flag.",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h20",
+          "text": "Amending a scope entry then re-exporting yields the corrected text with no state-JSON edit and no frame replay.",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "Amend an entry, assert the finding text is replaced and the id/surface are stable; assert unknown-id refusals exit non-zero."
+    }
+  ],
+  "open_vagueness": [
+    {
+      "id": "v1",
+      "text": "Whether `resolve` should be reversible (an un-resolve / re-open path). No reporter asked for it; the evidence is all one-directional. Deferring until someone hits it.",
+      "kind": "follow_up",
+      "claim_id": null
+    },
+    {
+      "id": "v2",
+      "text": "Whether `resolve <vN> --kind unknown_blocking` \u2014 re-kinding an item INTO the blocking kind \u2014 should be refused as incoherent or allowed as a legitimate re-open.",
+      "kind": "unknown_nonblocking",
+      "claim_id": null
+    },
+    {
+      "id": "v3",
+      "text": "Operator confusion risk between two same-named loops on different stores: `question --resolve <qid>` (uncommitted markdown working state) versus the new flat `resolve <vN>` (committed frame state). Naming is decided; whether it needs disambiguation in `learn` is not.",
+      "kind": "unknown_nonblocking",
+      "claim_id": null
+    },
+    {
+      "id": "v4",
+      "text": "Whether the frame-side claim-text edit ask in #60 (`devague edit <cN> --text`) gets its own follow-up issue, now that the plan-side half is closed by `plan amend` (#68) and this frame rules claim-text editing out of scope.",
+      "kind": "follow_up",
+      "claim_id": null
+    },
+    {
+      "id": "v5",
+      "text": "Whether `scope --amend` should also allow amending the `surface` field, not just the `--finding` text. No evidence either way yet; the lint trap that motivated it was finding-text only.",
+      "kind": "unknown_nonblocking",
+      "claim_id": null
+    }
+  ],
+  "scope_entries": [
+    {
+      "id": "s1",
+      "surface": "devague/frame.py",
+      "finding": "`Vagueness` is a 4-field dataclass (`id`/`text`/`kind`/`claim_id`) with no status or resolution field; `add_vagueness` only appends; `set_status` routes `c*`/`h*` only, so `v*` ids are unaddressable by any move. Deserialization is strict kwargs (`Vagueness(**v)`), so a new field means an older devague raises `TypeError` rather than a clean schema error.",
+      "seeds": []
+    },
+    {
+      "id": "s2",
+      "surface": "devague/convergence.py",
+      "finding": "Only `kind == unknown_blocking` blocks (line 102); everything else is reported as tracked non-blocking via `_parked_items`. `suggest_move` line 188 emits a hint naming two moves that cannot clear a `vN` \u2014 the mis-hint all four issues cite.",
+      "seeds": []
+    },
+    {
+      "id": "s3",
+      "surface": "devague/cli/_commands/question.py",
+      "finding": "The `question --resolve` loop cited as precedent by #55/#57 does NOT mutate frame state: it writes uncommitted markdown working state under `.devague/questions/`. Vagueness lives in committed frame JSON, so resolve is a frame mutation and a stronger contract than its cited precedent.",
+      "seeds": []
+    },
+    {
+      "id": "s4",
+      "surface": "devague/cli/_commands/plan.py",
+      "finding": "`plan amend` (#68, 0.18.0) already ships summary + acceptance-criteria editing and flips a CONFIRMED task back to proposed. This closes the plan-side half of issue #60 before this frame starts.",
+      "seeds": []
+    },
+    {
+      "id": "s5",
+      "surface": "devague/store.py",
+      "finding": "`SCHEMA_VERSION` is 2, and load fails closed when a persisted frame declares a newer one. Any new `Vagueness` field forces a decision on bumping to 3.",
+      "seeds": []
+    },
+    {
+      "id": "s6",
+      "surface": "devague/frame.py + devague/cli/_commands/scope.py",
+      "finding": "Discovered by dogfooding THIS frame: `add_scope_entry` is append-only and `scope` exposes no edit or remove, so `s*` ids are unaddressable exactly like `v*`. This frame's own first export failed markdownlint on scope-entry text that no move could fix \u2014 the same trap, one surface over, hit within a single session of speccing it.",
+      "seeds": []
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2026-07-17
+
+### Added
+
+- Spec (docs + frame state only; no CLI change yet): **resolve parked vagueness
+  and scope findings** — `docs/specs/2026-07-17-resolve-parked-vagueness-and-scope-findings.md`,
+  the converged frame for the unaddressable-id class reported by #45, #55, #57
+  and #60. Specifies a new flat `devague resolve <vN> "<text>" [--kind <kind>]
+  [--claim <cN>]` move (close out an answered unknown; `--kind` also re-kinds a
+  downgraded one so it stops blocking yet stays tracked), plus
+  `devague scope --amend <sN> --finding "<text>"` for the identical append-only
+  hole on scope entries. Resolved items stay in the frame as evidence — history,
+  not deletion. `SCHEMA_VERSION` bumps 2 → 3 so an older devague fails closed
+  with an upgrade hint instead of a raw `TypeError`. The frame-side claim-text
+  edit ask in #60 stays out of scope; its plan-side half already shipped as
+  `plan amend` (#68, 0.18.0).
+
 ## [0.19.1] - 2026-07-15
 
 ### Fixed

--- a/docs/specs/2026-07-17-resolve-parked-vagueness-and-scope-findings.md
+++ b/docs/specs/2026-07-17-resolve-parked-vagueness-and-scope-findings.md
@@ -1,0 +1,105 @@
+# resolve parked vagueness and scope findings
+
+> Parked vagueness and recorded scope findings in devague now have close-out moves: once the user decides an open unknown, a single move records the resolution, keeps the item in the frame as evidence, and stops it blocking convergence — and a stale scope finding can be amended in place. No more hand-editing .devague state JSON.
+> instruction: Verify by running the #57 reproduction verbatim against the shipped build: park an `unknown_blocking`, decide it, resolve it, and confirm `converge` passes with no edit to `.devague` state.
+
+## Audience
+
+- devague operators (the main agent driving the CLI move by move) and the humans who own the spec gate — plus the three reporting repos that hit this hole in practice: colleague (#45, #55), devague itself (#57), and league-of-agents (#60).
+  - instruction: Check the exported spec names both audiences; the four issues are the evidence trail, not a guess.
+
+## Before → After
+
+- Before: `park` is append-only (`Frame.add_vagueness`) and `v*` ids are unaddressable — `set_status` routes only `c*`/`h*`, and `confirm`/`reject` accept only those. A decided `unknown_blocking` therefore blocks `converge` forever; operators recover by hand-editing `.devague/frames/<slug>.json` (evidenced in league-of-agents commit 0c71282) or by replaying the frame — exactly the out-of-band state mutation the move-driven design exists to prevent.
+  - instruction: Verify against `devague/frame.py` `set_status` (line 226) and the #57 reproduction; both confirm no `v*` path exists.
+- Before: Scope entries carry the identical hole: `add_scope_entry` only appends and `scope` exposes no edit or remove, so an `s*` id is unaddressable by any move. A scope finding recorded with a typo — or with an unbackticked token that fails the repo's markdownlint on export — can only be corrected by hand-editing state JSON or replaying the whole frame.
+  - instruction: Verify `devague scope --help` exposes only `--finding`/`--seeds`/`--list`, and that `add_scope_entry` appends unconditionally.
+- After: A decided parked vagueness is closed out by a single deterministic move that records the resolution text, keeps the item in the frame as evidence rather than deleting it, and excludes it from the convergence gate — and `converge`'s hint names that actually-executable move.
+  - instruction: Run the #57 reproduction end-to-end and confirm it converges with no edit to state JSON.
+- After: A recorded scope finding can be corrected in place through a move: `scope --amend <sN> --finding "<text>"` replaces the finding text (and optionally its `--seeds`), so a stale or lint-breaking entry never forces a hand-edit or a frame replay.
+  - instruction: Amend a scope entry, re-export, and confirm the corrected text lands with no state-JSON edit.
+
+## Why it matters
+
+- Hand-editing state JSON bypasses every state-transition rule, schema validation, and `--json` echo the CLI exists to enforce — the drift the method forbids. Four issues from three repos over five weeks (2026-06-03 to 2026-07-07) report the same hole, and `converge` actively recommends a move that cannot be executed.
+  - instruction: Cite `convergence.py` line 188 as the mis-hint and the four issue numbers as the demand evidence.
+
+## Requirements
+
+- Resolving is a user-only transition, mirroring `confirm`: the `resolve` move takes no `--origin llm` path and the agent must never resolve a vagueness on the user's behalf.
+  - instruction: Check the resolve parser exposes no `--origin` flag; assert in tests that resolution records origin user.
+  - honesty: The `resolve` parser exposes no `--origin` flag, so an agent cannot mark a resolution as user-originated.
+- A resolved vagueness stays in the frame with its resolution text — history, not deletion. This is the explicit contrast with the hand-edit evidenced in league-of-agents 0c71282, which had to DELETE v4 to unblock.
+  - instruction: Assert the item is still present in `open_vagueness` after resolve, with resolution text intact.
+  - honesty: `open_vagueness` still contains the item after resolve; nothing in the move deletes from the list.
+- `converge` excludes a resolved vagueness from its blockers: `_missing_open_uncertainty` blocks only on an `unknown_blocking` that is NOT resolved, and `_parked_items` reports resolved items distinctly from still-open non-blocking ones.
+  - instruction: Extend `devague/convergence.py` line 102 with the resolved predicate; test that a resolved `unknown_blocking` yields `ready_for_spec`.
+  - honesty: A resolved unknown_blocking yields `ready_for_spec`; an unresolved one still blocks; a resolved item is not silently dropped from the frame's reported parked items.
+- `converge`'s `suggest_move` hint for a blocking vagueness names the new executable move — replacing the current line 188 hint, whose two suggested moves cannot clear a `vN` and are the mis-hint all four issues cite.
+  - instruction: Assert `suggest_move` for a blocking vagueness returns a `devague resolve` invocation.
+  - honesty: The new hint text, pasted verbatim into a shell, executes successfully against the frame it was emitted for.
+- Frames round-trip: save then load yields an identical frame, including resolved vagueness, its resolution text, its optional claim link, and any re-kind — and a schema-2 frame still loads under schema 3 with defaults.
+  - instruction: Test round-trip on a resolved frame plus a schema-2 fixture; this is the #5 h15 contract.
+  - honesty: A schema-2 frame fixture committed before this change still loads and round-trips under schema 3.
+- Errors follow the existing output contract: an unknown `vN`, an unknown `--claim` id, and an already-resolved `vN` are each refused to stderr with a `hint:` line and a non-zero exit; results and `--json` go to stdout.
+  - instruction: Mirror the refusal style of `scope --seeds` for the unknown-id cases.
+  - honesty: Each refusal exits non-zero with a `hint:` on stderr and writes nothing to stdout.
+- `show` and `status` surface resolved vagueness distinctly from open vagueness, so the evidence trail is readable without `--json` — and the exported spec-md renders a resolved item as resolved, with its resolution text.
+  - instruction: Check `render/spec_md.py` and `render/frame_md.py`; markdownlint the exported spec.
+  - honesty: An exported spec containing a resolved vagueness passes `markdownlint-cli2`.
+- `scope --amend <sN> --finding "<text>" [--seeds <claim-id> ...]` replaces a recorded finding's text in place, refusing an unknown `sN` or an unknown seed id with a `hint:` on stderr. It mirrors the existing `scope` contract, adds no new store, and — like `resolve` — takes no `--origin` flag.
+  - instruction: Amend an entry, assert the finding text is replaced and the id/surface are stable; assert unknown-id refusals exit non-zero.
+  - honesty: Amending a scope entry then re-exporting yields the corrected text with no state-JSON edit and no frame replay.
+
+## Honesty conditions
+
+- The #57 reproduction runs verbatim and converges with zero edits to `.devague/frames/<slug>.json`; the operator never needs a text editor to unblock a decided unknown.
+- This frame's own spec re-exports lint-clean using `scope --amend` alone — no replay, no hand-edit. The bug that forced this very frame's replay is gone.
+- Each of the four issues (#45, #55, #57, #60) is answered by the shipped surface — #45's downgrade by `--kind`, #55/#57/#60's close-out by the bare form — and each can be closed citing this spec.
+- No existing move can address a `v*` id today: verified against `set_status` (frame.py line 226), `confirm`, and `reject` — all route `c*`/`h*` only.
+- No existing move can address an `s*` id today: `scope` exposes only `--finding`/`--seeds`/`--list`, and `add_scope_entry` appends unconditionally.
+- A resolved unknown_blocking no longer appears in `converge`'s blockers, while a still-open one still does — the gate keeps meaning something.
+- Amending a scope finding changes its text and nothing else: the `sN` id and surface are stable, and no other frame state moves.
+- After this ships, no documented path to unblocking convergence requires editing state JSON — the `learn` operating rules' ban on hand-editing becomes honest rather than aspirational.
+- This frame is itself evidence: it had to avoid parking any `unknown_blocking`, because doing so would trap it in the same unresolvable state the fix addresses — dogfooding the bug while speccing it.
+- This frame is evidence twice over: its first export failed markdownlint on scope-entry text that no move could repair, forcing the replay recorded in c16 — the `s*` half of the bug, hit while speccing the `v*` half.
+- The shipped surface adds exactly one flat verb plus one flag on an existing verb, and no LLM call inside the CLI; claim-text editing and frame-to-drafting reversion remain absent.
+- `uv run pytest -n auto` passes with coverage >= 95%, and flake8 / black / isort / markdownlint all pass.
+
+## Success signals
+
+- All four issues (#45, #55, #57, #60) close against this release; the verbatim reproduction in #57 converges without touching state JSON; this frame's own spec re-exports lint-clean through `scope --amend` alone; test coverage stays >= 95% and all linters pass.
+  - instruction: Run the #57 repro as an integration test; amend a scope entry and re-export; check coverage with `uv run pytest -n auto`.
+
+## Scope / boundaries
+
+- Not a general frame editor. In scope: resolving/re-kinding a `v*` and amending an `s*` finding — the two append-only surfaces with no close-out path. Out of scope: claim-text editing (the frame-side half of #60), deleting vagueness or scope entries, reverting a converged frame to drafting, and any LLM judgment on whether an unknown is genuinely resolved — resolving stays a user-only decision, mirroring `confirm`.
+  - instruction: Check no new move accepts `--origin llm` for the resolve transition, and that no claim-text edit path ships.
+
+## Non-goals
+
+- The plan-side half of issue #60 (a task-text edit verb) is not in scope: `devague plan amend` shipped it in 0.18.0 (#68), covering summary and acceptance-criteria edits with a confirmed-task demotion. #60 is closed on that half by what already exists.
+  - instruction: Confirm `devague/cli/_commands/plan.py` `cmd_plan_amend` covers the `plan edit <tN> --summary` ask in #60 before closing #60.
+
+## Scope exploration
+
+- `s1` — `devague/frame.py`: `Vagueness` is a 4-field dataclass (`id`/`text`/`kind`/`claim_id`) with no status or resolution field; `add_vagueness` only appends; `set_status` routes `c*`/`h*` only, so `v*` ids are unaddressable by any move. Deserialization is strict kwargs (`Vagueness(**v)`), so a new field means an older devague raises `TypeError` rather than a clean schema error.
+- `s2` — `devague/convergence.py`: Only `kind == unknown_blocking` blocks (line 102); everything else is reported as tracked non-blocking via `_parked_items`. `suggest_move` line 188 emits a hint naming two moves that cannot clear a `vN` — the mis-hint all four issues cite.
+- `s3` — `devague/cli/_commands/question.py`: The `question --resolve` loop cited as precedent by #55/#57 does NOT mutate frame state: it writes uncommitted markdown working state under `.devague/questions/`. Vagueness lives in committed frame JSON, so resolve is a frame mutation and a stronger contract than its cited precedent.
+- `s4` — `devague/cli/_commands/plan.py`: `plan amend` (#68, 0.18.0) already ships summary + acceptance-criteria editing and flips a CONFIRMED task back to proposed. This closes the plan-side half of issue #60 before this frame starts.
+- `s5` — `devague/store.py`: `SCHEMA_VERSION` is 2, and load fails closed when a persisted frame declares a newer one. Any new `Vagueness` field forces a decision on bumping to 3.
+- `s6` — `devague/frame.py + devague/cli/_commands/scope.py`: Discovered by dogfooding THIS frame: `add_scope_entry` is append-only and `scope` exposes no edit or remove, so `s*` ids are unaddressable exactly like `v*`. This frame's own first export failed markdownlint on scope-entry text that no move could fix — the same trap, one surface over, hit within a single session of speccing it.
+
+## Decisions
+
+- The move is a new flat verb: `devague resolve <vN> "<resolution text>"` — a peer of `confirm`/`reject`/`park`, matching the language `converge` already uses in its hint, and the shape 2 of the 4 issues (#55, #60) proposed.
+- One move, two situations: bare `resolve <vN> "<text>"` closes out an answered unknown (#55/#57/#60); `resolve <vN> "<text>" --kind <vagueness-kind>` additionally re-kinds it, so a downgraded dependency stops blocking yet stays tracked under its new kind (#45). Both paths mark the item resolved and record the resolution text.
+- The decision-claim link is optional: `resolve <vN> "<text>" [--claim <cN>]`. Never required — forcing a claim to satisfy the gate would invite fabricating one, which the method forbids. An unknown claim id is refused with a hint (the `scope --seeds` precedent).
+- `SCHEMA_VERSION` bumps 2 -> 3. `Vagueness` deserializes via strict kwargs, so without a bump an older devague hits a raw `TypeError` on the new field; with it, `store.load` refuses cleanly with an upgrade hint — the fail-closed contract from #5 (h15). New devague still reads schema-2 frames (missing keys take defaults).
+- The spec widens beyond the four issues to cover scope entries (`s*`) alongside vagueness (`v*`): one release closes the whole unaddressable-id class rather than leaving an identical trap one surface over. Claim-text editing stays out, so the boundary against a general frame editor holds.
+- This frame was replayed from its move history (rather than hand-edited) to fix lint-breaking scope text — the #57 recovery, and the only path that uses moves alone. Previously confirmed claim and honesty texts were reproduced verbatim so prior user confirmations stay honest; changed and new items went back to the user as proposed.
+
+## Open / follow-up
+
+- Whether `resolve` should be reversible (an un-resolve / re-open path). No reporter asked for it; the evidence is all one-directional. Deferring until someone hits it.
+- Whether the frame-side claim-text edit ask in #60 (`devague edit <cN> --text`) gets its own follow-up issue, now that the plan-side half is closed by `plan amend` (#68) and this frame rules claim-text editing out of scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.19.1"
+version = "0.19.2"
 
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"


### PR DESCRIPTION
## What

The converged spec for the **unaddressable-id class** — the gap reported four times across three repos over five weeks: [#45](https://github.com/agentculture/devague/issues/45), [#55](https://github.com/agentculture/devague/issues/55), [#57](https://github.com/agentculture/devague/issues/57), [#60](https://github.com/agentculture/devague/issues/60).

**Docs + frame state only. No CLI change yet** — the build is the `/spec-to-plan` leg.

`park` and `scope` record first-class state, but no move can address a `v*` or `s*` id: `set_status` routes `c*`/`h*` only, and `confirm`/`reject` accept only those. So a decided `unknown_blocking` blocks `converge` forever, and operators escape by hand-editing `.devague/frames/<slug>.json` — the exact out-of-band mutation the move-driven design exists to prevent. `converge` makes it worse by recommending a move that cannot be executed (`convergence.py` line 188).

## What ships (per the spec)

- **`devague resolve <vN> "<text>" [--kind <kind>] [--claim <cN>]`** — a new flat verb. The bare form closes out an answered unknown (#55, #57, #60); `--kind` also re-kinds a downgraded one so it stops blocking yet stays tracked (#45). Resolved items **stay in the frame with their resolution text** — history, not deletion, in explicit contrast with the hand-edit in league-of-agents `0c71282`, which had to *delete* `v4` to unblock.
- **`devague scope --amend <sN> --finding "<text>"`** — the identical append-only hole on scope entries.
- **`SCHEMA_VERSION` 2 → 3** — `Vagueness` deserializes via strict kwargs, so without a bump an older devague hits a raw `TypeError` on the new field; with it, `store.load` refuses cleanly with an upgrade hint (the fail-closed contract from #5/h15).
- Resolving is **user-only**, mirroring `confirm` — no `--origin` flag exists, so an agent cannot resolve on the user's behalf.

## Three findings from reading the code, not the issues

**#60 is already half-closed.** Its plan-side ask (a task-text edit verb) shipped as `plan amend` in 0.18.0 (#68). No work needed there; the frame-side claim-text edit ask stays out of scope, so the boundary against a general frame editor holds.

**The `question --resolve` precedent #55 and #57 lean on is weaker than they assume.** It writes uncommitted markdown under `.devague/questions/`, not frame state. Vagueness lives in committed frame JSON, so `resolve` is a genuine state mutation needing a stronger contract than its cited model.

**#45 is not the same request as the other three.** They want to close out an *answered* unknown; #45 wants to *downgrade* one that is still real. `--kind` covers both without ever labeling a live unknown "resolved and gone."

## Why the scope widened past the four issues

The issues only report `v*`. This frame's **own first export failed markdownlint** on scope-entry text that no move could repair — `add_scope_entry` appends unconditionally and `scope` exposes no edit or remove. The `s*` half of the bug was hit while speccing the `v*` half, within a single session. That is stronger evidence than any of the four issues carry, so one release closes the whole class rather than leaving an identical trap one surface over.

The frame carries its own recovery: rather than hand-edit state JSON (which would have made honesty condition `h8` false at the moment it was asserted), the frame was **replayed from its move history** — the #57 recovery, and the only path that uses moves alone. Previously confirmed claim and honesty texts were reproduced verbatim so prior user confirmations stay honest; changed and new items went back to the user as proposed. `c16` records that replay in the spec.

There is a second piece of self-evidence in `h9`: this frame had to avoid parking any `unknown_blocking`, because doing so would have trapped it in the same unresolvable state it specs.

## Gates

- **Spec gate** (this PR): 24 claims, 20 honesty conditions, all user-confirmed. `converge ✓`.
- Exported spec passes `markdownlint-cli2` — 0 errors.
- No code touched, so no test surface moves.

## Open items (parked, all non-blocking)

- `v1` whether `resolve` should be reversible — no reporter asked; deferring.
- `v2` whether `resolve --kind unknown_blocking` should be refused as incoherent or allowed as a re-open.
- `v3` whether `question --resolve <qid>` vs `resolve <vN>` needs disambiguation in `learn` (different stores: working markdown vs committed frame state).
- `v4` whether #60's frame-side `edit <cN> --text` gets its own follow-up issue.
- `v5` whether `scope --amend` should also amend the `surface` field, not just `--finding`.

## Next

`/spec-to-plan` turns this into a buildable plan. Closes #45, #55, #57, #60 once that lands.

- devague (Claude)
