### PR TITLE
park --resolve / plan risk --resolve: the close-out for parked vagueness (0.20.0, #45 #55 #57 #60)

### DIFF
--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -80,6 +80,7 @@ for portable resolution.
 | `scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]` / `scope --list` | Record (or list) a pre-frame exploration finding as first-class state (see the scope pointer above). |
 | `question "<text>"` | Record / list / `--resolve` a pending user decision as durable working state in `.devague/questions/<slug>.md`. |
 | `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
+| `park --resolve <vN> --decision "<text>" [--claim <cN>]` | Close out a decided parked item — stays on record with its resolution, drops out of the convergence gate; `--claim` links the deciding claim. **User-only decision**, same as `confirm`. |
 | `converge` | Evaluate the gate; list remaining gaps. |
 | `export` | Write the buildable spec to `docs/specs/` — only after `converge` passes. |
 | `status` | Read-only: where the frame stands + the recommended next move (`--json` too). |
@@ -207,7 +208,12 @@ These are the point of the method — convergence must mean something.
   and no unresolved blocking vagueness or hard question.
 - **Park real unknowns; don't paper over them.** If something is genuinely
   unknown, `park` it (blocking or non-blocking) rather than fabricating an
-  answer. Blocking vagueness holds back convergence — by design.
+  answer. Blocking vagueness holds back convergence — by design. Once it's
+  decided, close it out with `park --resolve <vN> --decision "<text>"` —
+  the item stays on record with its resolution and stops blocking. Never
+  leave a decided blocking park sitting forever, and never hand-edit
+  `.devague` state to work around it — the resolve move is the CLI's own
+  escape hatch.
 
 ## Output contract
 

--- a/.devague/current_plan
+++ b/.devague/current_plan
@@ -1,1 +1,1 @@
-challenge-skill
+resolve-parked-vagueness

--- a/.devague/frames/resolve-parked-vagueness.json
+++ b/.devague/frames/resolve-parked-vagueness.json
@@ -1,0 +1,490 @@
+{
+  "slug": "resolve-parked-vagueness",
+  "title": "resolve parked vagueness",
+  "schema_version": 2,
+  "status": "exported",
+  "created": "2026-07-17T09:40:09Z",
+  "updated": "2026-07-17T10:18:05Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "devague ships a resolve move for parked vagueness: a blocking park can now be resolved or reclassified through CLI moves alone, closing issues 45, 55, 57, and 60",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "the shipped release clears a decided blocking park via CLI moves alone \u2014 issue 57's repro converges with zero .devague JSON edits",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "on the shipped build run issue 57's repro: park a blocking unknown, capture the decision, park --resolve it, converge passes, export succeeds \u2014 no file edits"
+    },
+    {
+      "id": "c2",
+      "kind": "requirement",
+      "text": "the Vagueness dataclass (devague/frame.py:106) gains resolution state \u2014 e.g. a resolved flag plus resolution text \u2014 kept in frame state for the evidence trail rather than deleted; add_vagueness today only appends and set_status (frame.py:226) routes only claim and honesty ids, so v-ids are unaddressable by any move",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "a resolved Vagueness keeps its text, kind, and claim_id plus the resolution on the record, and round-trips save-load identical",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "extend Vagueness with resolved: bool = False and resolution: str = \"\"; round-trip tests in tests/test_frame.py and tests/test_store.py"
+    },
+    {
+      "id": "c3",
+      "kind": "requirement",
+      "text": "the convergence gate (devague/convergence.py:100-102) stops counting a resolved vagueness as a blocker, and suggest_move (convergence.py:188) names an actually executable move instead of today's 're-park it as non-blocking' hint, which only appends a second item while the first keeps blocking \u2014 the acceptance bar issue 45 sets explicitly",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "after park --resolve, converge no longer lists the item as a blocker and the blocking-vagueness hint names park --resolve verbatim \u2014 an executable move, issue 45's acceptance bar",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "in _missing_open_uncertainty skip resolved items; rewrite the suggest_move blocking-vagueness branch (convergence.py:188) to emit the park --resolve syntax; tests in tests/test_convergence.py"
+    },
+    {
+      "id": "c4",
+      "kind": "requirement",
+      "text": "a new user-only resolve surface for v-ids that mirrors the existing `question --resolve <qid> --decision \"<text>\"` shape (devague/cli/_commands/question.py) \u2014 resolving is a user decision like confirm (issue 55), validated fail-closed with a hint on an unknown v-id, with stdout result, --json, and the existing exit-code contract",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "an unknown v-id is refused with a hint and nothing is persisted; output follows the existing stdout/--json/exit-code contract; resolving stays a user-decided move like confirm",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [
+        {
+          "id": "q1",
+          "text": "what does park --resolve do on an already-resolved v-id \u2014 refuse with a hint, or no-op idempotently? (decide in the plan; either is defensible, silence is not)",
+          "resolved": false,
+          "blocking": false
+        }
+      ],
+      "links": [],
+      "instruction": "add --resolve VID and --decision to park's argparse in cli/_commands/park.py; unknown id raises DevagueError with a 'run devague show' hint; CLI tests in tests/test_cli_moves.py"
+    },
+    {
+      "id": "c5",
+      "kind": "requirement",
+      "text": "SCHEMA_VERSION bumps 2 to 3 (devague/frame.py:15) because adding fields to Vagueness breaks old loaders \u2014 from_dict does Vagueness(**v) (frame.py:284), so an old CLI reading a new frame raises TypeError; the documented fail-closed policy and the v2 scope_entries precedent both say bump; docs/spec-contract.md's Vagueness entity section gains the resolved state",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "a v3 frame on a v2-only binary fails closed with the schema_version error, never a Vagueness(**v) TypeError; v2 frames without the new fields still load with defaults",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "bump SCHEMA_VERSION to 3 in devague/frame.py; from_dict defaults resolved/resolution for old artifacts; fail-closed + back-compat tests in tests/test_store.py and tests/test_frame_schema_v2.py's pattern"
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "renderers keep a resolved vagueness on the record as provenance instead of dropping it \u2014 render/frame_md.py:56-60 lists every open_vagueness item flat, and render/spec_md.py:111 routes only follow_up/out_of_scope kinds into the spec; a resolved item should render with its resolution text so the exported spec shows the answered unknown (the provenance issue 45's comment asks for)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "an exported spec from a frame with a resolved blocking park renders the unknown together with its resolution text, and the export passes markdownlint",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "render resolved items with their resolution in render/frame_md.py and render/spec_md.py; golden updates in tests/goldens plus the markdownlint integration test"
+    },
+    {
+      "id": "c7",
+      "kind": "requirement",
+      "text": "every surface that teaches park also teaches the resolve close-out: devague/cli/_commands/learn.py (move table line 26, operating rules line 107), docs/llm-guidance.md (park rows in the fabrication table, lines 109-130), and .claude/skills/think/SKILL.md (move table line 82, rules lines 209-210) \u2014 otherwise operators keep learning the trap issues 45/55/57/60 all fell into",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "learn, docs/llm-guidance.md, and the think skill each name park --resolve wherever they teach park; issue 57's prefer-question workaround guidance is retired",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "sweep learn.py (move table + operating rules), docs/llm-guidance.md park rows, and .claude/skills/think/SKILL.md move table and rules; teaching tests in tests/test_cli_learn.py"
+    },
+    {
+      "id": "c8",
+      "kind": "non_goal",
+      "text": "no task-text or claim-text edit verb ships in this fix: issue 60's plan-side half is already shipped as `devague plan amend` (0.18.0, issue 68 \u2014 edits a task summary and acceptance criteria, flips confirmed back to proposed), and its floated `devague edit <cN> --text` frame-claim parity is a separate feature, not part of the shared vagueness-resolve gap",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c9",
+      "kind": "boundary",
+      "text": "the resolve move is deterministic recording only \u2014 no LLM calls in the CLI (issue 20), and hand-editing .devague state stays forbidden; the fix removes the last reason operators had to hand-edit (the workaround all four issues document), it does not legitimize state edits",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "the diff adds no LLM call and no subprocess to the CLI; resolution text is authored by the user/operator, never generated in-CLI",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c10",
+      "kind": "assumption",
+      "text": "the plan engine has the same gap: PlanRisk (devague/plan.py:60) is append-only with no resolved field, blocking unknown_blocking risks (plan_convergence.py:136) and hinting a non-executable 're-record it as non-blocking' (plan_convergence.py:172) \u2014 none of the four issues reports it, but whichever resolve shape ships should at least not preclude the plan-side twin",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c11",
+      "kind": "decision",
+      "text": "user decision (q1, 2026-07-17): the resolve surface is `park --resolve <vN> [--decision \"<text>\"]` \u2014 extend the existing park verb, mirroring `question --resolve`; no new flat verb, no reject-on-v-ids",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c12",
+      "kind": "decision",
+      "text": "user decision (q2, 2026-07-17): the plan-side twin ships in the same PR \u2014 `plan risk --resolve <rN>` gains the same close-out for blocking PlanRisks, keeping the engines structural peers",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "the plan engine ships the twin in the same PR: PlanRisk (devague/plan.py:60) gains the same resolution state, `plan risk --resolve <rN>` the same user-only surface, plan_convergence.py:136 skips resolved risks, the hint at plan_convergence.py:172 names the executable move, and PLAN_SCHEMA_VERSION bumps 2 to 3 (PlanRisk(**r) at plan.py:310 has the same old-loader crash shape as the frame side)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "plan converge drops a resolved blocking risk; the plan hint at plan_convergence.py:172 names plan risk --resolve verbatim; a v3 plan fails closed on a v2-only binary",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "mirror the frame-side change end to end: PlanRisk.resolved/resolution, plan risk --resolve RID --decision, plan_convergence skip + hint, PLAN_SCHEMA_VERSION 3; tests across tests/test_plan.py, test_plan_convergence.py, test_plan_store.py, test_cli_plan.py"
+    },
+    {
+      "id": "c14",
+      "kind": "audience",
+      "text": "operators driving /think and /spec-to-plan (the agents making CLI moves), the humans who own confirms, and the downstream AgentCulture repos that filed the four reports \u2014 colleague, lobes-cli, league-of-agents, and devague's own dogfooding",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h10",
+          "text": "devague learn output alone teaches the close-out (park --resolve and plan risk --resolve) \u2014 an operator never needs to read source to escape a decided blocking park",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c15",
+      "kind": "after_state",
+      "text": "a parked blocking unknown, once decided, is closed through `park --resolve` (frames) or `plan risk --resolve` (plans): the item stays on record with its resolution text, drops out of the convergence gate, the converge hints name executable moves, and no operator ever hand-edits .devague state again",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "no .devague hand-edit remains necessary anywhere in the vagueness lifecycle: park, decide, resolve, converge, export all work through moves",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c16",
+      "kind": "why_it_matters",
+      "text": "four independent reports in five weeks (issues 45, 55, 57, 60) show the method punishing correct behavior: honest parking leads to a permanently blocked frame, and the only escape is the exact out-of-band state mutation the move-driven design exists to prevent \u2014 one repo has the hand-edit in committed history (league-of-agents 0c71282)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "each of the four issues is closed with a comment naming the shipped release and the move that replaces its documented workaround",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c17",
+      "kind": "success_signal",
+      "text": "all 4 issues close against the shipped release; issue 57's repro script (park blocking, decide, resolve, converge) passes through moves alone with 0 hand-edits of .devague state; test coverage stays >= 95%",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "the stated numbers are verified before close: 4 issues closed, the repro converges with 0 hand-edits, coverage >= 95% in CI",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c18",
+      "kind": "requirement",
+      "text": "every secondary reader of open vagueness and plan risks handles resolved items consistently, not just the gate: _parked_items in convergence.py:151 and plan_convergence.py:141 (whose output feeds converge/status parked_items), and render/deliverables_md.py:72-81 (plan deliverables' surviving-open-items section, which reads frame.open_vagueness and plan risks directly) \u2014 a resolved item must stop being advertised as open everywhere, or status and deliverables contradict the spec",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h14",
+          "text": "with a resolved blocking item on a frame and a resolved blocking risk on a plan: converge/status parked_items and plan deliverables' open-items section show neither as open \u2014 verified by tests against those exact surfaces",
+          "status": "confirmed",
+          "instruction": ""
+        }
+      ],
+      "hard_questions": [],
+      "links": [],
+      "instruction": "filter (or annotate) resolved items in _parked_items of convergence.py and plan_convergence.py and in deliverables_md's open-items builder; tests in tests/test_convergence.py, test_plan_convergence.py, test_plan_deliverables.py"
+    },
+    {
+      "id": "c19",
+      "kind": "assumption",
+      "text": "reclassification ships as two executable moves \u2014 `park --resolve <vN>` closing the old item plus a fresh `park --kind <new-kind>` \u2014 not an in-place kind mutation; this satisfies issue 45's acceptance (the item stops blocking, stays on record) with cleaner provenance than editing kind in place, and issue 45 offered any-one-of-three shapes",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c20",
+      "kind": "non_goal",
+      "text": "no unresolve move ships: a mistakenly resolved vagueness is recovered by parking a fresh item (append is cheap and keeps provenance), not by reopening the resolved record \u2014 avoiding a second one-way-mutation surface in the same PR",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    },
+    {
+      "id": "c21",
+      "kind": "decision",
+      "text": "user decision (q3, 2026-07-17): `park --resolve <vN>` requires `--decision \"<text>\"` \u2014 a bare resolve is refused with a hint; an optional `--claim <cN>` links the deciding claim; the plan-side `plan risk --resolve` carries the same bar",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": [],
+      "instruction": ""
+    }
+  ],
+  "open_vagueness": [
+    {
+      "id": "v1",
+      "text": "rollout friction: stale installed devague binaries in downstream checkouts (colleague, lobes-cli, league-of-agents) will fail closed on v3 artifacts until upgraded \u2014 known operational cost, same shape as the v2 rollout's stale-PATH-binary reports; mitigation is the existing upgrade hint in the error",
+      "kind": "unknown_nonblocking",
+      "claim_id": null
+    }
+  ],
+  "scope_entries": [
+    {
+      "id": "s1",
+      "surface": "devague/frame.py (Vagueness model, set_status)",
+      "finding": "Vagueness has fields id/text/kind/claim_id only \u2014 no resolved state; add_vagueness appends with a fresh v-id; set_status routes only c*/h* ids, so no existing move can touch a v-id",
+      "seeds": [
+        "c2"
+      ]
+    },
+    {
+      "id": "s2",
+      "surface": "devague/convergence.py (gate + suggest_move)",
+      "finding": "only kind unknown_blocking blocks (lines 100-102); suggest_move line 188 recommends 'capture+confirm the answer, or re-park it as non-blocking' \u2014 neither branch can clear the blocker: capture+confirm never touches the v-item (confirmed live in issue 45's lobes-cli comment) and re-park appends a new id",
+      "seeds": [
+        "c3"
+      ]
+    },
+    {
+      "id": "s3",
+      "surface": "devague/cli/_commands/park.py + question.py + confirm.py",
+      "finding": "park is append-only (cmd_park calls frame.add_vagueness, no flags beyond --kind/--claim); question.py already ships the --resolve/--decision close-out pattern issues 45/57 ask to mirror; confirm.py shows the transactional validate-first, user-only convention the resolve move must follow",
+      "seeds": [
+        "c4"
+      ]
+    },
+    {
+      "id": "s4",
+      "surface": "docs/spec-contract.md (Vagueness entity, Versioning) + devague/frame.py:15,284",
+      "finding": "contract lists Vagueness as id/text/kind/claim_id with no resolved state; SCHEMA_VERSION comment says bump when the persisted shape changes incompatibly; Vagueness(**v) in from_dict means new fields crash old binaries \u2014 same shape as the v2 scope_entries bump",
+      "seeds": [
+        "c5"
+      ]
+    },
+    {
+      "id": "s5",
+      "surface": "devague/render/spec_md.py:111 + render/frame_md.py:56-60",
+      "finding": "frame_md renders all open_vagueness as flat '[kind] text' bullets; spec_md renders only follow_up/out_of_scope kinds \u2014 neither has a representation for a resolved item, so rendering is a real decision surface, not free",
+      "seeds": [
+        "c6"
+      ]
+    },
+    {
+      "id": "s6",
+      "surface": "devague/cli/_commands/learn.py + docs/llm-guidance.md + .claude/skills/think/SKILL.md",
+      "finding": "all three teach 'park it (blocking or non-blocking)' with no close-out loop; issue 57's interim guidance (prefer question / unknown_nonblocking) exists precisely because the taught path is one-way",
+      "seeds": [
+        "c7"
+      ]
+    },
+    {
+      "id": "s7",
+      "surface": "devague/cli/_commands/plan.py (amend, instruct, depend --remove)",
+      "finding": "plan amend exists since 0.18.0 (issue 68) with the demote-to-proposed echo (issue 67) \u2014 issue 60's second complaint (task text immutable after plan task) is already fixed; only its vagueness-resolve half remains live",
+      "seeds": [
+        "c8"
+      ]
+    },
+    {
+      "id": "s8",
+      "surface": "issue 20 (no-orchestration boundary) + the four issue reports",
+      "finding": "issues 45/55/57/60 each document hand-editing .devague/frames/*.json as the only escape \u2014 league-of-agents commit 0c71282 has it in committed history; the fix's job is to make the CLI's own contract satisfiable, keeping the deterministic boundary intact",
+      "seeds": [
+        "c9"
+      ]
+    },
+    {
+      "id": "s9",
+      "surface": "devague/plan.py:60 (PlanRisk) + devague/plan_convergence.py:136,172",
+      "finding": "PlanRisk mirrors Vagueness exactly (id/text/kind/task_id, append-only via add_risk, no resolve verb in cli/_commands/plan.py); a blocking plan risk today can only be cleared by covering it with a task \u2014 the reclassify/resolve gap is engine-wide, pending the q2 decision",
+      "seeds": [
+        "c10"
+      ]
+    },
+    {
+      "id": "s10",
+      "surface": "tests/ (test_frame.py, test_convergence.py, test_cli_moves.py, test_contract.py, test_store.py)",
+      "finding": "existing park/vagueness coverage lives across these five files; issue 45's acceptance criteria (gate stops listing the item, hint names an executable move, save-load round-trip, valid kinds only) map one-to-one onto them, so the fix lands test-first in the same map",
+      "seeds": [
+        "c2",
+        "c3",
+        "c5"
+      ]
+    },
+    {
+      "id": "s11",
+      "surface": "devague/plan.py:310 + PLAN_SCHEMA_VERSION (plan.py:30) + plan_store.py fail-closed gate",
+      "finding": "plan side round-trips risks via PlanRisk(**r) and fails closed on newer schema_version, exactly like the frame side \u2014 the twin fix needs its own 2-to-3 bump and mirrors every frame-side piece",
+      "seeds": [
+        "c13"
+      ]
+    },
+    {
+      "id": "s12",
+      "surface": "challenge pass / adjacent-systems lens: render/deliverables_md.py:72-81 + convergence.py:151 + plan_convergence.py:141",
+      "finding": "found two uncovered consumers of open_vagueness/risks beyond the gate and the two renderers the spec already covers: parked_items (status/converge output, both engines) and the deliverables surviving-open-items section \u2014 neither was named by any confirmed claim",
+      "seeds": [
+        "c18"
+      ]
+    },
+    {
+      "id": "s13",
+      "surface": "challenge pass / unstated-assumptions lens: issue 45's reclassify ask vs the c11 decision",
+      "finding": "the announcement says 'resolved or reclassified' but no confirmed claim states the reclassify path; c11 chose park --resolve with no --kind flag, so reclassify must be resolve+re-park \u2014 made this explicit as a proposed assumption instead of leaving it implied",
+      "seeds": [
+        "c19"
+      ]
+    },
+    {
+      "id": "s14",
+      "surface": "challenge pass / reversibility lens: the new resolve transition itself",
+      "finding": "resolve is one-way by design; recovery from a mistaken resolve exists through a fresh park, so no unresolve verb is needed \u2014 recorded as a proposed non-goal so the boundary is explicit",
+      "seeds": [
+        "c20"
+      ]
+    },
+    {
+      "id": "s15",
+      "surface": "challenge pass / counter-evidence lens: devague/store.py:119-146 fail-closed gate",
+      "finding": "verified by reading, not assumed: load raises IncompatibleSchemaError when schema_version exceeds the binary's, and save re-stamps the current version (the comment documents the exact silent-data-loss hazard the re-stamp prevents) \u2014 h5's claim holds on the frame side; plan_store mirrors it",
+      "seeds": [
+        "c5"
+      ]
+    },
+    {
+      "id": "s16",
+      "surface": "challenge pass / concurrency lens: devague/store.py + plan_store.py + delivery_store.py",
+      "finding": "clean pass \u2014 single-writer CLI, atomic-enough small-file writes, no locking today; resolve adds no new concurrent writer; residual risk only if two agents ever drive the same checkout, which is the standing store-wide posture, not new exposure from this change",
+      "seeds": []
+    },
+    {
+      "id": "s17",
+      "surface": "challenge pass / operations lens: mixed-version rollout across downstream repos",
+      "finding": "the v2 rollout already produced stale-binary friction reports; v3 repeats that cost by design (fail-closed beats silent data loss) \u2014 parked as residual, non-blocking, with the mitigation being the error's own upgrade hint",
+      "seeds": []
+    }
+  ]
+}

--- a/.devague/plans/resolve-parked-vagueness.json
+++ b/.devague/plans/resolve-parked-vagueness.json
@@ -1,0 +1,369 @@
+{
+  "slug": "resolve-parked-vagueness",
+  "title": "resolve parked vagueness",
+  "frame_slug": "resolve-parked-vagueness",
+  "schema_version": 2,
+  "status": "exported",
+  "created": "2026-07-17T10:18:49Z",
+  "updated": "2026-07-17T10:26:48Z",
+  "targets": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "devague ships a resolve move for parked vagueness: a blocking park can now be resolved or reclassified through CLI moves alone, closing issues 45, 55, 57, and 60"
+    },
+    {
+      "id": "h1",
+      "kind": "honesty",
+      "text": "the shipped release clears a decided blocking park via CLI moves alone \u2014 issue 57's repro converges with zero .devague JSON edits"
+    },
+    {
+      "id": "c2",
+      "kind": "requirement",
+      "text": "the Vagueness dataclass (devague/frame.py:106) gains resolution state \u2014 e.g. a resolved flag plus resolution text \u2014 kept in frame state for the evidence trail rather than deleted; add_vagueness today only appends and set_status (frame.py:226) routes only claim and honesty ids, so v-ids are unaddressable by any move"
+    },
+    {
+      "id": "h2",
+      "kind": "honesty",
+      "text": "a resolved Vagueness keeps its text, kind, and claim_id plus the resolution on the record, and round-trips save-load identical"
+    },
+    {
+      "id": "c3",
+      "kind": "requirement",
+      "text": "the convergence gate (devague/convergence.py:100-102) stops counting a resolved vagueness as a blocker, and suggest_move (convergence.py:188) names an actually executable move instead of today's 're-park it as non-blocking' hint, which only appends a second item while the first keeps blocking \u2014 the acceptance bar issue 45 sets explicitly"
+    },
+    {
+      "id": "h3",
+      "kind": "honesty",
+      "text": "after park --resolve, converge no longer lists the item as a blocker and the blocking-vagueness hint names park --resolve verbatim \u2014 an executable move, issue 45's acceptance bar"
+    },
+    {
+      "id": "c4",
+      "kind": "requirement",
+      "text": "a new user-only resolve surface for v-ids that mirrors the existing `question --resolve <qid> --decision \"<text>\"` shape (devague/cli/_commands/question.py) \u2014 resolving is a user decision like confirm (issue 55), validated fail-closed with a hint on an unknown v-id, with stdout result, --json, and the existing exit-code contract"
+    },
+    {
+      "id": "h4",
+      "kind": "honesty",
+      "text": "an unknown v-id is refused with a hint and nothing is persisted; output follows the existing stdout/--json/exit-code contract; resolving stays a user-decided move like confirm"
+    },
+    {
+      "id": "c5",
+      "kind": "requirement",
+      "text": "SCHEMA_VERSION bumps 2 to 3 (devague/frame.py:15) because adding fields to Vagueness breaks old loaders \u2014 from_dict does Vagueness(**v) (frame.py:284), so an old CLI reading a new frame raises TypeError; the documented fail-closed policy and the v2 scope_entries precedent both say bump; docs/spec-contract.md's Vagueness entity section gains the resolved state"
+    },
+    {
+      "id": "h5",
+      "kind": "honesty",
+      "text": "a v3 frame on a v2-only binary fails closed with the schema_version error, never a Vagueness(**v) TypeError; v2 frames without the new fields still load with defaults"
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "renderers keep a resolved vagueness on the record as provenance instead of dropping it \u2014 render/frame_md.py:56-60 lists every open_vagueness item flat, and render/spec_md.py:111 routes only follow_up/out_of_scope kinds into the spec; a resolved item should render with its resolution text so the exported spec shows the answered unknown (the provenance issue 45's comment asks for)"
+    },
+    {
+      "id": "h6",
+      "kind": "honesty",
+      "text": "an exported spec from a frame with a resolved blocking park renders the unknown together with its resolution text, and the export passes markdownlint"
+    },
+    {
+      "id": "c7",
+      "kind": "requirement",
+      "text": "every surface that teaches park also teaches the resolve close-out: devague/cli/_commands/learn.py (move table line 26, operating rules line 107), docs/llm-guidance.md (park rows in the fabrication table, lines 109-130), and .claude/skills/think/SKILL.md (move table line 82, rules lines 209-210) \u2014 otherwise operators keep learning the trap issues 45/55/57/60 all fell into"
+    },
+    {
+      "id": "h7",
+      "kind": "honesty",
+      "text": "learn, docs/llm-guidance.md, and the think skill each name park --resolve wherever they teach park; issue 57's prefer-question workaround guidance is retired"
+    },
+    {
+      "id": "c9",
+      "kind": "boundary",
+      "text": "the resolve move is deterministic recording only \u2014 no LLM calls in the CLI (issue 20), and hand-editing .devague state stays forbidden; the fix removes the last reason operators had to hand-edit (the workaround all four issues document), it does not legitimize state edits"
+    },
+    {
+      "id": "h8",
+      "kind": "honesty",
+      "text": "the diff adds no LLM call and no subprocess to the CLI; resolution text is authored by the user/operator, never generated in-CLI"
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "the plan engine ships the twin in the same PR: PlanRisk (devague/plan.py:60) gains the same resolution state, `plan risk --resolve <rN>` the same user-only surface, plan_convergence.py:136 skips resolved risks, the hint at plan_convergence.py:172 names the executable move, and PLAN_SCHEMA_VERSION bumps 2 to 3 (PlanRisk(**r) at plan.py:310 has the same old-loader crash shape as the frame side)"
+    },
+    {
+      "id": "h9",
+      "kind": "honesty",
+      "text": "plan converge drops a resolved blocking risk; the plan hint at plan_convergence.py:172 names plan risk --resolve verbatim; a v3 plan fails closed on a v2-only binary"
+    },
+    {
+      "id": "c14",
+      "kind": "audience",
+      "text": "operators driving /think and /spec-to-plan (the agents making CLI moves), the humans who own confirms, and the downstream AgentCulture repos that filed the four reports \u2014 colleague, lobes-cli, league-of-agents, and devague's own dogfooding"
+    },
+    {
+      "id": "h10",
+      "kind": "honesty",
+      "text": "devague learn output alone teaches the close-out (park --resolve and plan risk --resolve) \u2014 an operator never needs to read source to escape a decided blocking park"
+    },
+    {
+      "id": "c15",
+      "kind": "after_state",
+      "text": "a parked blocking unknown, once decided, is closed through `park --resolve` (frames) or `plan risk --resolve` (plans): the item stays on record with its resolution text, drops out of the convergence gate, the converge hints name executable moves, and no operator ever hand-edits .devague state again"
+    },
+    {
+      "id": "h11",
+      "kind": "honesty",
+      "text": "no .devague hand-edit remains necessary anywhere in the vagueness lifecycle: park, decide, resolve, converge, export all work through moves"
+    },
+    {
+      "id": "c16",
+      "kind": "why_it_matters",
+      "text": "four independent reports in five weeks (issues 45, 55, 57, 60) show the method punishing correct behavior: honest parking leads to a permanently blocked frame, and the only escape is the exact out-of-band state mutation the move-driven design exists to prevent \u2014 one repo has the hand-edit in committed history (league-of-agents 0c71282)"
+    },
+    {
+      "id": "h12",
+      "kind": "honesty",
+      "text": "each of the four issues is closed with a comment naming the shipped release and the move that replaces its documented workaround"
+    },
+    {
+      "id": "c17",
+      "kind": "success_signal",
+      "text": "all 4 issues close against the shipped release; issue 57's repro script (park blocking, decide, resolve, converge) passes through moves alone with 0 hand-edits of .devague state; test coverage stays >= 95%"
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "the stated numbers are verified before close: 4 issues closed, the repro converges with 0 hand-edits, coverage >= 95% in CI"
+    },
+    {
+      "id": "c18",
+      "kind": "requirement",
+      "text": "every secondary reader of open vagueness and plan risks handles resolved items consistently, not just the gate: _parked_items in convergence.py:151 and plan_convergence.py:141 (whose output feeds converge/status parked_items), and render/deliverables_md.py:72-81 (plan deliverables' surviving-open-items section, which reads frame.open_vagueness and plan risks directly) \u2014 a resolved item must stop being advertised as open everywhere, or status and deliverables contradict the spec"
+    },
+    {
+      "id": "h14",
+      "kind": "honesty",
+      "text": "with a resolved blocking item on a frame and a resolved blocking risk on a plan: converge/status parked_items and plan deliverables' open-items section show neither as open \u2014 verified by tests against those exact surfaces"
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "Frame-side model: Vagueness resolution state + schema v3",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "Vagueness gains resolved: bool = False and resolution: str = '' with id/text/kind/claim_id unchanged; Frame.resolve_vagueness(vid, resolution) marks it resolved and raises ValueError on an unknown or already-resolved id",
+        "SCHEMA_VERSION == 3; a v2 frame JSON without the new keys loads with defaults; save-load round-trips a resolved item identical (tests/test_frame.py, tests/test_store.py)",
+        "store.load still fails closed with the upgrade hint when schema_version exceeds 3"
+      ],
+      "deps": [],
+      "covers": [
+        "c2",
+        "h2",
+        "c5",
+        "h5"
+      ],
+      "instruction": "extend Vagueness in devague/frame.py with resolved: bool = False and resolution: str = ''; add Frame.resolve_vagueness(vid: str, resolution: str); bump SCHEMA_VERSION to 3; default the new keys in from_dict for v2 artifacts; keep set_status untouched \u2014 v-ids stay out of confirm/reject per decision c11; field names are pinned (resolved, resolution) \u2014 t2 and t7 read them verbatim"
+    },
+    {
+      "id": "t2",
+      "summary": "Plan-side model: PlanRisk resolution state + plan schema v3",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "PlanRisk gains resolved: bool = False and resolution: str = '' with id/text/kind/task_id unchanged; Plan.resolve_risk(rid, resolution) mirrors the frame-side error contract (ValueError on unknown or already-resolved)",
+        "PLAN_SCHEMA_VERSION == 3; a v2 plan JSON loads with defaults; save-load round-trips a resolved risk identical (tests/test_plan.py, tests/test_plan_store.py)"
+      ],
+      "deps": [],
+      "covers": [
+        "c13",
+        "h9"
+      ],
+      "instruction": "mirror t1 exactly in devague/plan.py: PlanRisk.resolved/resolution, Plan.resolve_risk, PLAN_SCHEMA_VERSION = 3, from_dict defaults for v2 artifacts; field names must match t1 verbatim (resolved, resolution) \u2014 deliverables_md reads both models"
+    },
+    {
+      "id": "t3",
+      "summary": "Frame gate: skip resolved vagueness, executable hint, parked_items",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "_missing_open_uncertainty skips resolved items: a resolved unknown_blocking no longer appears in blockers (tests/test_convergence.py)",
+        "suggest_move for a blocking-vagueness blocker names the executable syntax verbatim: park --resolve VID --decision TEXT",
+        "_parked_items excludes resolved items, so converge/status parked_items stops advertising a closed item as open"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c3",
+        "h3",
+        "c18",
+        "h14"
+      ],
+      "instruction": "in devague/convergence.py: filter v.resolved in _missing_open_uncertainty and _parked_items; rewrite the blocking-vagueness branch of suggest_move (line 188) to emit the park --resolve move; plain CLI text, stdout only \u2014 renderer changes are t7, not here"
+    },
+    {
+      "id": "t4",
+      "summary": "Plan gate: skip resolved risks, executable hint, parked_items",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "a resolved unknown_blocking risk no longer blocks plan convergence (tests/test_plan_convergence.py)",
+        "the blocking-risk hint at plan_convergence.py:172 names the executable syntax verbatim: plan risk --resolve RID --decision TEXT",
+        "plan-side _parked_items excludes resolved risks"
+      ],
+      "deps": [
+        "t2"
+      ],
+      "covers": [
+        "c13",
+        "h9",
+        "c18",
+        "h14"
+      ],
+      "instruction": "mirror t3 in devague/plan_convergence.py: filter r.resolved in _missing_risks and _parked_items; rewrite the blocking-risk hint branch to emit the plan risk --resolve move"
+    },
+    {
+      "id": "t5",
+      "summary": "CLI: park --resolve VID --decision TEXT",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "park --resolve VID --decision TEXT marks the item resolved, echoes the transition on stdout, and has --json parity",
+        "a bare park --resolve VID without --decision is refused with a hint and persists nothing (decision c21); unknown and already-resolved ids are refused with a hint, exit 1 (answers the frame hard question: refuse, not no-op)",
+        "--claim CN links the deciding claim and an unknown claim id is refused; passing positional text together with --resolve is refused; the park-create path is unchanged (tests/test_cli_moves.py)"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c4",
+        "h4"
+      ],
+      "instruction": "in devague/cli/_commands/park.py make the positional text optional (nargs='?') the way question.py does; add --resolve VID, --decision TEXT, --claim CN; require --decision whenever --resolve is passed; route through Frame.resolve_vagueness and translate ValueError into DevagueError with a run-devague-show hint; fail-closed refusal for already-resolved ids, consistent with the store posture"
+    },
+    {
+      "id": "t6",
+      "summary": "CLI: plan risk --resolve RID --decision TEXT",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "plan risk --resolve RID --decision TEXT resolves the risk with stdout echo and --json parity; bare resolve without --decision refused; unknown and already-resolved ids refused with hint, exit 1 (tests/test_cli_plan.py)",
+        "the risk-create path (positional text --kind K --task TN) is unchanged"
+      ],
+      "deps": [
+        "t2"
+      ],
+      "covers": [
+        "c13",
+        "h9"
+      ],
+      "instruction": "mirror t5 on the risk subcommand in devague/cli/_commands/plan.py: positional text becomes optional, add --resolve RID and --decision TEXT with the same refusal semantics; no --claim analog (risks link tasks via --task); route through Plan.resolve_risk"
+    },
+    {
+      "id": "t7",
+      "summary": "Renderers: resolved items render with resolution; deliverables excludes them",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "frame_md and spec_md render a resolved item with its resolution text verbatim; an exported spec from a frame with a resolved blocking park passes markdownlint (integration test + goldens)",
+        "deliverables_md surviving-open-items excludes resolved frame vagueness and resolved plan risks (tests/test_plan_deliverables.py)"
+      ],
+      "deps": [
+        "t1",
+        "t2"
+      ],
+      "covers": [
+        "c6",
+        "h6",
+        "c18",
+        "h14"
+      ],
+      "instruction": "frame_md: keep the flat Open vagueness list for open items and render resolved ones as '- [kind] text \u2014 resolved: TEXT'; spec_md: render resolved items of any kind with their resolution under the existing structure (a Resolved vagueness subsection is acceptable); deliverables_md: filter on the resolved flag from both models; update tests/goldens accordingly"
+    },
+    {
+      "id": "t8",
+      "summary": "Teaching + contract docs sweep: the close-out loop everywhere park is taught",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "devague learn and devague plan learn name park --resolve / plan risk --resolve wherever park/risk are taught (tests/test_cli_learn.py asserts the strings)",
+        "docs/spec-contract.md documents resolved/resolution on Vagueness and PlanRisk, the resolve move rows, and schema_version 3 for both engines",
+        "docs/llm-guidance.md and .claude/skills/think/SKILL.md teach the close-out loop; the taught prefer-question workaround framing is retired"
+      ],
+      "deps": [
+        "t5",
+        "t6"
+      ],
+      "covers": [
+        "c7",
+        "h7",
+        "c14",
+        "h10",
+        "c5"
+      ],
+      "instruction": "sweep devague/cli/_commands/learn.py (move table + operating rules), docs/llm-guidance.md park rows, .claude/skills/think/SKILL.md move table and rules, and docs/spec-contract.md (entities, move tables, Versioning); match the exact flag names t5/t6 shipped; markdownlint everything touched"
+    },
+    {
+      "id": "t9",
+      "summary": "E2E repro + quality gates: issue 57 lifecycle through the real CLI, both engines",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "a new e2e test drives the installed entry point through issue 57's repro: park blocking, capture the decision claim, park --resolve with --decision and --claim, converge passes, export succeeds \u2014 zero direct edits of .devague files; a plan-side twin e2e does the same through plan risk --resolve",
+        "coverage stays at 95 percent or higher; flake8, black, isort, bandit all clean",
+        "the resolve code paths add no LLM call and no subprocess usage inside the devague package (boundary h8) \u2014 asserted by inspection of the diff, not assumed"
+      ],
+      "deps": [
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7"
+      ],
+      "covers": [
+        "c1",
+        "h1",
+        "c15",
+        "h11",
+        "c9",
+        "h8",
+        "c17",
+        "h13"
+      ],
+      "instruction": "new tests/test_e2e_resolve.py exercising devague.cli main() end to end for both engines; keep it hermetic in tmp_path working dirs; verify the exported spec passes the existing markdownlint integration harness"
+    },
+    {
+      "id": "t10",
+      "summary": "Release + close-out: 0.20.0, CHANGELOG, PR, close the four issues",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "pyproject.toml bumps 0.19.1 to 0.20.0 with a prepended CHANGELOG.md entry naming issues 45, 55, 57, 60; CI version-check passes",
+        "after merge, each of issues 45, 55, 57, 60 is closed with a comment naming the shipped release and the move that replaces its documented workaround, signed per convention"
+      ],
+      "deps": [
+        "t8",
+        "t9"
+      ],
+      "covers": [
+        "c16",
+        "h12",
+        "c17",
+        "h13"
+      ],
+      "instruction": "minor bump (new CLI surface); PR via the cicd skill / agex pr open, linking the spec and plan artifacts; issue-close comments quote the exact replacing move per issue (park --resolve for 45/55/57; both moves plus the existing plan amend pointer for 60)"
+    }
+  ],
+  "risks": [
+    {
+      "id": "r1",
+      "text": "the updated think skill reaches downstream mesh repos only on guildmaster's next re-broadcast sync \u2014 until then vendored copies still teach the one-way park; known cadence cost, not a blocker",
+      "kind": "follow_up",
+      "task_id": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-07-17
+
+### Added
+
+- **`devague park --resolve <vN> --decision "<text>" [--claim <cN>]`** — the
+  close-out for parked vagueness (#45, #55, #57, #60). A decided blocking park
+  now resolves through a CLI move: the item stays on the record with its
+  resolution text (and optionally the deciding claim via a new
+  `resolution_claim_id`), drops out of the convergence gate, and renders under
+  a `## Resolved vagueness` section in exported specs. A bare `--resolve`
+  without `--decision` is refused (evidence-bearing close-out); unknown and
+  already-resolved ids are refused fail-closed.
+- **`devague plan risk --resolve <rN> --decision "<text>"`** — the plan-side
+  twin: a resolved blocking risk stops blocking `plan converge`, stays on the
+  record, and drops out of open-item listings (`plan deliverables`,
+  `parked_items`).
+
+### Changed
+
+- Frame `SCHEMA_VERSION` and `PLAN_SCHEMA_VERSION` bump 2 → 3 (the new
+  `Vagueness.resolved`/`.resolution`/`.resolution_claim_id` and
+  `PlanRisk.resolved`/`.resolution` fields); older binaries fail closed on v3
+  artifacts with the existing upgrade hint, and v2 artifacts load with
+  defaults.
+- The blocking-vagueness and blocking-risk convergence hints now name the
+  executable resolve move (previously they recommended "re-park it as
+  non-blocking", which only ever appended a second item — #45's acceptance
+  bar).
+- Teaching surfaces (`devague learn`, `docs/llm-guidance.md`, the `/think`
+  skill, `docs/spec-contract.md`) teach the resolve close-out wherever park
+  is taught.
+
 ## [0.19.1] - 2026-07-15
 
 ### Fixed

--- a/devague/cli/_commands/learn.py
+++ b/devague/cli/_commands/learn.py
@@ -23,7 +23,10 @@ MOVES = {
         "human review (read-only)."
     ),
     "question": "Record, list, or resolve a pending user decision (durable working state).",
-    "park": "Move uncertainty into first-class open vagueness instead of forcing an answer.",
+    "park": (
+        "Move uncertainty into first-class open vagueness instead of forcing an "
+        "answer, or close a decided one with 'park --resolve VID --decision TEXT'."
+    ),
     "converge": "Check whether the frame is solid enough to export a spec.",
     "export": "Write the buildable spec — only once the frame converges.",
     "status": "Report where the frame stands + the recommended next move (read-only).",
@@ -105,7 +108,10 @@ OPERATING_RULES = (
     "Honesty conditions route through the user — propose freely with "
     "'interrogate --honesty'; the user owns whether each one holds.",
     "Park real unknowns instead of papering over them — 'park' a genuine "
-    "unknown rather than writing confident prose that hides the gap.",
+    "unknown rather than writing confident prose that hides the gap. Once it's "
+    "decided, close it out with 'park --resolve VID --decision TEXT' instead of "
+    "leaving it parked or hand-editing state — the item stays on record with "
+    "its resolution and drops out of the gate.",
     "Converge, don't vibe — 'export' is gated on 'converge'; resolve every "
     "listed gap instead of declaring readiness on a hunch.",
     "Order is adaptive — the ten stages are an artifact shape, not a mandatory "

--- a/devague/cli/_commands/park.py
+++ b/devague/cli/_commands/park.py
@@ -1,17 +1,38 @@
-"""``devague park`` — move uncertainty into first-class open vagueness."""
+"""``devague park`` — move uncertainty into first-class open vagueness, and
+resolve it later without routing it through confirm/reject.
+
+Two mutually exclusive paths share one parser (mirrors ``question.py``):
+parking new vagueness (positional ``text`` + ``--kind``) and resolving a
+previously parked item (``--resolve VID --decision TEXT``, optionally
+``--claim CN`` to link the deciding claim). ``--resolve`` fails closed on an
+unknown id, an already-resolved id, and an unknown ``--claim`` id — never a
+silent no-op (issue #57, decision c21).
+"""
 
 from __future__ import annotations
 
 import argparse
 
 from devague import store
+from devague.cli._errors import EXIT_USER_ERROR, DevagueError
 from devague.cli._frames import resolve
 from devague.cli._output import emit_result
 from devague.frame import VAGUENESS_KINDS
 
 
-def cmd_park(args: argparse.Namespace) -> int:
-    frame = resolve(args.frame)
+def _create(args: argparse.Namespace, frame) -> int:
+    if not args.text:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "no text to park",
+            "pass vagueness text, or --resolve VID --decision TEXT to resolve an existing one",
+        )
+    if not args.kind:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "--kind is required to park new vagueness",
+            f"choose one of: {', '.join(VAGUENESS_KINDS)}",
+        )
     v = frame.add_vagueness(args.text, args.kind, claim_id=args.claim)
     store.save(frame)
     if getattr(args, "json", False):
@@ -21,11 +42,63 @@ def cmd_park(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_vagueness(args: argparse.Namespace, frame) -> int:
+    if args.text:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "pass positional text or --resolve, not both",
+            "drop the positional text when resolving an existing id",
+        )
+    if not args.decision:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "--resolve requires --decision",
+            'pass --decision "<text>" with the resolving decision',
+        )
+    try:
+        v = frame.resolve_vagueness(args.resolve, args.decision, claim_id=args.claim)
+    except ValueError as err:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            str(err),
+            "run 'devague show' to see current vagueness ids and claim ids",
+        ) from err
+    store.save(frame)
+    if getattr(args, "json", False):
+        emit_result(
+            {
+                "id": v.id,
+                "resolved": True,
+                "resolution": v.resolution,
+                "resolution_claim_id": v.resolution_claim_id,
+            },
+            json_mode=True,
+        )
+    else:
+        emit_result(f"{v.id} -> resolved", json_mode=False)
+    return 0
+
+
+def cmd_park(args: argparse.Namespace) -> int:
+    frame = resolve(args.frame)
+    if args.resolve:
+        return _resolve_vagueness(args, frame)
+    return _create(args, frame)
+
+
 def register(sub: argparse._SubParsersAction) -> None:
     p = sub.add_parser("park", help="Record open vagueness instead of forcing an answer.")
-    p.add_argument("text", help="The uncertainty.")
-    p.add_argument("--kind", required=True, choices=VAGUENESS_KINDS, help="Vagueness kind.")
-    p.add_argument("--claim", help="Link to a claim id.")
+    p.add_argument("text", nargs="?", help="The uncertainty (omit when using --resolve).")
+    p.add_argument(
+        "--kind", choices=VAGUENESS_KINDS, help="Vagueness kind (required to park new vagueness)."
+    )
+    p.add_argument(
+        "--claim",
+        help="Link to a claim id: the owning claim when parking, "
+        "the deciding claim when --resolve.",
+    )
+    p.add_argument("--resolve", metavar="VID", help="Mark a parked vagueness id resolved.")
+    p.add_argument("--decision", help="The resolution note recorded with --resolve.")
     p.add_argument("--frame", help="Frame slug (default: current).")
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     p.set_defaults(func=cmd_park)

--- a/devague/cli/_commands/plan.py
+++ b/devague/cli/_commands/plan.py
@@ -59,7 +59,10 @@ PLAN_MOVES = {
     "cover": "Mark a task as covering a coverage target (c*/h*).",
     "confirm": "Confirm a task (user-only — no fabricated rigor).",
     "reject": "Reject a task.",
-    "risk": "Record a first-class plan risk instead of papering over it.",
+    "risk": (
+        "Record a first-class plan risk instead of papering over it, "
+        "or --resolve RID --decision TEXT to close one out."
+    ),
     "converge": "Check whether the plan can export, against the live frame.",
     "export": "Write the buildable plan — only once the plan converges.",
     "waves": "Emit deterministic dependency waves (scheduling metadata, not orchestration).",
@@ -427,7 +430,24 @@ def cmd_plan_reject(args: argparse.Namespace) -> int:
 
 
 def cmd_plan_risk(args: argparse.Namespace) -> int:
+    """Record a new plan risk, or (``--resolve RID --decision TEXT``) close one
+    out — mirrors ``park --resolve`` (t5) on the risk subcommand.
+
+    ``--kind`` is optional at the parser level (so a bare ``--resolve`` call
+    does not need it), but the create path still requires it — refused here,
+    in the handler, rather than by argparse. The create path (positional text
+    + ``--kind`` + optional ``--task``) is otherwise unchanged.
+    """
     plan = resolve_plan(args.plan)
+    if args.resolve:
+        return _cmd_plan_risk_resolve(args, plan)
+    if not args.text or not args.kind:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "text and --kind are required to record a new risk",
+            'pass "<risk text>" --kind <kind>, or --resolve RID --decision "<text>" to '
+            "resolve an existing risk",
+        )
     if args.task is not None:
         _require_task(plan, args.task)
     risk = plan.add_risk(args.text, args.kind, task_id=args.task)
@@ -436,6 +456,37 @@ def cmd_plan_risk(args: argparse.Namespace) -> int:
         emit_result({"id": risk.id, "kind": risk.kind, "task": risk.task_id}, json_mode=True)
     else:
         emit_result(f"recorded risk {risk.id} ({risk.kind})", json_mode=False)
+    return 0
+
+
+def _cmd_plan_risk_resolve(args: argparse.Namespace, plan: Plan) -> int:
+    """``plan risk --resolve RID --decision TEXT`` — close out a risk without
+    routing it through confirm/reject (the plan-side twin of ``park --resolve``, t5).
+
+    Fail-closed, same contract as :meth:`Plan.resolve_risk`: a bare ``--resolve``
+    without ``--decision`` persists nothing; an unknown id is refused; an
+    already-resolved id is refused rather than silently no-op'd.
+    """
+    if not args.decision:
+        raise DevagueError(
+            EXIT_USER_ERROR,
+            "--decision is required to resolve a risk",
+            f'pass --decision "<text>" describing the resolution for {args.resolve}',
+        )
+    try:
+        risk = plan.resolve_risk(args.resolve, args.decision)
+    except ValueError as exc:
+        raise DevagueError(
+            EXIT_USER_ERROR, str(exc), "run 'devague plan show' to see current risks"
+        ) from exc
+    plan_store.save(plan)
+    if getattr(args, "json", False):
+        emit_result(
+            {"id": risk.id, "resolved": risk.resolved, "resolution": risk.resolution},
+            json_mode=True,
+        )
+    else:
+        emit_result(f"{risk.id} -> resolved ({risk.resolution})", json_mode=False)
     return 0
 
 
@@ -783,10 +834,14 @@ def register(sub: argparse._SubParsersAction) -> None:
     _plan_opt(prj)
     prj.set_defaults(func=cmd_plan_reject)
 
-    prk = psub.add_parser("risk", help="Record a first-class plan risk.")
-    prk.add_argument("text", help="The risk.")
-    prk.add_argument("--kind", required=True, choices=RISK_KINDS, help="Risk kind.")
+    prk = psub.add_parser("risk", help="Record or resolve a first-class plan risk.")
+    prk.add_argument("text", nargs="?", help="The risk (required unless --resolve).")
+    prk.add_argument("--kind", choices=RISK_KINDS, help="Risk kind (required unless --resolve).")
     prk.add_argument("--task", help="Task id this risk attaches to (optional).")
+    prk.add_argument(
+        "--resolve", metavar="RID", help="Resolve an existing risk id instead of creating one."
+    )
+    prk.add_argument("--decision", help="The resolution text recorded with --resolve.")
     _plan_opt(prk)
     prk.set_defaults(func=cmd_plan_risk)
 

--- a/devague/convergence.py
+++ b/devague/convergence.py
@@ -95,11 +95,18 @@ def _missing_claim_resolution(frame: Frame, confirmed: list) -> list[str]:
 
 
 def _missing_open_uncertainty(frame: Frame) -> list[str]:
-    """No blocking vagueness or unresolved blocking hard question remains."""
+    """No blocking vagueness or unresolved blocking hard question remains.
+
+    A blocking vagueness that has been closed via ``Frame.resolve_vagueness``
+    (``v.resolved``) is no longer counted — it stays on record with its
+    resolution text, but it has already been resolved through the ``park
+    --resolve`` move, so it must not keep blocking convergence
+    (resolve-parked-vagueness t3, #45/#55/#57).
+    """
     missing = [
         f"blocking vagueness {v.id} unresolved"
         for v in frame.open_vagueness
-        if v.kind == "unknown_blocking"
+        if v.kind == "unknown_blocking" and not v.resolved
     ]
     missing += [
         f"blocking hard question {q.id} on {c.id} unresolved"
@@ -147,8 +154,17 @@ def _sharpness_warnings(frame: Frame, confirmed: list) -> list[str]:
 
 
 def _parked_items(frame: Frame) -> list[str]:
-    """Tracked, non-blocking open vagueness (everything but unknown_blocking)."""
-    return [f"[{v.kind}] {v.text}" for v in frame.open_vagueness if v.kind != "unknown_blocking"]
+    """Tracked, non-blocking open vagueness (everything but unknown_blocking).
+
+    A resolved item is closed, not open, so it drops out here too — otherwise
+    ``converge``/``status`` would keep advertising a decided item as a live
+    parked item (resolve-parked-vagueness t3).
+    """
+    return [
+        f"[{v.kind}] {v.text}"
+        for v in frame.open_vagueness
+        if v.kind != "unknown_blocking" and not v.resolved
+    ]
 
 
 def suggest_move(blocker: str) -> str:
@@ -185,7 +201,8 @@ def suggest_move(blocker: str) -> str:
         )
     m = re.search(r"blocking vagueness (v\d+)", blocker)
     if m:
-        return f"resolve {m.group(1)}: capture+confirm the answer, or re-park it as non-blocking"
+        vid = m.group(1)
+        return f'devague park --resolve {vid} --decision "<the decision>"'
     m = re.search(r"blocking hard question (q\d+) on (c\d+)", blocker)
     if m:
         return (

--- a/devague/frame.py
+++ b/devague/frame.py
@@ -12,7 +12,8 @@ from typing import Optional
 # Bump when the persisted shape changes incompatibly. `store.load` fails closed
 # on a frame whose schema_version is newer/unknown (see #5, honesty condition h15).
 # v2 (#53 t1) adds Frame.scope_entries and Claim/HonestyCondition.instruction.
-SCHEMA_VERSION = 2
+# v3 (resolve-parked-vagueness t1) adds Vagueness.resolved / Vagueness.resolution.
+SCHEMA_VERSION = 3
 
 CLAIM_KINDS = (
     "announcement",
@@ -108,6 +109,11 @@ class Vagueness:
     text: str
     kind: str
     claim_id: Optional[str] = None
+    # v2 frames predate these fields (resolve-parked-vagueness t1); default to
+    # "not yet resolved". Set only via Frame.resolve_vagueness — v-ids stay out
+    # of confirm/reject (decision c11), so set_status must not touch them.
+    resolved: bool = False
+    resolution: str = ""
 
     def __post_init__(self) -> None:
         if self.kind not in VAGUENESS_KINDS:
@@ -205,6 +211,25 @@ class Frame:
             claim_id=claim_id,
         )
         self.open_vagueness.append(v)
+        return v
+
+    def find_vagueness(self, vid: str) -> Optional[Vagueness]:
+        return next((v for v in self.open_vagueness if v.id == vid), None)
+
+    def resolve_vagueness(self, vid: str, resolution: str) -> Vagueness:
+        """Close out a parked item without routing it through confirm/reject.
+
+        v-ids stay out of set_status (decision c11) — this is the only mutator
+        for Vagueness.resolved/resolution. Fails closed on an unknown id and on
+        an already-resolved one, rather than silently no-op'ing (issue #57).
+        """
+        v = self.find_vagueness(vid)
+        if v is None:
+            raise ValueError(f"unknown vagueness id: {vid!r}")
+        if v.resolved:
+            raise ValueError(f"vagueness {vid!r} is already resolved")
+        v.resolved = True
+        v.resolution = resolution
         return v
 
     def add_scope_entry(

--- a/devague/frame.py
+++ b/devague/frame.py
@@ -114,6 +114,10 @@ class Vagueness:
     # of confirm/reject (decision c11), so set_status must not touch them.
     resolved: bool = False
     resolution: str = ""
+    # v2/early-v3 frames predate this field (resolve-parked-vagueness t5); the
+    # *deciding* claim recorded at resolve time — distinct from claim_id, the
+    # *owning* claim set at park time, which resolve_vagueness never touches.
+    resolution_claim_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.kind not in VAGUENESS_KINDS:
@@ -216,20 +220,29 @@ class Frame:
     def find_vagueness(self, vid: str) -> Optional[Vagueness]:
         return next((v for v in self.open_vagueness if v.id == vid), None)
 
-    def resolve_vagueness(self, vid: str, resolution: str) -> Vagueness:
+    def resolve_vagueness(
+        self, vid: str, resolution: str, claim_id: Optional[str] = None
+    ) -> Vagueness:
         """Close out a parked item without routing it through confirm/reject.
 
         v-ids stay out of set_status (decision c11) — this is the only mutator
         for Vagueness.resolved/resolution. Fails closed on an unknown id and on
         an already-resolved one, rather than silently no-op'ing (issue #57).
+        ``claim_id``, if given, must name an existing claim (validated here,
+        the same seam as :meth:`add_scope_entry`'s seed-id check) and is
+        recorded as ``resolution_claim_id`` — the *deciding* claim, which
+        never overwrites ``claim_id``, the *owning* claim set at park time.
         """
         v = self.find_vagueness(vid)
         if v is None:
             raise ValueError(f"unknown vagueness id: {vid!r}")
         if v.resolved:
             raise ValueError(f"vagueness {vid!r} is already resolved")
+        if claim_id is not None and self.find_claim(claim_id) is None:
+            raise ValueError(f"unknown claim id: {claim_id!r}")
         v.resolved = True
         v.resolution = resolution
+        v.resolution_claim_id = claim_id
         return v
 
     def add_scope_entry(

--- a/devague/plan.py
+++ b/devague/plan.py
@@ -27,7 +27,9 @@ from devague.frame import (
 # Bump when the persisted plan shape changes incompatibly. `plan_store.load`
 # fails closed on a plan whose schema_version is newer/unknown (see #18; the
 # plan-engine peer of frame.SCHEMA_VERSION). v2 (#53 t2) adds Task.instruction.
-PLAN_SCHEMA_VERSION = 2
+# v3 (resolve-parked-vagueness t2) adds PlanRisk.resolved/resolution — the
+# plan-side twin of frame.SCHEMA_VERSION's Vagueness.resolved/resolution bump.
+PLAN_SCHEMA_VERSION = 3
 
 TASK_STATUSES = ("proposed", "confirmed", "rejected")
 # Risks reuse the frame's open-vagueness kinds: a plan risk is the task-level peer of
@@ -62,6 +64,13 @@ class PlanRisk:
     text: str
     kind: str  # one of RISK_KINDS
     task_id: Optional[str] = None
+    # Resolution state (resolve-parked-vagueness t2), the plan-side twin of
+    # frame.Vagueness.resolved/resolution — field names are pinned verbatim, since
+    # render/deliverables_md.py (t7) reads both models. Empty string means "no
+    # resolution recorded"; a resolved risk stays on the record for provenance
+    # instead of being deleted (see Plan.resolve_risk).
+    resolved: bool = False
+    resolution: str = ""
 
     def __post_init__(self) -> None:
         if self.kind not in RISK_KINDS:
@@ -154,6 +163,30 @@ class Plan:
         )
         self.risks.append(r)
         return r
+
+    def find_risk(self, rid: str) -> Optional[PlanRisk]:
+        return next((r for r in self.risks if r.id == rid), None)
+
+    def resolve_risk(self, rid: str, resolution: str) -> PlanRisk:
+        """Close out a risk with a decision (resolve-parked-vagueness t2 — the
+        plan-side twin of ``Frame.resolve_vagueness``).
+
+        The risk stays on the record with its resolution text for the evidence
+        trail instead of being deleted; it is the convergence gate (t4) that stops
+        counting a resolved risk as a blocker. Raises ``ValueError`` on an unknown
+        id or on an id that is already resolved — mirroring the frame-side error
+        contract exactly, so both engines refuse the same way. The caller (the
+        CLI ``plan risk --resolve`` move, t6) is responsible for requiring
+        ``--decision`` up front and translating this into a user-facing refusal.
+        """
+        risk = self.find_risk(rid)
+        if risk is None:
+            raise ValueError(f"unknown risk id: {rid!r}")
+        if risk.resolved:
+            raise ValueError(f"risk already resolved: {rid!r}")
+        risk.resolved = True
+        risk.resolution = resolution
+        return risk
 
     def find_target(self, target_id: str) -> Optional[CoverageTarget]:
         return next((tg for tg in self.targets if tg.id == target_id), None)

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -190,7 +190,7 @@ def suggest_move(blocker: str) -> str:
     if m:
         return (
             f"resolve {m.group(1)} with a decision: "
-            f"devague plan risk --resolve RID --decision TEXT"
+            f'devague plan risk --resolve {m.group(1)} --decision "<the decision>"'
         )
     return "devague plan show     # inspect and decide"
 

--- a/devague/plan_convergence.py
+++ b/devague/plan_convergence.py
@@ -133,12 +133,31 @@ def dependency_blockers(plan: Plan) -> list[str]:
 
 
 def _missing_risks(plan: Plan) -> list[str]:
-    return [f"blocking risk {r.id} unresolved" for r in plan.risks if r.kind == "unknown_blocking"]
+    """Unresolved blocking risks only.
+
+    A resolved risk stays on the plan's record for provenance (see
+    ``Plan.resolve_risk``) but drops out of the gate the moment it is resolved
+    (resolve-parked-vagueness t4, mirrors t3's frame-side twin).
+    """
+    return [
+        f"blocking risk {r.id} unresolved"
+        for r in plan.risks
+        if r.kind == "unknown_blocking" and not r.resolved
+    ]
 
 
 def _parked_items(plan: Plan) -> list[str]:
-    """Tracked, non-blocking risks (everything but unknown_blocking)."""
-    return [f"[{r.kind}] {r.text}" for r in plan.risks if r.kind != "unknown_blocking"]
+    """Tracked, non-blocking, *unresolved* risks (everything but unknown_blocking).
+
+    A resolved risk is no longer open vagueness — it stays on the plan's record for
+    provenance (``Plan.resolve_risk``) but should stop being advertised as parked
+    (t4 AC3, mirrors t3's frame-side ``_parked_items``).
+    """
+    return [
+        f"[{r.kind}] {r.text}"
+        for r in plan.risks
+        if r.kind != "unknown_blocking" and not r.resolved
+    ]
 
 
 def suggest_move(blocker: str) -> str:
@@ -169,7 +188,10 @@ def suggest_move(blocker: str) -> str:
         return "break the dependency cycle: re-point one task's --dep so the graph is acyclic"
     m = re.search(r"blocking risk (r\d+)", blocker)
     if m:
-        return f"resolve {m.group(1)}: cover it with a task, or re-record it as non-blocking"
+        return (
+            f"resolve {m.group(1)} with a decision: "
+            f"devague plan risk --resolve RID --decision TEXT"
+        )
     return "devague plan show     # inspect and decide"
 
 

--- a/devague/render/deliverables_md.py
+++ b/devague/render/deliverables_md.py
@@ -6,8 +6,8 @@ that question, synthesized *only* from existing frame/plan state: the live sourc
 frame's confirmed ``announcement`` / ``after_state`` / ``success_signal`` claims
 (verbatim), the plan's terminal tasks (:func:`devague.plan.terminal_tasks` — active
 tasks no other active task depends on) with their acceptance criteria, and surviving
-open items (the frame's non-blocking parked vagueness plus the plan's non-blocking
-risks).
+open items (the frame's non-blocking, unresolved parked vagueness plus the plan's
+non-blocking, unresolved risks — a resolved item is no longer open, #53-esd t7).
 
 Like :mod:`devague.render.plan_md` this is **not** registered in the
 ``devague.render`` registry (that registry is ``Callable[[Frame], str]``; a
@@ -69,20 +69,25 @@ def _terminal_tasks_section(plan: Plan) -> list[str]:
 
 
 def _open_items_section(frame: Frame, plan: Plan) -> list[str]:
-    """Surviving open items: non-blocking frame vagueness + non-blocking plan risks.
+    """Surviving open items: non-blocking, unresolved frame vagueness + plan risks.
 
     ``unknown_blocking`` items are excluded on both sides — a genuinely blocking item
     would have kept the frame/plan from converging in the first place, so what
     survives here is exactly the tracked-but-non-blocking uncertainty (mirrors
-    ``convergence._parked_items`` / ``plan_convergence._parked_items``).
+    ``convergence._parked_items`` / ``plan_convergence._parked_items``). A resolved
+    item — frame vagueness or plan risk — is also excluded regardless of kind: once
+    decided it is no longer a surviving *open* item (resolve-parked-vagueness t7);
+    it still renders elsewhere with its resolution (frame_md, spec_md).
     """
     items = [
         f"[{v.kind}] {autolink_urls(v.text)}"
         for v in frame.open_vagueness
-        if v.kind != "unknown_blocking"
+        if v.kind != "unknown_blocking" and not v.resolved
     ]
     items += [
-        f"[{r.kind}] {autolink_urls(r.text)}" for r in plan.risks if r.kind != "unknown_blocking"
+        f"[{r.kind}] {autolink_urls(r.text)}"
+        for r in plan.risks
+        if r.kind != "unknown_blocking" and not r.resolved
     ]
     if not items:
         return []

--- a/devague/render/frame_md.py
+++ b/devague/render/frame_md.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from devague.frame import Frame
+from devague.frame import Frame, Vagueness
 
 _SECTIONS = [
     ("announcement", "Announcement"),
@@ -53,11 +53,26 @@ def _section_lines(frame: Frame, kind: str, heading: str) -> list[str]:
     return lines
 
 
+def _vagueness_bullet(v: Vagueness) -> str:
+    """A single ``open_vagueness`` bullet: plain for an item still open, or
+    carrying its resolution text for a resolved one (resolve-parked-vagueness
+    t7). The flat list stays a single section — resolved items are not split
+    into their own heading here (spec_md's ``Resolved vagueness`` subsection is
+    the polished-export treatment; frame_md is the working-state view). An
+    already-resolved item with no resolution text renders the plain form —
+    never a fabricated ``— resolved:`` with nothing after it.
+    """
+    base = f"- [{v.kind}] {v.text}"
+    if v.resolved and v.resolution:
+        return f"{base} — resolved: {v.resolution}"
+    return base
+
+
 def _vagueness_lines(frame: Frame) -> list[str]:
     if not frame.open_vagueness:
         return []
     lines = ["## Open vagueness", ""]
-    lines.extend(f"- [{v.kind}] {v.text}" for v in frame.open_vagueness)
+    lines.extend(_vagueness_bullet(v) for v in frame.open_vagueness)
     lines.append("")
     return lines
 

--- a/devague/render/spec_md.py
+++ b/devague/render/spec_md.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from devague.frame import Claim, Frame, HonestyCondition
+from devague.frame import Claim, Frame, HonestyCondition, Vagueness
 from devague.render._md_safety import autolink_urls, heading_safe
 
 
@@ -108,7 +108,40 @@ def _hard_questions(frame: Frame) -> list[str]:
 
 
 def _follow_up(frame: Frame) -> list[str]:
-    return [v.text for v in frame.open_vagueness if v.kind in ("follow_up", "out_of_scope")]
+    # A resolved follow_up/out_of_scope item is no longer open — it moves into
+    # ``_resolved_vagueness_section`` instead (resolve-parked-vagueness t7);
+    # counting it here too would fabricate it as still-open.
+    return [
+        v.text
+        for v in frame.open_vagueness
+        if v.kind in ("follow_up", "out_of_scope") and not v.resolved
+    ]
+
+
+def _resolved_vagueness(frame: Frame) -> list[Vagueness]:
+    """Resolved open-vagueness items, of any kind.
+
+    Unlike ``_follow_up`` (which only ever surfaced follow_up/out_of_scope
+    kinds), a decided item — including a resolved ``unknown_blocking`` or
+    ``unknown_nonblocking`` park — belongs in the exported spec once it carries
+    a resolution: the whole point of resolving a parked unknown is that the
+    answer ships with the spec (issue 45's provenance ask). An item marked
+    resolved with no resolution text renders nothing here — never fabricated
+    filler (mirrors ``_instruction_lines``).
+    """
+    return [v for v in frame.open_vagueness if v.resolved and v.resolution]
+
+
+def _resolved_vagueness_section(frame: Frame) -> list[str]:
+    items = _resolved_vagueness(frame)
+    if not items:
+        return []
+    out = ["## Resolved vagueness", ""]
+    out.extend(
+        f"- [{v.kind}] {autolink_urls(v.text)} — resolved: {autolink_urls(v.resolution)}"
+        for v in items
+    )
+    return out + [""]
 
 
 def _scope_section(frame: Frame) -> list[str]:
@@ -149,4 +182,5 @@ def render_spec(frame: Frame) -> str:
     out += _hard_questions(frame)
     out += _claim_section("Open questions", _claims(frame, "open_question"))
     out += _text_section("Open / follow-up", _follow_up(frame))
+    out += _resolved_vagueness_section(frame)
     return "\n".join(out).rstrip() + "\n"

--- a/docs/deliveries/2026-07-17-resolve-parked-vagueness.md
+++ b/docs/deliveries/2026-07-17-resolve-parked-vagueness.md
@@ -107,9 +107,9 @@ confirmed (task-by-task accounting above).
   comment on each of #45/#55/#57/#60 naming release 0.20.0 and the move that
   replaces its documented workaround (the `Closes` keywords auto-close them on
   merge). Owner: operator, post-merge.
-- Stale branch `resolve-parked-vagueness` (commit `b5c9e7c`, superseded
-  flat-verb spec) — delete if the reviewer agrees it is superseded. Owner:
-  human at gate 3.
+- ~~Stale branch `resolve-parked-vagueness` (commit `b5c9e7c`, superseded
+  flat-verb spec)~~ — done: the human approved deletion 2026-07-17; removed
+  locally and on origin.
 - Plan risk `r1` (follow_up, still open by design): downstream vendored copies
   of the think skill keep teaching the one-way park until guildmaster's next
   re-broadcast sync.

--- a/docs/deliveries/2026-07-17-resolve-parked-vagueness.md
+++ b/docs/deliveries/2026-07-17-resolve-parked-vagueness.md
@@ -1,0 +1,118 @@
+# Delivery Summary — resolve parked vagueness
+
+plan: `resolve-parked-vagueness` · run: `partial` · date: `2026-07-17`
+baseline: `devague summary skeleton`
+
+## Intent
+
+Ship the close-out for parked vagueness on both engines — `park --resolve`
+(frames) and `plan risk --resolve` (plans) — closing issues #45, #55, #57,
+and #60, by executing the ten-task converged plan via `/assign-to-workforce`:
+nine build tasks fanned out to subagent worktrees across three waves with
+TDD-gated merges, plus the release task. The run is `partial` only because
+`t10`'s issue-close half is post-merge by definition and PR
+[#81](https://github.com/agentculture/devague/pull/81) awaits the human gate.
+
+## Planned Work
+
+Quoted verbatim from the `devague summary` skeleton:
+
+- `t1` — Frame-side model: Vagueness resolution state + schema v3
+- `t2` — Plan-side model: PlanRisk resolution state + plan schema v3
+- `t3` — Frame gate: skip resolved vagueness, executable hint, parked_items
+- `t4` — Plan gate: skip resolved risks, executable hint, parked_items
+- `t5` — CLI: park --resolve VID --decision TEXT
+- `t6` — CLI: plan risk --resolve RID --decision TEXT
+- `t7` — Renderers: resolved items render with resolution; deliverables excludes them
+- `t8` — Teaching + contract docs sweep: the close-out loop everywhere park is taught
+- `t9` — E2E repro + quality gates: issue 57 lifecycle through the real CLI, both engines
+- `t10` — Release + close-out: 0.20.0, CHANGELOG, PR, close the four issues
+
+## Actual Delivery
+
+| Plan task | Status | What actually landed |
+|-----------|--------|----------------------|
+| `t1` | delivered | `Vagueness.resolved`/`.resolution`, `Frame.resolve_vagueness`, `SCHEMA_VERSION` 3 — commit `367c2fe`, merged `c277e5b` |
+| `t2` | delivered | `PlanRisk.resolved`/`.resolution`, `Plan.resolve_risk`, `PLAN_SCHEMA_VERSION` 3 — commit `625097f`, merged `691c545` |
+| `t3` | delivered | frame gate + `parked_items` skip resolved; hint names `park --resolve` with the real id — commit `3f354ce`, merged `7ec6fbc` |
+| `t4` | delivered | plan gate + `parked_items` skip resolved; hint names `plan risk --resolve` — commit `7f2dc74`, merged `6434e9f`, operator reconcile `1f80c3f` |
+| `t5` | delivered | `park --resolve VID --decision TEXT [--claim CN]`, fail-closed refusals; adds `Vagueness.resolution_claim_id` — commit `62085ef`, merged `d1584b4` |
+| `t6` | delivered | `plan risk --resolve RID --decision TEXT`, same refusal semantics — commit `f00fe51`, merged `f082f1f` |
+| `t7` | delivered | frame_md/spec_md render resolution verbatim (`## Resolved vagueness` in specs); deliverables excludes resolved; new goldens — commit `0ad0c86`, merged `fd91dfc` |
+| `t8` | delivered | `learn`, `docs/llm-guidance.md`, think skill, `docs/spec-contract.md` all teach the close-out; two learn tests — commit `c17a339`, merged `46aedb2` |
+| `t9` | delivered | `tests/test_e2e_resolve.py`: issue-57 lifecycle e2e on both engines + markdownlint integration; quality gates all green — commit `93c7072`, merged `fb1ddbb` |
+| `t10` | partial | 0.20.0 bump + CHANGELOG + PR #81 delivered (commit `abdc5d4`); the issue-close comments are post-merge and pending the human gate — `Closes` keywords in the PR body will auto-close #45/#55/#57/#60 on merge, comments naming the release still to be posted |
+
+## Mid-work Decisions
+
+No `/deviate` records exist for this plan (`devague deviate --list`: "no
+deviations recorded yet") — no execution step departed from a confirmed task's
+contract. Operator-level decisions inside the plan's latitude, captured
+directly:
+
+- `t5` storage seam: the plan required `--claim CN` to link the deciding claim
+  but specified no storage; the operator granted a minimal
+  `Vagueness.resolution_claim_id` field (additive, dataclass default — no
+  extra schema bump) rather than overwriting the owning `claim_id` from park
+  time. Validation landed in the model (`Frame.resolve_vagueness`), the same
+  seam `add_scope_entry` uses.
+- `t4` reconcile (commit `1f80c3f`): the delivered blocking-risk hint emitted a
+  literal `RID` placeholder while the frame-side hint interpolated the real
+  id; the operator harmonized the plan-side hint to interpolate `rN` before
+  advancing the wave.
+- `t5`/`t6` answered the frame's open hard question (already-resolved id →
+  **refuse with a hint**, not no-op), the fail-closed choice the plan's
+  instruction pre-pinned.
+- Branch naming: a pre-existing `resolve-parked-vagueness` branch (commit
+  `b5c9e7c`, an earlier session) holds a superseded flat-verb spec; this run
+  shipped on `park-resolve` instead and left that branch untouched for the
+  reviewer to delete.
+- `t8` found `devague plan learn` already taught the resolve form (t6's commit
+  covered `PLAN_MOVES`), so only the frame-side teaching needed edits.
+
+## Drift From Plan
+
+| Plan item | Reason for divergence | Classification |
+|-----------|-----------------------|----------------|
+| `t10` | the issue-close half is sequenced on the human PR gate (gate 3) — it cannot complete before merge; all pre-merge halves (bump, CHANGELOG, PR) are delivered | needs-follow-up |
+
+No other task drifted: `t1`–`t9` delivered to their acceptance criteria as
+confirmed (task-by-task accounting above).
+
+## Evidence
+
+- tests: `uv run pytest -n auto -q` — **689 passed** (baseline at plan start: 616), run after every wave merge and again at release
+- coverage: `uv run pytest -n auto -q --cov=devague --cov-report=term` — **98.12%** (gate ≥ 95%)
+- lint: `flake8` / `black` / `isort` / `bandit -r devague/` — clean (t9 report + release-commit run); `markdownlint-cli2` on all touched docs — 0 errors
+- e2e: `tests/test_e2e_resolve.py::test_e2e_issue57_frame_park_resolve_lifecycle`, `::test_e2e_issue57_frame_export_passes_markdownlint`, `::test_e2e_issue57_plan_risk_resolve_lifecycle` — pass
+- boundary: `git diff main...HEAD -- devague/` grep for subprocess/network/LLM usage — empty
+- commits: `3e82751..abdc5d4` on branch `park-resolve` (9 task commits + 9 TDD-gated merge commits + 1 operator reconcile + release)
+- PRs / issues: PR `#81` (SonarCloud quality gate passed; Qodo: 0 bugs, 0 rule violations, 0 requirement gaps); issues `#45` `#55` `#57` `#60`
+
+## Delivery Claims
+
+| Claim | Confidence | Evidence |
+|-------|------------|----------|
+| a decided blocking park resolves through CLI moves alone — issue 57's exact repro converges and exports with zero `.devague` hand-edits | high | test `tests/test_e2e_resolve.py::test_e2e_issue57_frame_park_resolve_lifecycle` |
+| the plan-side twin works end to end | high | test `tests/test_e2e_resolve.py::test_e2e_issue57_plan_risk_resolve_lifecycle` |
+| resolved items stay on the record and render with their resolution; open-item listings exclude them | high | commit `0ad0c86` · goldens `tests/goldens/resolved_vagueness_{frame,spec}.md` |
+| convergence hints now name executable moves on both engines | high | commits `3f354ce`, `7f2dc74`, `1f80c3f` · tests in `tests/test_convergence.py`, `tests/test_plan_convergence.py` |
+| v2 artifacts load with defaults; newer artifacts fail closed on older binaries | high | round-trip/fail-closed tests in `tests/test_store.py`, `tests/test_plan_store.py`, `tests/test_frame.py`, `tests/test_plan.py` |
+| every teaching surface teaches the close-out | high | commit `c17a339` · tests `tests/test_cli_learn.py` |
+| issues #45/#55/#57/#60 are closed against the shipped release | unverified | pending gate 3 — PR `#81` carries the `Closes` keywords; comments naming the release follow the merge, not claimed done |
+
+## Remaining Work / Follow-up
+
+- `t10` second half — after the human merges PR `#81`: post the close-out
+  comment on each of #45/#55/#57/#60 naming release 0.20.0 and the move that
+  replaces its documented workaround (the `Closes` keywords auto-close them on
+  merge). Owner: operator, post-merge.
+- Stale branch `resolve-parked-vagueness` (commit `b5c9e7c`, superseded
+  flat-verb spec) — delete if the reviewer agrees it is superseded. Owner:
+  human at gate 3.
+- Plan risk `r1` (follow_up, still open by design): downstream vendored copies
+  of the think skill keep teaching the one-way park until guildmaster's next
+  re-broadcast sync.
+- Frame park `v1` (unknown_nonblocking, on the record): stale installed
+  binaries downstream fail closed on v3 artifacts until upgraded — mitigated
+  by the error's own upgrade hint.

--- a/docs/llm-guidance.md
+++ b/docs/llm-guidance.md
@@ -45,7 +45,10 @@ Three legs share one chassis (the third optional):
   `success_signal`, `open_question`, `non_goal`, `requirement`, `assumption`,
   `decision`); honesty conditions and hard questions attached to claims; and
   **open vagueness** (parked unknowns, kinds `unknown_nonblocking` /
-  `unknown_blocking` / `out_of_scope` / `follow_up`).
+  `unknown_blocking` / `out_of_scope` / `follow_up`). A parked item is not
+  stuck once decided: `park --resolve <vN> --decision "<text>" [--claim <cN>]`
+  closes it out — it stays on record with its resolution, drops out of the
+  convergence gate, and never requires hand-editing `.devague` state.
 - **Plan (spec → plan).** Coverage targets (derived from a converged frame),
   tasks (with acceptance criteria, dependencies, and the targets they cover),
   and first-class plan risks.
@@ -107,7 +110,11 @@ These are not style preferences. Convergence is only meaningful if these hold.
   `interrogate --honesty`; the user owns whether each one actually holds.
 - **Park real unknowns; do not paper over them.** If something is genuinely
   unknown, `park` it (blocking or non-blocking) instead of writing confident
-  prose that hides the gap. Blocking vagueness holds back convergence by design.
+  prose that hides the gap. Blocking vagueness holds back convergence by
+  design — and once it is decided, close it out with `park --resolve <vN>
+  --decision "<text>"` (plan side: `plan risk --resolve <rN> --decision
+  "<text>"`) rather than leaving it parked forever or hand-editing state; the
+  resolved item stays on record with its resolution and stops blocking.
 - **Converge, don't vibe.** `export` is gated on `converge` passing. Never
   declare a frame or plan "ready" on a hunch — run `converge` and resolve every
   listed gap first.
@@ -125,6 +132,7 @@ These are not style preferences. Convergence is only meaningful if these hold.
 | You have a strong guess at the audience | `capture --kind audience … --origin user` (passing your guess off as the user's) | `capture --kind audience … --origin llm`, then ask the user to `confirm` |
 | You proposed an honesty condition | `confirm h3` yourself so the gate passes | leave `h3` proposed; surface it for the user to confirm |
 | A key detail is genuinely unknown | invent a plausible answer to keep momentum | `park "<the unknown>" --kind unknown_blocking` |
+| A blocking park just got decided | leave it parked forever, or hand-edit `.devague` state to unblock convergence | `park --resolve <vN> --decision "<the decision>"` |
 | User asks "is this ready?" | "Yes, looks solid." | run `converge`; report the actual blockers/warnings |
 | The user skipped a stage | march through the stages in order anyway | capture what they gave you; let the arc fill in adaptively |
 | Plan: a task has no clear acceptance test | mark it confirmed and move on | leave it without criteria (the gate blocks it) or `park` the risk |
@@ -139,7 +147,9 @@ spirit:
 - **LLM-proposed tasks stay proposed**; the user confirms them.
 - **Cover every target, criteria on every task** — the gate requires it.
 - **Keep the dependency graph honest** — real task ids, acyclic.
-- **Park genuine unknowns as risks** (`unknown_blocking` holds convergence back).
+- **Park genuine unknowns as risks** (`unknown_blocking` holds convergence
+  back); close a decided one out with `plan risk --resolve <rN> --decision
+  "<text>"` rather than leaving it parked or hand-editing plan state.
 - **Converge against the live frame** — `converge`/`export` re-load the source
   frame; if it regressed below convergence, re-converge the spec first.
 - **Instructions ride along to the workforce.** A task's optional

--- a/docs/plans/2026-07-17-resolve-parked-vagueness.md
+++ b/docs/plans/2026-07-17-resolve-parked-vagueness.md
@@ -1,0 +1,105 @@
+# Build Plan — resolve parked vagueness
+
+slug: `resolve-parked-vagueness` · status: `exported` · from frame: `resolve-parked-vagueness`
+
+> devague ships a resolve move for parked vagueness: a blocking park can now be resolved or reclassified through CLI moves alone, closing issues 45, 55, 57, and 60
+
+## Tasks
+
+### t1 — Frame-side model: Vagueness resolution state + schema v3
+
+- instruction: extend Vagueness in devague/frame.py with resolved: bool = False and resolution: str = ''; add Frame.resolve_vagueness(vid: str, resolution: str); bump SCHEMA_VERSION to 3; default the new keys in from_dict for v2 artifacts; keep set_status untouched — v-ids stay out of confirm/reject per decision c11; field names are pinned (resolved, resolution) — t2 and t7 read them verbatim
+- covers: c2, h2, c5, h5
+- acceptance:
+  - Vagueness gains resolved: bool = False and resolution: str = '' with id/text/kind/claim_id unchanged; Frame.resolve_vagueness(vid, resolution) marks it resolved and raises ValueError on an unknown or already-resolved id
+  - SCHEMA_VERSION == 3; a v2 frame JSON without the new keys loads with defaults; save-load round-trips a resolved item identical (tests/test_frame.py, tests/test_store.py)
+  - store.load still fails closed with the upgrade hint when schema_version exceeds 3
+
+### t2 — Plan-side model: PlanRisk resolution state + plan schema v3
+
+- instruction: mirror t1 exactly in devague/plan.py: PlanRisk.resolved/resolution, Plan.resolve_risk, PLAN_SCHEMA_VERSION = 3, from_dict defaults for v2 artifacts; field names must match t1 verbatim (resolved, resolution) — deliverables_md reads both models
+- covers: c13, h9
+- acceptance:
+  - PlanRisk gains resolved: bool = False and resolution: str = '' with id/text/kind/task_id unchanged; Plan.resolve_risk(rid, resolution) mirrors the frame-side error contract (ValueError on unknown or already-resolved)
+  - PLAN_SCHEMA_VERSION == 3; a v2 plan JSON loads with defaults; save-load round-trips a resolved risk identical (tests/test_plan.py, tests/test_plan_store.py)
+
+### t3 — Frame gate: skip resolved vagueness, executable hint, parked_items
+
+- instruction: in devague/convergence.py: filter v.resolved in _missing_open_uncertainty and _parked_items; rewrite the blocking-vagueness branch of suggest_move (line 188) to emit the park --resolve move; plain CLI text, stdout only — renderer changes are t7, not here
+- depends on: t1
+- covers: c3, h3, c18, h14
+- acceptance:
+  - _missing_open_uncertainty skips resolved items: a resolved unknown_blocking no longer appears in blockers (tests/test_convergence.py)
+  - suggest_move for a blocking-vagueness blocker names the executable syntax verbatim: park --resolve VID --decision TEXT
+  - _parked_items excludes resolved items, so converge/status parked_items stops advertising a closed item as open
+
+### t4 — Plan gate: skip resolved risks, executable hint, parked_items
+
+- instruction: mirror t3 in devague/plan_convergence.py: filter r.resolved in _missing_risks and _parked_items; rewrite the blocking-risk hint branch to emit the plan risk --resolve move
+- depends on: t2
+- covers: c13, h9, c18, h14
+- acceptance:
+  - a resolved unknown_blocking risk no longer blocks plan convergence (tests/test_plan_convergence.py)
+  - the blocking-risk hint at plan_convergence.py:172 names the executable syntax verbatim: plan risk --resolve RID --decision TEXT
+  - plan-side _parked_items excludes resolved risks
+
+### t5 — CLI: park --resolve VID --decision TEXT
+
+- instruction: in devague/cli/_commands/park.py make the positional text optional (nargs='?') the way question.py does; add --resolve VID, --decision TEXT, --claim CN; require --decision whenever --resolve is passed; route through Frame.resolve_vagueness and translate ValueError into DevagueError with a run-devague-show hint; fail-closed refusal for already-resolved ids, consistent with the store posture
+- depends on: t1
+- covers: c4, h4
+- acceptance:
+  - park --resolve VID --decision TEXT marks the item resolved, echoes the transition on stdout, and has --json parity
+  - a bare park --resolve VID without --decision is refused with a hint and persists nothing (decision c21); unknown and already-resolved ids are refused with a hint, exit 1 (answers the frame hard question: refuse, not no-op)
+  - --claim CN links the deciding claim and an unknown claim id is refused; passing positional text together with --resolve is refused; the park-create path is unchanged (tests/test_cli_moves.py)
+
+### t6 — CLI: plan risk --resolve RID --decision TEXT
+
+- instruction: mirror t5 on the risk subcommand in devague/cli/_commands/plan.py: positional text becomes optional, add --resolve RID and --decision TEXT with the same refusal semantics; no --claim analog (risks link tasks via --task); route through Plan.resolve_risk
+- depends on: t2
+- covers: c13, h9
+- acceptance:
+  - plan risk --resolve RID --decision TEXT resolves the risk with stdout echo and --json parity; bare resolve without --decision refused; unknown and already-resolved ids refused with hint, exit 1 (tests/test_cli_plan.py)
+  - the risk-create path (positional text --kind K --task TN) is unchanged
+
+### t7 — Renderers: resolved items render with resolution; deliverables excludes them
+
+- instruction: frame_md: keep the flat Open vagueness list for open items and render resolved ones as '- [kind] text — resolved: TEXT'; spec_md: render resolved items of any kind with their resolution under the existing structure (a Resolved vagueness subsection is acceptable); deliverables_md: filter on the resolved flag from both models; update tests/goldens accordingly
+- depends on: t1, t2
+- covers: c6, h6, c18, h14
+- acceptance:
+  - frame_md and spec_md render a resolved item with its resolution text verbatim; an exported spec from a frame with a resolved blocking park passes markdownlint (integration test + goldens)
+  - deliverables_md surviving-open-items excludes resolved frame vagueness and resolved plan risks (tests/test_plan_deliverables.py)
+
+### t8 — Teaching + contract docs sweep: the close-out loop everywhere park is taught
+
+- instruction: sweep devague/cli/_commands/learn.py (move table + operating rules), docs/llm-guidance.md park rows, .claude/skills/think/SKILL.md move table and rules, and docs/spec-contract.md (entities, move tables, Versioning); match the exact flag names t5/t6 shipped; markdownlint everything touched
+- depends on: t5, t6
+- covers: c7, h7, c14, h10, c5
+- acceptance:
+  - devague learn and devague plan learn name park --resolve / plan risk --resolve wherever park/risk are taught (tests/test_cli_learn.py asserts the strings)
+  - docs/spec-contract.md documents resolved/resolution on Vagueness and PlanRisk, the resolve move rows, and schema_version 3 for both engines
+  - docs/llm-guidance.md and .claude/skills/think/SKILL.md teach the close-out loop; the taught prefer-question workaround framing is retired
+
+### t9 — E2E repro + quality gates: issue 57 lifecycle through the real CLI, both engines
+
+- instruction: new tests/test_e2e_resolve.py exercising devague.cli main() end to end for both engines; keep it hermetic in tmp_path working dirs; verify the exported spec passes the existing markdownlint integration harness
+- depends on: t3, t4, t5, t6, t7
+- covers: c1, h1, c15, h11, c9, h8, c17, h13
+- acceptance:
+  - a new e2e test drives the installed entry point through issue 57's repro: park blocking, capture the decision claim, park --resolve with --decision and --claim, converge passes, export succeeds — zero direct edits of .devague files; a plan-side twin e2e does the same through plan risk --resolve
+  - coverage stays at 95 percent or higher; flake8, black, isort, bandit all clean
+  - the resolve code paths add no LLM call and no subprocess usage inside the devague package (boundary h8) — asserted by inspection of the diff, not assumed
+
+### t10 — Release + close-out: 0.20.0, CHANGELOG, PR, close the four issues
+
+- instruction: minor bump (new CLI surface); PR via the cicd skill / agex pr open, linking the spec and plan artifacts; issue-close comments quote the exact replacing move per issue (park --resolve for 45/55/57; both moves plus the existing plan amend pointer for 60)
+- depends on: t8, t9
+- covers: c16, h12, c17, h13
+- acceptance:
+  - pyproject.toml bumps 0.19.1 to 0.20.0 with a prepended CHANGELOG.md entry naming issues 45, 55, 57, 60; CI version-check passes
+  - after merge, each of issues 45, 55, 57, 60 is closed with a comment naming the shipped release and the move that replaces its documented workaround, signed per convention
+
+## Risks
+
+- [follow_up] the updated think skill reaches downstream mesh repos only on guildmaster's next re-broadcast sync — until then vendored copies still teach the one-way park; known cadence cost, not a blocker

--- a/docs/spec-contract.md
+++ b/docs/spec-contract.md
@@ -20,12 +20,19 @@ see [`llm-guidance.md`](llm-guidance.md) (also surfaced in `devague learn`).
 
 ## Versioning
 
-Every frame carries an integer `schema_version` (currently `2`). It is written
+Every frame carries an integer `schema_version` (currently `3`). It is written
 on save and checked on load: a frame whose `schema_version` is newer than this
 devague supports is rejected, fail-closed, with an actionable error. A 0.4.0
 frame predates the field and loads as the current schema, so existing frames
 keep working.
 
+> **v3 (resolve-parked-vagueness t1).** Bumped to add `Vagueness.resolved`,
+> `Vagueness.resolution`, and `Vagueness.resolution_claim_id` — see *Vagueness*
+> under Entities. A v2 frame predates all three: it loads with `resolved`
+> defaulted to `False`, `resolution` to `""`, and `resolution_claim_id` to
+> `None` — every pre-existing parked item loads as still-open, never silently
+> resolved.
+>
 > **v2 (#53 t1).** Bumped to add `Frame.scope_entries` and an `instruction`
 > field on `Claim` and `HonestyCondition` — see *ScopeEntry* under Entities and
 > the *Instructions* section below. A v1 frame predates both: it loads with no
@@ -93,7 +100,16 @@ First-class open vagueness — parked uncertainty, not a markdown afterthought.
 - `id` — `v1`, `v2`, …
 - `text` — the unknown.
 - `kind` — see Vagueness kinds.
-- `claim_id` — optional owning claim.
+- `claim_id` — optional owning claim, set at park time.
+- `resolved` — boolean; `False` until closed via `Frame.resolve_vagueness`
+  (v3, resolve-parked-vagueness t1). The **only** mutator — `park`/`confirm`/
+  `reject` never touch it (decision c11).
+- `resolution` — the resolution text recorded with `--decision`; `""` means
+  not yet resolved (v3). The item stays on record with its resolution for
+  provenance instead of being deleted.
+- `resolution_claim_id` — optional *deciding* claim id recorded at resolve
+  time via `--claim` (v3); distinct from `claim_id`, the *owning* claim set
+  at park time, which `resolve_vagueness` never overwrites.
 
 ### ScopeEntry
 
@@ -232,6 +248,7 @@ the exit code is non-zero and `stderr` carries a `hint:` line.
 | `interrogate <cN> [--honesty/--hard-question/--risk/--contradicts]` | claim id + attachment | `{added: [...]}` | attaches a honesty condition / question (`llm` honesty → `proposed`) |
 | `confirm <id>` / `reject <id>` | claim or honesty id | `{id, status}` | the **only** path to `confirmed` / `rejected` — user-only |
 | `park "<text>" --kind K` | text, vagueness kind | `{id, kind}` | adds first-class open vagueness |
+| `park --resolve VID --decision "<text>" [--claim CN]` | vagueness id, decision text, optional deciding claim id | `{id, resolved, resolution, resolution_claim_id}` | closes out a parked item (v3, resolve-parked-vagueness t5) — the **only** path to `Vagueness.resolved`; user-only, mirrors `question --resolve` |
 | `converge` | — | the convergence result | promotes/demotes frame `status` |
 | `export [--format spec-md]` | — | `{path, format}` | writes the spec; requires `ready_for_spec` |
 | `show` / `list` | — | frame dict / slug list | none |
@@ -239,10 +256,13 @@ the exit code is non-zero and `stderr` carries a `hint:` line.
 
 **Validation errors** (all raise a clean `DevagueError`, exit code 1): unknown
 claim kind / origin / status or vagueness kind (rejected at construction);
-unknown claim or honesty id on `confirm`/`reject`; an invalid `--frame` slug; a
-missing frame; a malformed or hand-edited frame file (including one whose
-embedded slug doesn't match the requested slug, or whose `schema_version` is not
-an integer); a frame whose `schema_version` is too new.
+unknown claim or honesty id on `confirm`/`reject`; `park --resolve` without
+`--decision`; positional park text passed together with `--resolve`; an
+unknown or already-resolved vagueness id on `park --resolve`; an unknown
+`--claim` id on `park --resolve`; an invalid `--frame` slug; a missing frame;
+a malformed or hand-edited frame file (including one whose embedded slug
+doesn't match the requested slug, or whose `schema_version` is not an
+integer); a frame whose `schema_version` is too new.
 
 ## Anti-fabrication guarantee
 
@@ -276,7 +296,10 @@ The plan engine (`devague plan …`) is the structural peer: a Plan holds covera
 targets derived from a converged frame, Tasks (`origin`/`status` like claims,
 plus `deps`, `covers`, `acceptance_criteria`, and an optional `instruction` —
 verbatim text on how to implement/verify the task, `""` means none, v2, #53 t2;
-see *Instructions* above), and PlanRisks. It reuses the same structured
+see *Instructions* above), and PlanRisks (`id`, `text`, `kind`, optional
+`task_id`, plus `resolved` / `resolution` — the plan-side twin of
+`Vagueness.resolved` / `.resolution`, field names pinned verbatim across both
+models, v3, resolve-parked-vagueness t2). It reuses the same structured
 convergence result, serialized under `ready_for_plan`. See
 `docs/superpowers/specs/2026-05-23-devague-spec-to-plan-design.md`.
 
@@ -300,6 +323,7 @@ seeded surfaces as a clean error (frame drift) rather than a stale pass.
 | `cover <tN> --target <c*\|h*>` | task id, coverage target id | `{id, covers}` | marks a task as covering a coverage target; does not change `status` |
 | `confirm <tN>` / `reject <tN>` | task id | `{id, status}` | the **only** path to `confirmed` / `rejected` — user-only |
 | `risk "<text>" --kind K [--task <tN>]` | risk text, vagueness kind, optional task ref | `{id, kind, task}` | records a first-class PlanRisk |
+| `risk --resolve RID --decision "<text>"` | risk id, decision text | `{id, resolved, resolution}` | closes out a plan risk (v3, resolve-parked-vagueness t6) — the **only** path to `PlanRisk.resolved`; user-only, mirrors `park --resolve` (no `--claim` analog — risks link tasks via `--task`, not a deciding claim) |
 | `converge` | — | the convergence result (`ready_for_plan`) | promotes/demotes plan `status`; re-evaluates against the live source frame |
 | `export [--format plan-md]` | — | `{path, format}` | writes the buildable plan; requires `ready_for_plan` |
 | `waves [--json]` | — | `{plan, waves, tasks}` | none — read-only, convergence-agnostic (see below) |
@@ -316,8 +340,10 @@ unknown task id on `instruct` / `accept` / `amend` / `depend` / `cover` /
 dependency graph (a cycle, or a dependency on a missing/rejected task) on
 `waves`; `new` against an unconverged frame or over an existing plan; a
 source frame that has regressed below its own convergence on `converge` /
-`export` / `status` (frame drift); an invalid `--plan` / `--frame` slug; a
-missing plan; a malformed or hand-edited plan file; a plan whose
+`export` / `status` (frame drift); `risk --resolve` without `--decision`;
+positional risk text passed together with `--resolve`; an unknown or
+already-resolved risk id on `risk --resolve`; an invalid `--plan` / `--frame`
+slug; a missing plan; a malformed or hand-edited plan file; a plan whose
 `schema_version` is too new.
 
 ### The re-confirm rule
@@ -359,7 +385,7 @@ what is useful *before* convergence, at the assign-to-workforce go/no-go
 (issue #20: Devague describes state, it does not gate the human's decision).
 
 Plans carry the same persistence contract as frames. Every plan has an integer
-`schema_version` (currently `2`, `PLAN_SCHEMA_VERSION`), written on save and
+`schema_version` (currently `3`, `PLAN_SCHEMA_VERSION`), written on save and
 checked on load: `plan_store.load` **fails closed** with a clean `DevagueError`
 (exit code 1, upgrade hint) when a plan declares a `schema_version` newer than
 this devague supports. A pre-0.7.0 plan with no `schema_version` key loads
@@ -375,6 +401,12 @@ slug (so a tampered file can't silently redirect a later `save`), and parse
 non-integer value is rejected rather than coerced. These guards are symmetric
 across the frame and plan persistence twins.
 
+> **v3 (resolve-parked-vagueness t2).** `PLAN_SCHEMA_VERSION` bumped to add
+> `PlanRisk.resolved` and `PlanRisk.resolution` — the plan-side twin of the
+> frame's v3 Vagueness bump. A v2 plan predates both: it loads with `resolved`
+> defaulted to `False` and `resolution` to `""`, so every pre-existing risk
+> loads as still-open.
+>
 > **v2 (#53 t2).** `PLAN_SCHEMA_VERSION` bumped to add `Task.instruction`. A v1
 > plan predates it and loads with every task's `instruction` defaulted to `""`.
 

--- a/docs/specs/2026-07-17-resolve-parked-vagueness.md
+++ b/docs/specs/2026-07-17-resolve-parked-vagueness.md
@@ -1,0 +1,114 @@
+# resolve parked vagueness
+
+> devague ships a resolve move for parked vagueness: a blocking park can now be resolved or reclassified through CLI moves alone, closing issues 45, 55, 57, and 60
+> instruction: on the shipped build run issue 57's repro: park a blocking unknown, capture the decision, park --resolve it, converge passes, export succeeds — no file edits
+
+## Audience
+
+- operators driving /think and /spec-to-plan (the agents making CLI moves), the humans who own confirms, and the downstream AgentCulture repos that filed the four reports — colleague, lobes-cli, league-of-agents, and devague's own dogfooding
+
+## Before → After
+
+- After: a parked blocking unknown, once decided, is closed through `park --resolve` (frames) or `plan risk --resolve` (plans): the item stays on record with its resolution text, drops out of the convergence gate, the converge hints name executable moves, and no operator ever hand-edits .devague state again
+
+## Why it matters
+
+- four independent reports in five weeks (issues 45, 55, 57, 60) show the method punishing correct behavior: honest parking leads to a permanently blocked frame, and the only escape is the exact out-of-band state mutation the move-driven design exists to prevent — one repo has the hand-edit in committed history (league-of-agents 0c71282)
+
+## Requirements
+
+- the Vagueness dataclass (devague/frame.py:106) gains resolution state — e.g. a resolved flag plus resolution text — kept in frame state for the evidence trail rather than deleted; add_vagueness today only appends and set_status (frame.py:226) routes only claim and honesty ids, so v-ids are unaddressable by any move
+  - instruction: extend Vagueness with resolved: bool = False and resolution: str = ""; round-trip tests in tests/test_frame.py and tests/test_store.py
+  - honesty: a resolved Vagueness keeps its text, kind, and claim_id plus the resolution on the record, and round-trips save-load identical
+- the convergence gate (devague/convergence.py:100-102) stops counting a resolved vagueness as a blocker, and suggest_move (convergence.py:188) names an actually executable move instead of today's 're-park it as non-blocking' hint, which only appends a second item while the first keeps blocking — the acceptance bar issue 45 sets explicitly
+  - instruction: in _missing_open_uncertainty skip resolved items; rewrite the suggest_move blocking-vagueness branch (convergence.py:188) to emit the park --resolve syntax; tests in tests/test_convergence.py
+  - honesty: after park --resolve, converge no longer lists the item as a blocker and the blocking-vagueness hint names park --resolve verbatim — an executable move, issue 45's acceptance bar
+- a new user-only resolve surface for v-ids that mirrors the existing `question --resolve <qid> --decision "<text>"` shape (devague/cli/_commands/question.py) — resolving is a user decision like confirm (issue 55), validated fail-closed with a hint on an unknown v-id, with stdout result, --json, and the existing exit-code contract
+  - instruction: add --resolve VID and --decision to park's argparse in cli/_commands/park.py; unknown id raises DevagueError with a 'run devague show' hint; CLI tests in tests/test_cli_moves.py
+  - honesty: an unknown v-id is refused with a hint and nothing is persisted; output follows the existing stdout/--json/exit-code contract; resolving stays a user-decided move like confirm
+- SCHEMA_VERSION bumps 2 to 3 (devague/frame.py:15) because adding fields to Vagueness breaks old loaders — from_dict does Vagueness(**v) (frame.py:284), so an old CLI reading a new frame raises TypeError; the documented fail-closed policy and the v2 scope_entries precedent both say bump; docs/spec-contract.md's Vagueness entity section gains the resolved state
+  - instruction: bump SCHEMA_VERSION to 3 in devague/frame.py; from_dict defaults resolved/resolution for old artifacts; fail-closed + back-compat tests in tests/test_store.py and tests/test_frame_schema_v2.py's pattern
+  - honesty: a v3 frame on a v2-only binary fails closed with the schema_version error, never a Vagueness(**v) TypeError; v2 frames without the new fields still load with defaults
+- renderers keep a resolved vagueness on the record as provenance instead of dropping it — render/frame_md.py:56-60 lists every open_vagueness item flat, and render/spec_md.py:111 routes only follow_up/out_of_scope kinds into the spec; a resolved item should render with its resolution text so the exported spec shows the answered unknown (the provenance issue 45's comment asks for)
+  - instruction: render resolved items with their resolution in render/frame_md.py and render/spec_md.py; golden updates in tests/goldens plus the markdownlint integration test
+  - honesty: an exported spec from a frame with a resolved blocking park renders the unknown together with its resolution text, and the export passes markdownlint
+- every surface that teaches park also teaches the resolve close-out: devague/cli/_commands/learn.py (move table line 26, operating rules line 107), docs/llm-guidance.md (park rows in the fabrication table, lines 109-130), and .claude/skills/think/SKILL.md (move table line 82, rules lines 209-210) — otherwise operators keep learning the trap issues 45/55/57/60 all fell into
+  - instruction: sweep learn.py (move table + operating rules), docs/llm-guidance.md park rows, and .claude/skills/think/SKILL.md move table and rules; teaching tests in tests/test_cli_learn.py
+  - honesty: learn, docs/llm-guidance.md, and the think skill each name park --resolve wherever they teach park; issue 57's prefer-question workaround guidance is retired
+- the plan engine ships the twin in the same PR: PlanRisk (devague/plan.py:60) gains the same resolution state, `plan risk --resolve <rN>` the same user-only surface, plan_convergence.py:136 skips resolved risks, the hint at plan_convergence.py:172 names the executable move, and PLAN_SCHEMA_VERSION bumps 2 to 3 (PlanRisk(**r) at plan.py:310 has the same old-loader crash shape as the frame side)
+  - instruction: mirror the frame-side change end to end: PlanRisk.resolved/resolution, plan risk --resolve RID --decision, plan_convergence skip + hint, PLAN_SCHEMA_VERSION 3; tests across tests/test_plan.py, test_plan_convergence.py, test_plan_store.py, test_cli_plan.py
+  - honesty: plan converge drops a resolved blocking risk; the plan hint at plan_convergence.py:172 names plan risk --resolve verbatim; a v3 plan fails closed on a v2-only binary
+- every secondary reader of open vagueness and plan risks handles resolved items consistently, not just the gate: _parked_items in convergence.py:151 and plan_convergence.py:141 (whose output feeds converge/status parked_items), and render/deliverables_md.py:72-81 (plan deliverables' surviving-open-items section, which reads frame.open_vagueness and plan risks directly) — a resolved item must stop being advertised as open everywhere, or status and deliverables contradict the spec
+  - instruction: filter (or annotate) resolved items in _parked_items of convergence.py and plan_convergence.py and in deliverables_md's open-items builder; tests in tests/test_convergence.py, test_plan_convergence.py, test_plan_deliverables.py
+  - honesty: with a resolved blocking item on a frame and a resolved blocking risk on a plan: converge/status parked_items and plan deliverables' open-items section show neither as open — verified by tests against those exact surfaces
+
+## Honesty conditions
+
+- the shipped release clears a decided blocking park via CLI moves alone — issue 57's repro converges with zero .devague JSON edits
+- the diff adds no LLM call and no subprocess to the CLI; resolution text is authored by the user/operator, never generated in-CLI
+- devague learn output alone teaches the close-out (park --resolve and plan risk --resolve) — an operator never needs to read source to escape a decided blocking park
+- no .devague hand-edit remains necessary anywhere in the vagueness lifecycle: park, decide, resolve, converge, export all work through moves
+- each of the four issues is closed with a comment naming the shipped release and the move that replaces its documented workaround
+- the stated numbers are verified before close: 4 issues closed, the repro converges with 0 hand-edits, coverage >= 95% in CI
+
+## Success signals
+
+- all 4 issues close against the shipped release; issue 57's repro script (park blocking, decide, resolve, converge) passes through moves alone with 0 hand-edits of .devague state; test coverage stays >= 95%
+
+## Scope / boundaries
+
+- the resolve move is deterministic recording only — no LLM calls in the CLI (issue 20), and hand-editing .devague state stays forbidden; the fix removes the last reason operators had to hand-edit (the workaround all four issues document), it does not legitimize state edits
+
+## Non-goals
+
+- no task-text or claim-text edit verb ships in this fix: issue 60's plan-side half is already shipped as `devague plan amend` (0.18.0, issue 68 — edits a task summary and acceptance criteria, flips confirmed back to proposed), and its floated `devague edit <cN> --text` frame-claim parity is a separate feature, not part of the shared vagueness-resolve gap
+- no unresolve move ships: a mistakenly resolved vagueness is recovered by parking a fresh item (append is cheap and keeps provenance), not by reopening the resolved record — avoiding a second one-way-mutation surface in the same PR
+
+## Assumptions
+
+- reclassification ships as two executable moves — `park --resolve <vN>` closing the old item plus a fresh `park --kind <new-kind>` — not an in-place kind mutation; this satisfies issue 45's acceptance (the item stops blocking, stays on record) with cleaner provenance than editing kind in place, and issue 45 offered any-one-of-three shapes
+
+## Scope exploration
+
+- `s1` — `devague/frame.py (Vagueness model, set_status)`: Vagueness has fields id/text/kind/claim_id only — no resolved state; add_vagueness appends with a fresh v-id; set_status routes only c*/h* ids, so no existing move can touch a v-id
+  - seeds: `c2`
+- `s2` — `devague/convergence.py (gate + suggest_move)`: only kind unknown_blocking blocks (lines 100-102); suggest_move line 188 recommends 'capture+confirm the answer, or re-park it as non-blocking' — neither branch can clear the blocker: capture+confirm never touches the v-item (confirmed live in issue 45's lobes-cli comment) and re-park appends a new id
+  - seeds: `c3`
+- `s3` — `devague/cli/_commands/park.py + question.py + confirm.py`: park is append-only (cmd_park calls frame.add_vagueness, no flags beyond --kind/--claim); question.py already ships the --resolve/--decision close-out pattern issues 45/57 ask to mirror; confirm.py shows the transactional validate-first, user-only convention the resolve move must follow
+  - seeds: `c4`
+- `s4` — `docs/spec-contract.md (Vagueness entity, Versioning) + devague/frame.py:15,284`: contract lists Vagueness as id/text/kind/claim_id with no resolved state; SCHEMA_VERSION comment says bump when the persisted shape changes incompatibly; Vagueness(**v) in from_dict means new fields crash old binaries — same shape as the v2 scope_entries bump
+  - seeds: `c5`
+- `s5` — `devague/render/spec_md.py:111 + render/frame_md.py:56-60`: frame_md renders all open_vagueness as flat '[kind] text' bullets; spec_md renders only follow_up/out_of_scope kinds — neither has a representation for a resolved item, so rendering is a real decision surface, not free
+  - seeds: `c6`
+- `s6` — `devague/cli/_commands/learn.py + docs/llm-guidance.md + .claude/skills/think/SKILL.md`: all three teach 'park it (blocking or non-blocking)' with no close-out loop; issue 57's interim guidance (prefer question / unknown_nonblocking) exists precisely because the taught path is one-way
+  - seeds: `c7`
+- `s7` — `devague/cli/_commands/plan.py (amend, instruct, depend --remove)`: plan amend exists since 0.18.0 (issue 68) with the demote-to-proposed echo (issue 67) — issue 60's second complaint (task text immutable after plan task) is already fixed; only its vagueness-resolve half remains live
+  - seeds: `c8`
+- `s8` — `issue 20 (no-orchestration boundary) + the four issue reports`: issues 45/55/57/60 each document hand-editing .devague/frames/*.json as the only escape — league-of-agents commit 0c71282 has it in committed history; the fix's job is to make the CLI's own contract satisfiable, keeping the deterministic boundary intact
+  - seeds: `c9`
+- `s9` — `devague/plan.py:60 (PlanRisk) + devague/plan_convergence.py:136,172`: PlanRisk mirrors Vagueness exactly (id/text/kind/task_id, append-only via add_risk, no resolve verb in cli/_commands/plan.py); a blocking plan risk today can only be cleared by covering it with a task — the reclassify/resolve gap is engine-wide, pending the q2 decision
+  - seeds: `c10`
+- `s10` — `tests/ (test_frame.py, test_convergence.py, test_cli_moves.py, test_contract.py, test_store.py)`: existing park/vagueness coverage lives across these five files; issue 45's acceptance criteria (gate stops listing the item, hint names an executable move, save-load round-trip, valid kinds only) map one-to-one onto them, so the fix lands test-first in the same map
+  - seeds: `c2`, `c3`, `c5`
+- `s11` — `devague/plan.py:310 + PLAN_SCHEMA_VERSION (plan.py:30) + plan_store.py fail-closed gate`: plan side round-trips risks via PlanRisk(**r) and fails closed on newer schema_version, exactly like the frame side — the twin fix needs its own 2-to-3 bump and mirrors every frame-side piece
+  - seeds: `c13`
+- `s12` — `challenge pass / adjacent-systems lens: render/deliverables_md.py:72-81 + convergence.py:151 + plan_convergence.py:141`: found two uncovered consumers of open_vagueness/risks beyond the gate and the two renderers the spec already covers: parked_items (status/converge output, both engines) and the deliverables surviving-open-items section — neither was named by any confirmed claim
+  - seeds: `c18`
+- `s13` — `challenge pass / unstated-assumptions lens: issue 45's reclassify ask vs the c11 decision`: the announcement says 'resolved or reclassified' but no confirmed claim states the reclassify path; c11 chose park --resolve with no --kind flag, so reclassify must be resolve+re-park — made this explicit as a proposed assumption instead of leaving it implied
+  - seeds: `c19`
+- `s14` — `challenge pass / reversibility lens: the new resolve transition itself`: resolve is one-way by design; recovery from a mistaken resolve exists through a fresh park, so no unresolve verb is needed — recorded as a proposed non-goal so the boundary is explicit
+  - seeds: `c20`
+- `s15` — `challenge pass / counter-evidence lens: devague/store.py:119-146 fail-closed gate`: verified by reading, not assumed: load raises IncompatibleSchemaError when schema_version exceeds the binary's, and save re-stamps the current version (the comment documents the exact silent-data-loss hazard the re-stamp prevents) — h5's claim holds on the frame side; plan_store mirrors it
+  - seeds: `c5`
+- `s16` — `challenge pass / concurrency lens: devague/store.py + plan_store.py + delivery_store.py`: clean pass — single-writer CLI, atomic-enough small-file writes, no locking today; resolve adds no new concurrent writer; residual risk only if two agents ever drive the same checkout, which is the standing store-wide posture, not new exposure from this change
+- `s17` — `challenge pass / operations lens: mixed-version rollout across downstream repos`: the v2 rollout already produced stale-binary friction reports; v3 repeats that cost by design (fail-closed beats silent data loss) — parked as residual, non-blocking, with the mitigation being the error's own upgrade hint
+
+## Decisions
+
+- user decision (q1, 2026-07-17): the resolve surface is `park --resolve <vN> [--decision "<text>"]` — extend the existing park verb, mirroring `question --resolve`; no new flat verb, no reject-on-v-ids
+- user decision (q2, 2026-07-17): the plan-side twin ships in the same PR — `plan risk --resolve <rN>` gains the same close-out for blocking PlanRisks, keeping the engines structural peers
+- user decision (q3, 2026-07-17): `park --resolve <vN>` requires `--decision "<text>"` — a bare resolve is refused with a hint; an optional `--claim <cN>` links the deciding claim; the plan-side `plan risk --resolve` carries the same bar
+
+## Hard questions
+
+- what does park --resolve do on an already-resolved v-id — refuse with a hint, or no-op idempotently? (decide in the plan; either is defensible, silence is not)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devague"
-version = "0.19.1"
+version = "0.20.0"
 
 description = "devague — turns a vague feature idea into a buildable spec, then a buildable plan."
 readme = "README.md"

--- a/tests/goldens/resolved_vagueness_frame.md
+++ b/tests/goldens/resolved_vagueness_frame.md
@@ -1,0 +1,13 @@
+# Announcement Frame — Resolved Vagueness
+
+slug: `resolved` · status: `drafting`
+
+## Announcement
+
+- Shipped the resolve move
+
+## Open vagueness
+
+- [unknown_blocking] what happens on double resolve — resolved: refuse with a hint, exit 1
+- [unknown_nonblocking] scale unknown
+- [follow_up] follow up on docs — resolved: docs updated in t8

--- a/tests/goldens/resolved_vagueness_spec.md
+++ b/tests/goldens/resolved_vagueness_spec.md
@@ -1,0 +1,8 @@
+# Resolved Vagueness
+
+> Shipped the resolve move
+
+## Resolved vagueness
+
+- [unknown_blocking] what happens on double resolve — resolved: refuse with a hint, exit 1
+- [follow_up] follow up on docs — resolved: docs updated in t8

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -40,6 +40,30 @@ def test_learn_json_includes_assign_to_workforce_section(
     assert "assign_to_workforce" in payload or "assign-to-workforce" in str(payload).lower()
 
 
+def test_learn_names_park_resolve_close_out(capsys: pytest.CaptureFixture[str]) -> None:
+    """`devague learn` names the `park --resolve` close-out move wherever it
+    teaches `park` — the fix for issues 45/55/57/60 (a decided blocking park
+    must not read as a permanent dead end).
+    """
+    rc = main(["learn"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "park --resolve" in out
+    assert "--decision" in out
+
+
+def test_plan_learn_names_risk_resolve_close_out(capsys: pytest.CaptureFixture[str]) -> None:
+    """`devague plan learn` names the `risk --resolve` close-out move — the
+    plan-side twin of `park --resolve`.
+    """
+    rc = main(["plan", "learn"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "--resolve" in out
+    assert "--decision" in out
+    assert "risk" in out
+
+
 # The seven origin skills, in seven-leg workflow order (devague#73).
 SKILL_NAMES = (
     "scope",

--- a/tests/test_cli_moves.py
+++ b/tests/test_cli_moves.py
@@ -162,6 +162,129 @@ def test_park_adds_vagueness(tmp_path, monkeypatch, capsys) -> None:
     assert payload["id"] == "v1"
 
 
+# --- resolve-parked-vagueness t5: park --resolve VID --decision TEXT ----------
+
+
+def test_park_create_path_unchanged_without_json(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()  # drain the "new" output
+    rc = main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "parked v1 (unknown_blocking)"
+
+
+def test_park_bare_without_text_or_resolve_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()  # drain the "new" output
+    rc = main(["park"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no text to park" in err and "--resolve" in err
+
+
+def test_park_create_without_kind_errors(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()  # drain the "new" output
+    rc = main(["park", "scale is unclear"])
+    assert rc == 1
+    assert "--kind" in capsys.readouterr().err
+
+
+def test_park_resolve_marks_resolved_and_echoes_transition(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["park", "--resolve", "v1", "--decision", "cap at 10k"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "v1 -> resolved"
+    f = store.load(store.current_slug())
+    v = f.find_vagueness("v1")
+    assert v.resolved is True
+    assert v.resolution == "cap at 10k"
+
+
+def test_park_resolve_json_parity(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["park", "--resolve", "v1", "--decision", "cap at 10k", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["id"] == "v1"
+    assert payload["resolved"] is True
+    assert payload["resolution"] == "cap at 10k"
+
+
+def test_park_resolve_without_decision_refused_and_persists_nothing(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["park", "--resolve", "v1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--decision" in err and "hint" in err
+    f = store.load(store.current_slug())
+    assert f.find_vagueness("v1").resolved is False
+
+
+def test_park_resolve_unknown_id_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    capsys.readouterr()  # drain the "new" output
+    rc = main(["park", "--resolve", "v9", "--decision", "x"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unknown vagueness" in err and "hint" in err
+
+
+def test_park_resolve_already_resolved_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    main(["park", "--resolve", "v1", "--decision", "cap at 10k"])
+    capsys.readouterr()
+    rc = main(["park", "--resolve", "v1", "--decision", "cap at 20k"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "already" in err and "hint" in err
+    f = store.load(store.current_slug())
+    assert f.find_vagueness("v1").resolution == "cap at 10k"  # untouched
+
+
+def test_park_resolve_with_claim_links_deciding_claim(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)  # announcement = c1
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["park", "--resolve", "v1", "--decision", "cap at 10k", "--claim", "c1"])
+    assert rc == 0
+    f = store.load(store.current_slug())
+    assert f.find_vagueness("v1").resolution_claim_id == "c1"
+
+
+def test_park_resolve_unknown_claim_id_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["park", "--resolve", "v1", "--decision", "cap at 10k", "--claim", "c99"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unknown claim" in err and "hint" in err
+    f = store.load(store.current_slug())
+    assert f.find_vagueness("v1").resolved is False
+
+
+def test_park_positional_text_with_resolve_refused(tmp_path, monkeypatch, capsys) -> None:
+    _seed(monkeypatch, tmp_path)
+    main(["park", "scale is unclear", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["park", "stray text", "--resolve", "v1", "--decision", "cap at 10k"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not both" in err
+    f = store.load(store.current_slug())
+    assert f.find_vagueness("v1").resolved is False
+
+
 def test_show_renders_frame_markdown(tmp_path, monkeypatch, capsys) -> None:
     _seed(monkeypatch, tmp_path)
     rc = main(["show"])

--- a/tests/test_cli_plan.py
+++ b/tests/test_cli_plan.py
@@ -166,6 +166,75 @@ def test_risk_recorded_and_unknown_task_errors(tmp_path, monkeypatch, capsys) ->
     assert "no such task" in capsys.readouterr().err
 
 
+def test_risk_create_path_requires_text_and_kind(tmp_path, monkeypatch, capsys) -> None:
+    """The risk-create path (positional text + --kind, optional --task) is
+    unchanged by adding --resolve/--decision — but --kind is no longer required
+    at the parser level (it must work as an optional so --resolve can omit it),
+    so the handler must refuse a missing --kind on the create path itself."""
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(["plan", "risk", "no kind here"])
+    assert rc == 1
+    assert "--kind" in capsys.readouterr().err
+    assert plan_store.load(slug).risks == []
+
+
+def test_risk_resolve_happy_path_and_json_parity(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "risk", "scaling unknown", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+
+    rc = main(["plan", "risk", "--resolve", "r1", "--decision", "capped at 10k"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "r1" in out and "resolved" in out
+    risk = plan_store.load(slug).find_risk("r1")
+    assert risk.resolved is True
+    assert risk.resolution == "capped at 10k"
+
+    main(["plan", "risk", "another risk", "--kind", "follow_up"])
+    capsys.readouterr()
+    rc = main(["plan", "risk", "--resolve", "r2", "--decision", "deferred", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"id": "r2", "resolved": True, "resolution": "deferred"}
+
+
+def test_risk_resolve_without_decision_refused(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "risk", "scaling unknown", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    rc = main(["plan", "risk", "--resolve", "r1"])
+    assert rc == 1
+    assert "--decision" in capsys.readouterr().err
+    assert plan_store.load(slug).find_risk("r1").resolved is False
+
+
+def test_risk_resolve_unknown_id_refused(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    capsys.readouterr()
+    rc = main(["plan", "risk", "--resolve", "rX", "--decision", "whatever"])
+    assert rc == 1
+    assert "unknown" in capsys.readouterr().err
+
+
+def test_risk_resolve_already_resolved_refused(tmp_path, monkeypatch, capsys) -> None:
+    slug = _converged_frame(monkeypatch, tmp_path)
+    main(["plan", "new", "--frame", slug])
+    main(["plan", "risk", "scaling unknown", "--kind", "unknown_blocking"])
+    capsys.readouterr()
+    main(["plan", "risk", "--resolve", "r1", "--decision", "first decision"])
+    capsys.readouterr()
+    rc = main(["plan", "risk", "--resolve", "r1", "--decision", "second decision"])
+    assert rc == 1
+    assert "already resolved" in capsys.readouterr().err
+    assert plan_store.load(slug).find_risk("r1").resolution == "first decision"
+
+
 # ── converge / export ───────────────────────────────────────────────────────
 def test_converge_reports_then_passes(tmp_path, monkeypatch, capsys) -> None:
     slug = _converged_frame(monkeypatch, tmp_path)

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from devague.convergence import evaluate
+from devague.convergence import evaluate, suggest_move
 from devague.frame import Frame
 
 _REQUIRED_KINDS = (
@@ -95,3 +95,51 @@ def test_structured_result_lists_parked_items() -> None:
     assert res.ready is True
     assert any("follow_up" in p for p in res.parked_items)
     assert res.required_next_moves == []  # nothing left to do
+
+
+# --- resolve-parked-vagueness (t3): resolved items stop blocking/parked ------
+
+
+def test_resolved_blocking_vagueness_no_longer_blocks() -> None:
+    f = _full_frame()
+    v = f.add_vagueness("scale?", "unknown_blocking")
+    f.resolve_vagueness(v.id, "decided: cap at 10k")
+    res = evaluate(f)
+    assert res.ready is True
+    assert not any("blocking vagueness" in m for m in res.blockers)
+    assert res.required_next_moves == []
+
+
+def test_unresolved_blocking_vagueness_still_blocks_alongside_resolved_one() -> None:
+    f = _full_frame()
+    resolved_v = f.add_vagueness("scale?", "unknown_blocking")
+    f.resolve_vagueness(resolved_v.id, "decided: cap at 10k")
+    still_open = f.add_vagueness("auth model?", "unknown_blocking")
+    res = evaluate(f)
+    assert res.ready is False
+    assert any(still_open.id in m for m in res.blockers)
+    assert not any(resolved_v.id in m for m in res.blockers)
+
+
+def test_suggest_move_for_blocking_vagueness_names_park_resolve_verbatim() -> None:
+    hint = suggest_move("blocking vagueness v3 unresolved")
+    assert "devague park --resolve v3" in hint
+    assert "--decision" in hint
+    # the old dead-end hint must be gone
+    assert "re-park it as non-blocking" not in hint
+
+
+def test_parked_items_excludes_resolved_nonblocking_vagueness() -> None:
+    f = _full_frame()
+    v = f.add_vagueness("ship a JSON Schema file?", "follow_up")
+    f.resolve_vagueness(v.id, "decided: yes, ship it")
+    res = evaluate(f)
+    assert res.ready is True
+    assert res.parked_items == []
+
+
+def test_parked_items_still_lists_unresolved_nonblocking_vagueness() -> None:
+    f = _full_frame()
+    f.add_vagueness("ship a JSON Schema file?", "follow_up")
+    res = evaluate(f)
+    assert any("follow_up" in p for p in res.parked_items)

--- a/tests/test_e2e_resolve.py
+++ b/tests/test_e2e_resolve.py
@@ -1,0 +1,218 @@
+"""t9: E2E repro + quality-gate coverage for issue 57's fix — the resolve
+lifecycle driven through the real CLI, both engines (frame side and plan
+side).
+
+Before waves 1-2 landed, a parked ``unknown_blocking`` vagueness (frame side)
+or risk (plan side) could **never** be closed out through a move — the frame
+or plan could not converge again once one existed. ``park --resolve VID
+--decision TEXT [--claim CN]`` and ``plan risk --resolve RID --decision
+TEXT`` are the fix. This test drives ``devague.cli.main`` end to end (mirrors
+the harness in ``tests/test_e2e_sharper_method.py`` and the converging-frame
+helper in ``tests/test_cli_converge_export.py`` / ``tests/test_cli_plan.py``)
+through issue 57's exact repro, asserting the gate blocks before the resolve
+and passes after, with zero direct reads/writes of ``.devague/*.json`` —
+state is only ever inspected via ``store.load`` / ``plan_store.load`` (module
+functions over the JSON, never a raw ``Path(".devague/...")`` open) or CLI
+``--json`` output, matching the "no hand-editing" contract the resolve moves
+exist to uphold.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # noqa: S404 - dev-tooling integration check, not shipped code
+from pathlib import Path
+
+import pytest
+
+from devague import plan_store, store
+from devague.cli import main
+
+_MARKDOWNLINT = shutil.which("markdownlint-cli2")
+_CONFIG = Path(__file__).resolve().parent.parent / ".markdownlint-cli2.yaml"
+
+_REQUIRED_KINDS = ("audience", "after_state", "why_it_matters", "boundary", "success_signal")
+_PLAN_TARGETS = [f"c{i}" for i in range(1, 7)] + [f"h{i}" for i in range(1, 7)]
+
+
+def _json_out(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def _converging_frame(monkeypatch, tmp_path) -> None:
+    """Build a frame that satisfies every required-kind gate check, confirmed
+    with a confirmed honesty condition on each spec-affecting claim — the
+    minimum an issue-57 frame needs so that, once the blocking park is
+    resolved, convergence is blocked by nothing else.
+    """
+    monkeypatch.chdir(tmp_path)
+    assert main(["new", "x", "--title", "x"]) == 0  # c1 announcement, user-origin -> confirmed
+    assert main(["interrogate", "c1", "--honesty", "announcement is true", "--origin", "user"]) == 0
+    for kind in _REQUIRED_KINDS:
+        assert main(["capture", "--kind", kind, f"{kind} text", "--origin", "user"]) == 0
+    frame = store.load(store.current_slug())
+    for c in frame.claims:
+        if c.id == "c1":
+            continue
+        assert main(["interrogate", c.id, "--honesty", "must hold", "--origin", "user"]) == 0
+
+
+def test_e2e_issue57_frame_park_resolve_lifecycle(tmp_path, monkeypatch, capsys) -> None:
+    """Frame side: park a blocking unknown, capture the deciding claim,
+    resolve the park with --decision/--claim, converge, export — the exact
+    issue-57 repro quoted in the plan brief, driven only through moves.
+    """
+    _converging_frame(monkeypatch, tmp_path)
+
+    # The frame would already converge but for the park below — prove the
+    # park is what blocks it (not a hole in the fixture).
+    capsys.readouterr()
+    assert main(["converge", "--json"]) == 0
+    assert _json_out(capsys)["ready_for_spec"] is True
+
+    # --- issue 57 repro -----------------------------------------------------
+    assert main(["park", "temporarily unknown", "--kind", "unknown_blocking"]) == 0  # v1
+
+    capsys.readouterr()
+    assert main(["converge", "--json"]) == 0
+    verdict = _json_out(capsys)
+    assert verdict["ready_for_spec"] is False
+    assert any("v1" in b and "vagueness" in b for b in verdict["blockers"])
+
+    assert (
+        main(["capture", "--kind", "decision", "decided: the answer is 42", "--origin", "user"])
+        == 0
+    )
+    frame = store.load(store.current_slug())
+    decision_claim_id = next(c.id for c in frame.claims if c.kind == "decision")
+
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "park",
+                "--resolve",
+                "v1",
+                "--decision",
+                "decided: the answer is 42",
+                "--claim",
+                decision_claim_id,
+            ]
+        )
+        == 0
+    )
+    assert "v1 -> resolved" in capsys.readouterr().out
+
+    # converge must now pass — the resolved park no longer blocks.
+    capsys.readouterr()
+    assert main(["converge", "--json"]) == 0
+    verdict = _json_out(capsys)
+    assert verdict["ready_for_spec"] is True
+
+    # export writes the spec, which renders the resolved item verbatim.
+    assert main(["export"]) == 0
+    frame = store.load(store.current_slug())
+    spec_path = Path("docs/specs") / f"{frame.created[:10]}-{frame.slug}.md"
+    assert spec_path.exists()
+    spec_md = spec_path.read_text(encoding="utf-8")
+    assert "## Resolved vagueness" in spec_md
+    assert (
+        "- [unknown_blocking] temporarily unknown — resolved: decided: the answer is 42" in spec_md
+    )
+
+
+def test_e2e_issue57_frame_export_passes_markdownlint(tmp_path, monkeypatch, capsys) -> None:
+    """The resolved-vagueness section renders through the same real
+    markdownlint-cli2 gate the repo's own dev tooling uses (mirrors
+    tests/test_export_markdownlint_integration.py); skips cleanly when the
+    binary is absent from PATH, matching that test's pattern.
+    """
+    if _MARKDOWNLINT is None:
+        pytest.skip("markdownlint-cli2 not on PATH (dev tooling; not installed by this repo's CI)")
+
+    _converging_frame(monkeypatch, tmp_path)
+    assert (
+        main(
+            ["park", "temporarily unknown, see https://example.com.", "--kind", "unknown_blocking"]
+        )
+        == 0
+    )
+    assert (
+        main(["capture", "--kind", "decision", "decided: the answer is 42", "--origin", "user"])
+        == 0
+    )
+    frame = store.load(store.current_slug())
+    decision_claim_id = next(c.id for c in frame.claims if c.kind == "decision")
+    assert (
+        main(
+            [
+                "park",
+                "--resolve",
+                "v1",
+                "--decision",
+                "decided: the answer is 42, see https://example.com.",
+                "--claim",
+                decision_claim_id,
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert main(["converge", "--json"]) == 0
+    assert _json_out(capsys)["ready_for_spec"] is True
+
+    assert main(["export"]) == 0
+    frame = store.load(store.current_slug())
+    spec_path = Path("docs/specs") / f"{frame.created[:10]}-{frame.slug}.md"
+    assert spec_path.exists()
+
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [_MARKDOWNLINT, "--config", str(_CONFIG), str(spec_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_e2e_issue57_plan_risk_resolve_lifecycle(tmp_path, monkeypatch, capsys) -> None:
+    """Plan side twin: an unknown_blocking risk blocks plan convergence until
+    ``plan risk --resolve RID --decision TEXT`` closes it out — the same
+    lifecycle as the frame side, on the plan engine's structural peer.
+    """
+    _converging_frame(monkeypatch, tmp_path)
+    slug = store.current_slug()
+
+    assert main(["plan", "new", "--frame", slug]) == 0
+    args = ["plan", "task", "cover everything", "--accept", "all targets satisfied"]
+    for target in _PLAN_TARGETS:
+        args += ["--covers", target]
+    assert main(args) == 0
+
+    # plan would already converge but for the risk below.
+    capsys.readouterr()
+    assert main(["plan", "converge", "--json"]) == 0
+    assert _json_out(capsys)["ready_for_plan"] is True
+
+    assert main(["plan", "risk", "scope is unclear", "--kind", "unknown_blocking"]) == 0  # r1
+
+    capsys.readouterr()
+    assert main(["plan", "converge", "--json"]) == 0
+    verdict = _json_out(capsys)
+    assert verdict["ready_for_plan"] is False
+    assert any("r1" in b and "risk" in b for b in verdict["blockers"])
+
+    capsys.readouterr()
+    assert main(["plan", "risk", "--resolve", "r1", "--decision", "scope is the whole repo"]) == 0
+    assert "r1 -> resolved" in capsys.readouterr().out
+
+    capsys.readouterr()
+    assert main(["plan", "converge", "--json"]) == 0
+    verdict = _json_out(capsys)
+    assert verdict["ready_for_plan"] is True
+
+    assert main(["plan", "export"]) == 0
+    plan = plan_store.load(slug)
+    plan_path = Path("docs/plans") / f"{plan.created[:10]}-{slug}.md"
+    assert plan_path.exists()

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -49,9 +49,12 @@ def test_roundtrip_to_from_dict() -> None:
     f.add_honesty(c, "cond")
     f.add_hard_question(c, "q?", blocking=True)
     f.add_vagueness("v", "follow_up", claim_id="c1")
+    f.resolve_vagueness("v1", "decided: ship v1", claim_id="c1")
     f2 = from_dict(to_dict(f))
     assert to_dict(f2) == to_dict(f)
     assert f2.claims[0].honesty_conditions[0].text == "cond"
+    assert f2.open_vagueness[0].resolved is True
+    assert f2.open_vagueness[0].resolution_claim_id == "c1"
 
 
 # --- #5 spec contract: enriched entity model ----------------------------------
@@ -177,3 +180,73 @@ def test_legacy_v2_vagueness_without_resolved_keys_defaults() -> None:
     f = from_dict(d)
     assert f.open_vagueness[0].resolved is False
     assert f.open_vagueness[0].resolution == ""
+
+
+# --- resolve-parked-vagueness t5: deciding-claim link on resolve --------------
+
+
+def test_vagueness_gains_resolution_claim_id_default() -> None:
+    v = Vagueness(id="v1", text="x", kind="follow_up", claim_id="c1")
+    assert v.resolution_claim_id is None
+
+
+def test_resolve_vagueness_records_deciding_claim() -> None:
+    f = Frame(slug="s", title="t")
+    f.add_claim("announcement", "x", origin="user")  # c1
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    resolved = f.resolve_vagueness("v1", "decided: cap at 10k", claim_id="c1")
+    assert resolved.resolution_claim_id == "c1"
+    assert f.open_vagueness[0].resolution_claim_id == "c1"
+
+
+def test_resolve_vagueness_without_claim_id_leaves_it_none() -> None:
+    f = Frame(slug="s", title="t")
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    resolved = f.resolve_vagueness("v1", "decided: cap at 10k")
+    assert resolved.resolution_claim_id is None
+
+
+def test_resolve_vagueness_claim_id_does_not_overwrite_owning_claim_id() -> None:
+    # claim_id is the *owning* claim set at park time; resolution_claim_id is
+    # the *deciding* claim recorded at resolve time — resolve must not clobber
+    # the former with the latter.
+    f = Frame(slug="s", title="t")
+    f.add_claim("announcement", "x", origin="user")  # c1
+    f.add_claim("audience", "devs", origin="user")  # c2
+    f.add_vagueness("unsure about scale", "unknown_blocking", claim_id="c1")
+    resolved = f.resolve_vagueness("v1", "decided: cap at 10k", claim_id="c2")
+    assert resolved.claim_id == "c1"
+    assert resolved.resolution_claim_id == "c2"
+
+
+def test_resolve_vagueness_unknown_claim_id_raises() -> None:
+    f = Frame(slug="s", title="t")
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    with pytest.raises(ValueError, match="unknown claim"):
+        f.resolve_vagueness("v1", "decided", claim_id="c99")
+    # Fails closed before mutating: the vagueness stays unresolved.
+    assert f.open_vagueness[0].resolved is False
+
+
+def test_legacy_v3_vagueness_without_resolution_claim_id_defaults() -> None:
+    # An early-v3 frame's open_vagueness entries (t1) predate resolution_claim_id.
+    d = {
+        "slug": "s",
+        "title": "t",
+        "schema_version": 3,
+        "claims": [],
+        "open_vagueness": [
+            {
+                "id": "v1",
+                "text": "x",
+                "kind": "follow_up",
+                "claim_id": None,
+                "resolved": True,
+                "resolution": "done",
+            }
+        ],
+    }
+    f = from_dict(d)
+    assert f.open_vagueness[0].resolved is True
+    assert f.open_vagueness[0].resolution == "done"
+    assert f.open_vagueness[0].resolution_claim_id is None

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -116,3 +116,64 @@ def test_dataclasses_validate_enums() -> None:
         Vagueness(id="v1", text="x", kind="nope")
     with pytest.raises(ValueError):
         HonestyCondition(id="h1", text="x", status="weird")
+
+
+# --- resolve-parked-vagueness t1: Vagueness resolution state (schema v3) ------
+
+
+def test_schema_version_is_3() -> None:
+    assert SCHEMA_VERSION == 3
+
+
+def test_vagueness_gains_resolved_and_resolution_defaults() -> None:
+    v = Vagueness(id="v1", text="x", kind="follow_up", claim_id="c1")
+    assert v.resolved is False
+    assert v.resolution == ""
+    assert (v.id, v.text, v.kind, v.claim_id) == ("v1", "x", "follow_up", "c1")
+
+
+def test_resolve_vagueness_marks_resolved_and_records_resolution() -> None:
+    f = Frame(slug="s", title="t")
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    resolved = f.resolve_vagueness("v1", "decided: cap at 10k")
+    assert resolved.resolved is True
+    assert resolved.resolution == "decided: cap at 10k"
+    assert f.open_vagueness[0].resolved is True
+    assert f.open_vagueness[0].resolution == "decided: cap at 10k"
+
+
+def test_resolve_vagueness_unknown_id_raises() -> None:
+    f = Frame(slug="s", title="t")
+    with pytest.raises(ValueError, match="unknown"):
+        f.resolve_vagueness("v99", "decision")
+
+
+def test_resolve_vagueness_already_resolved_raises() -> None:
+    f = Frame(slug="s", title="t")
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    f.resolve_vagueness("v1", "decision one")
+    with pytest.raises(ValueError, match="already"):
+        f.resolve_vagueness("v1", "decision two")
+
+
+def test_set_status_does_not_touch_vagueness() -> None:
+    # v-ids stay out of confirm/reject (decision c11) — set_status must not
+    # find or mutate a Vagueness by id.
+    f = Frame(slug="s", title="t")
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    assert f.set_status("v1", "confirmed") is False
+    assert f.open_vagueness[0].resolved is False
+
+
+def test_legacy_v2_vagueness_without_resolved_keys_defaults() -> None:
+    # A v2 frame's open_vagueness entries predate resolved/resolution.
+    d = {
+        "slug": "s",
+        "title": "t",
+        "schema_version": 2,
+        "claims": [],
+        "open_vagueness": [{"id": "v1", "text": "x", "kind": "follow_up", "claim_id": None}],
+    }
+    f = from_dict(d)
+    assert f.open_vagueness[0].resolved is False
+    assert f.open_vagueness[0].resolution == ""

--- a/tests/test_frame_schema_v2.py
+++ b/tests/test_frame_schema_v2.py
@@ -24,7 +24,10 @@ from devague.frame import (
 
 
 def test_schema_version_bumped_exactly_once() -> None:
-    assert SCHEMA_VERSION == 2
+    # Pinned at 2 when this file was written (#53 t1); a later legitimate bump
+    # (resolve-parked-vagueness t1, v3: Vagueness.resolved/resolution) moves
+    # this pin forward rather than leaving a stale, now-false assertion.
+    assert SCHEMA_VERSION == 3
 
 
 def test_claim_and_honesty_instruction_default_empty() -> None:

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -61,6 +61,45 @@ def test_add_risk_rejects_unknown_kind() -> None:
         p.add_risk("bad", "not_a_kind")
 
 
+def test_risk_resolved_resolution_default() -> None:
+    p = _plan()
+    r = p.add_risk("scope?", "unknown_blocking")
+    assert r.resolved is False
+    assert r.resolution == ""
+
+
+def test_find_risk_and_reports_unknown() -> None:
+    p = _plan()
+    r = p.add_risk("scope?", "unknown_blocking")
+    assert p.find_risk(r.id) is r
+    assert p.find_risk("rX") is None
+
+
+def test_resolve_risk_marks_resolved_and_records_resolution() -> None:
+    p = _plan()
+    r = p.add_risk("scope?", "unknown_blocking")
+    resolved = p.resolve_risk(r.id, "decided: ship option B")
+    assert resolved is r
+    assert r.resolved is True
+    assert r.resolution == "decided: ship option B"
+    # id/text/kind/task_id are untouched by resolving.
+    assert (r.text, r.kind, r.task_id) == ("scope?", "unknown_blocking", None)
+
+
+def test_resolve_risk_rejects_unknown_id() -> None:
+    p = _plan()
+    with pytest.raises(ValueError):
+        p.resolve_risk("rX", "decided")
+
+
+def test_resolve_risk_rejects_already_resolved() -> None:
+    p = _plan()
+    r = p.add_risk("scope?", "unknown_blocking")
+    p.resolve_risk(r.id, "first decision")
+    with pytest.raises(ValueError):
+        p.resolve_risk(r.id, "second decision")
+
+
 def test_set_status_transitions_and_reports_unknown() -> None:
     p = _plan()
     p.add_task("x")
@@ -76,9 +115,10 @@ def test_plan_carries_schema_version() -> None:
     assert from_dict(to_dict(p)).schema_version == PLAN_SCHEMA_VERSION
 
 
-def test_plan_schema_version_bumped_to_2_for_instruction_field() -> None:
-    # #53 t2: the instruction field bumps the persisted plan shape exactly once.
-    assert PLAN_SCHEMA_VERSION == 2
+def test_plan_schema_version_bumped_to_3_for_resolution_field() -> None:
+    # resolve-parked-vagueness t2: PlanRisk.resolved/resolution bumps the persisted
+    # plan shape exactly once (the plan-side twin of frame.SCHEMA_VERSION 2 -> 3).
+    assert PLAN_SCHEMA_VERSION == 3
 
 
 def test_legacy_plan_without_schema_version_loads() -> None:
@@ -112,6 +152,31 @@ def test_legacy_v1_task_dict_without_instruction_loads_with_empty_default() -> N
     }
     p = from_dict(legacy)
     assert p.find_task("t1").instruction == ""
+
+
+def test_legacy_v2_risk_dict_without_resolution_fields_loads_with_defaults() -> None:
+    # A schema_version-2 plan's risk dicts predate resolved/resolution entirely.
+    legacy = {
+        "slug": "s",
+        "title": "t",
+        "frame_slug": "s",
+        "schema_version": 2,
+        "risks": [{"id": "r1", "text": "scope?", "kind": "unknown_blocking", "task_id": None}],
+    }
+    p = from_dict(legacy)
+    r = p.find_risk("r1")
+    assert r.resolved is False
+    assert r.resolution == ""
+
+
+def test_risk_resolution_roundtrips_verbatim() -> None:
+    p = _plan()
+    r = p.add_risk("scope?", "unknown_blocking")
+    p.resolve_risk(r.id, "decided: ship option B")
+    restored = from_dict(to_dict(p))
+    restored_risk = restored.find_risk(r.id)
+    assert restored_risk.resolved is True
+    assert restored_risk.resolution == "decided: ship option B"
 
 
 def test_dataclasses_validate_enums() -> None:
@@ -150,7 +215,8 @@ def test_roundtrip_preserves_nested_fields() -> None:
     p.add_dep(t, "t9")
     p.add_cover(t, "h2")
     t.instruction = "verify against acceptance criteria before merge"
-    p.add_risk("scope?", "unknown_blocking", task_id="t1")
+    r = p.add_risk("scope?", "unknown_blocking", task_id="t1")
+    p.resolve_risk(r.id, "decided: covered by t1's acceptance criteria")
     p.targets.append(targets_from_frame(_seed_frame())[0])
     restored = from_dict(to_dict(p))
     assert restored == p

--- a/tests/test_plan_convergence.py
+++ b/tests/test_plan_convergence.py
@@ -435,12 +435,12 @@ def test_resolved_blocking_risk_does_not_appear_in_required_next_moves() -> None
 
 
 def test_blocking_risk_hint_names_executable_resolve_syntax() -> None:
-    """The blocking-risk hint at plan_convergence.py:172 names the executable
-    ``plan risk --resolve`` syntax verbatim (t4 AC2): ``plan risk --resolve RID
-    --decision TEXT`` (uppercase placeholders, mirroring t3's frame-side hint).
+    """The blocking-risk hint names the executable ``plan risk --resolve``
+    syntax with the actual risk id interpolated (t4 AC2), mirroring t3's
+    frame-side ``park --resolve v1 --decision "<the decision>"`` hint shape.
     """
     hint = suggest_move("blocking risk r1 unresolved")
-    assert "plan risk --resolve RID --decision TEXT" in hint
+    assert 'devague plan risk --resolve r1 --decision "<the decision>"' in hint
 
 
 def test_blocking_risk_hint_end_to_end_via_evaluate() -> None:
@@ -448,7 +448,7 @@ def test_blocking_risk_hint_end_to_end_via_evaluate() -> None:
     p = _converging()
     p.add_risk("scope unclear", "unknown_blocking")
     res = evaluate(p)
-    assert any("plan risk --resolve RID --decision TEXT" in m for m in res.required_next_moves)
+    assert any("plan risk --resolve r1 --decision" in m for m in res.required_next_moves)
 
 
 def test_resolved_risk_excluded_from_parked_items() -> None:

--- a/tests/test_plan_convergence.py
+++ b/tests/test_plan_convergence.py
@@ -11,7 +11,7 @@ These tests cover:
 from __future__ import annotations
 
 from devague.plan import CoverageTarget, Plan, Task, dependency_waves
-from devague.plan_convergence import evaluate
+from devague.plan_convergence import evaluate, suggest_move
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -401,3 +401,62 @@ def test_ready_for_plan_unchanged_by_warnings_only() -> None:
     assert any("serial" in w.lower() or "parallel" in w.lower() for w in res.warnings)
     # blockers empty
     assert res.blockers == []
+
+
+# ── blocking risk resolution (resolve-parked-vagueness t4, mirrors t3) ─────────
+
+
+def test_unresolved_blocking_risk_blocks_convergence() -> None:
+    """Baseline: an unresolved unknown_blocking risk still blocks convergence."""
+    p = _converging()
+    p.add_risk("scope unclear", "unknown_blocking")
+    res = evaluate(p)
+    assert res.ready is False
+    assert any("blocking risk r1" in b for b in res.blockers)
+
+
+def test_resolved_blocking_risk_no_longer_blocks_convergence() -> None:
+    """A resolved unknown_blocking risk must not block plan convergence (t4 AC1)."""
+    p = _converging()
+    r = p.add_risk("scope unclear", "unknown_blocking")
+    p.resolve_risk(r.id, "decided: ship option B")
+    res = evaluate(p)
+    assert res.ready is True, f"expected convergence; blockers: {res.blockers}"
+    assert not any("blocking risk" in b for b in res.blockers)
+
+
+def test_resolved_blocking_risk_does_not_appear_in_required_next_moves() -> None:
+    """A resolved risk generates no follow-up hint since it is no longer a blocker."""
+    p = _converging()
+    r = p.add_risk("scope unclear", "unknown_blocking")
+    p.resolve_risk(r.id, "decided: ship option B")
+    res = evaluate(p)
+    assert not any("risk" in m for m in res.required_next_moves)
+
+
+def test_blocking_risk_hint_names_executable_resolve_syntax() -> None:
+    """The blocking-risk hint at plan_convergence.py:172 names the executable
+    ``plan risk --resolve`` syntax verbatim (t4 AC2): ``plan risk --resolve RID
+    --decision TEXT`` (uppercase placeholders, mirroring t3's frame-side hint).
+    """
+    hint = suggest_move("blocking risk r1 unresolved")
+    assert "plan risk --resolve RID --decision TEXT" in hint
+
+
+def test_blocking_risk_hint_end_to_end_via_evaluate() -> None:
+    """The same executable-syntax hint surfaces through evaluate()'s required_next_moves."""
+    p = _converging()
+    p.add_risk("scope unclear", "unknown_blocking")
+    res = evaluate(p)
+    assert any("plan risk --resolve RID --decision TEXT" in m for m in res.required_next_moves)
+
+
+def test_resolved_risk_excluded_from_parked_items() -> None:
+    """Plan-side _parked_items excludes resolved risks (t4 AC3)."""
+    p = _converging()
+    r = p.add_risk("a non-blocking risk", "unknown_nonblocking")
+    res = evaluate(p)
+    assert any("a non-blocking risk" in item for item in res.parked_items)
+    p.resolve_risk(r.id, "decided: not an issue")
+    res2 = evaluate(p)
+    assert not any("a non-blocking risk" in item for item in res2.parked_items)

--- a/tests/test_plan_deliverables.py
+++ b/tests/test_plan_deliverables.py
@@ -129,6 +129,53 @@ def test_render_deliverables_open_items_excludes_blocking() -> None:
     assert "a blocking risk" not in out
 
 
+# ── resolve-parked-vagueness (#53-esd t7): surviving-open-items excludes ─────
+# resolved frame vagueness and resolved plan risks ───────────────────────────
+
+
+def test_render_deliverables_open_items_excludes_resolved_vagueness_and_risk() -> None:
+    frame = _frame_with_world_after()
+    plan = _plan_with_tasks()
+    v = next(v for v in frame.open_vagueness if v.kind == "unknown_nonblocking")
+    frame.resolve_vagueness(v.id, "decided: acceptable for v1")
+    r = next(r for r in plan.risks if r.kind == "unknown_nonblocking")
+    plan.resolve_risk(r.id, "mitigated by t2's retry logic")
+
+    out = render_deliverables(plan, frame, converged=True)
+    # both surviving non-blocking items are now resolved — nothing left to show.
+    assert "## Open items" not in out
+    assert "scale unknown" not in out
+    assert "perf unknown" not in out
+
+
+def test_render_deliverables_open_items_partial_resolution_keeps_unresolved() -> None:
+    frame = _frame_with_world_after()
+    plan = _plan_with_tasks()
+    v = next(v for v in frame.open_vagueness if v.kind == "unknown_nonblocking")
+    frame.resolve_vagueness(v.id, "decided: acceptable for v1")
+    # the plan risk stays unresolved.
+
+    out = render_deliverables(plan, frame, converged=True)
+    assert "## Open items" in out
+    assert "scale unknown" not in out  # resolved frame vagueness — excluded
+    assert "[unknown_nonblocking] perf unknown" in out  # unresolved risk — still shown
+
+
+def test_render_deliverables_resolved_blocking_items_still_excluded() -> None:
+    # A resolved unknown_blocking item was already excluded by kind alone; confirm
+    # resolving it doesn't somehow surface it (it must stay excluded either way).
+    frame = _frame_with_world_after()
+    plan = _plan_with_tasks()
+    blocker = next(v for v in frame.open_vagueness if v.kind == "unknown_blocking")
+    frame.resolve_vagueness(blocker.id, "decided: not a real blocker after all")
+    risk_blocker = next(r for r in plan.risks if r.kind == "unknown_blocking")
+    plan.resolve_risk(risk_blocker.id, "decided: mitigated")
+
+    out = render_deliverables(plan, frame, converged=True)
+    assert "a real blocker" not in out
+    assert "a blocking risk" not in out
+
+
 def test_render_deliverables_banner_when_not_converged() -> None:
     out = render_deliverables(_plan_with_tasks(), _frame_with_world_after(), converged=False)
     lines = out.splitlines()

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -125,6 +125,39 @@ def test_save_load_roundtrips_task_instruction_verbatim(tmp_path, monkeypatch) -
     assert loaded.find_task("t1").instruction == "write the failing test before the fix"
 
 
+def test_save_load_roundtrips_resolved_risk(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    p = _plan()
+    r = p.add_risk("scope?", "unknown_blocking")
+    p.resolve_risk(r.id, "decided: proceed with option B")
+    plan_store.save(p)
+    loaded = plan_store.load("demo")
+    loaded_risk = loaded.find_risk(r.id)
+    assert loaded_risk.resolved is True
+    assert loaded_risk.resolution == "decided: proceed with option B"
+
+
+def test_load_v2_plan_with_risk_but_no_resolution_fields(tmp_path, monkeypatch) -> None:
+    # resolve-parked-vagueness t2: a pre-existing (schema_version 2) plan predates
+    # PlanRisk.resolved/resolution entirely — it must still load, defaulting both.
+    monkeypatch.chdir(tmp_path)
+    plan_store.PLANS_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "slug": "demo",
+        "title": "Demo",
+        "frame_slug": "demo",
+        "schema_version": 2,
+        "tasks": [],
+        "risks": [{"id": "r1", "text": "scope?", "kind": "unknown_blocking", "task_id": None}],
+    }
+    plan_store.path_for("demo").write_text(json.dumps(legacy), encoding="utf-8")
+    loaded = plan_store.load("demo")
+    assert loaded.schema_version == 2
+    r = loaded.find_risk("r1")
+    assert r.resolved is False
+    assert r.resolution == ""
+
+
 def test_load_rejects_slug_mismatch(tmp_path, monkeypatch) -> None:
     # A file under demo.json whose internal slug is a *different* valid slug must
     # be rejected, so a later save() can't be redirected onto another plan.
@@ -149,4 +182,4 @@ def test_save_upgrades_stale_schema_version_on_write(tmp_path, monkeypatch) -> N
     plan_store.save(p)
     assert plan_store.load("demo").schema_version == PLAN_SCHEMA_VERSION
     raw = json.loads(plan_store.path_for("demo").read_text(encoding="utf-8"))
-    assert raw["schema_version"] == 2
+    assert raw["schema_version"] == PLAN_SCHEMA_VERSION

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import shutil
+import subprocess  # noqa: S404 - dev-tooling integration check, not shipped code
+from pathlib import Path
+
 import pytest
 
 from devague import render
@@ -232,3 +236,150 @@ def test_spec_md_does_not_mutate_frame_claim_text() -> None:
     after = [c.text for c in frame.claims]
     assert before == after
     assert frame.title == "League of Agents is live at https://league-of-agents.ai."
+
+
+# ── resolve-parked-vagueness (#53-esd t7): resolved items render with their ──
+# resolution; deliverables excludes them from surviving open items ───────────
+
+GOLDENS = Path(__file__).parent / "goldens"
+
+
+def _resolved_vagueness_frame() -> Frame:
+    """A frame with open + resolved vagueness across multiple kinds — a
+    resolved unknown_blocking (the exact issue-45/57 shape), a still-open
+    unknown_nonblocking, and a resolved follow_up (previously the only kind
+    spec_md rendered at all).
+    """
+    f = Frame(slug="resolved", title="Resolved Vagueness")
+    f.add_claim("announcement", "Shipped the resolve move", origin="user")
+    blocking = f.add_vagueness("what happens on double resolve", "unknown_blocking")
+    f.resolve_vagueness(blocking.id, "refuse with a hint, exit 1")
+    f.add_vagueness("scale unknown", "unknown_nonblocking")  # stays open
+    follow_up = f.add_vagueness("follow up on docs", "follow_up")
+    f.resolve_vagueness(follow_up.id, "docs updated in t8")
+    return f
+
+
+def test_frame_md_renders_resolved_vagueness_with_resolution_verbatim() -> None:
+    out = render.render(_resolved_vagueness_frame(), "frame-md")
+    assert "## Open vagueness" in out
+    assert (
+        "- [unknown_blocking] what happens on double resolve"
+        " — resolved: refuse with a hint, exit 1" in out
+    )
+    assert "- [follow_up] follow up on docs — resolved: docs updated in t8" in out
+
+
+def test_frame_md_still_open_item_carries_no_resolved_marker() -> None:
+    out = render.render(_resolved_vagueness_frame(), "frame-md")
+    lines = out.splitlines()
+    idx = lines.index("- [unknown_nonblocking] scale unknown")
+    assert "resolved" not in lines[idx]
+
+
+def test_frame_md_resolved_vagueness_is_markdownlint_clean() -> None:
+    assert_markdownlint_clean(render.render(_resolved_vagueness_frame(), "frame-md"))
+
+
+def test_spec_md_renders_resolved_vagueness_section_with_resolution_verbatim() -> None:
+    out = render.render(_resolved_vagueness_frame(), "spec-md")
+    assert "## Resolved vagueness" in out
+    assert (
+        "- [unknown_blocking] what happens on double resolve"
+        " — resolved: refuse with a hint, exit 1" in out
+    )
+    assert "- [follow_up] follow up on docs — resolved: docs updated in t8" in out
+
+
+def test_spec_md_resolved_follow_up_is_excluded_from_open_follow_up_section() -> None:
+    # The only vagueness item of kind follow_up/out_of_scope is resolved — the
+    # "Open / follow-up" section must not fabricate it as still open.
+    out = render.render(_resolved_vagueness_frame(), "spec-md")
+    assert "## Open / follow-up" not in out
+
+
+def test_spec_md_still_open_nonblocking_park_stays_unlisted() -> None:
+    # Unchanged pre-existing behavior: spec_md never rendered unknown_blocking/
+    # unknown_nonblocking kinds unless resolved — the still-open nonblocking
+    # item here has no resolution, so it stays absent from the exported spec.
+    out = render.render(_resolved_vagueness_frame(), "spec-md")
+    assert "scale unknown" not in out
+
+
+def test_spec_md_resolved_vagueness_is_markdownlint_clean() -> None:
+    assert_markdownlint_clean(render.render(_resolved_vagueness_frame(), "spec-md"))
+
+
+def test_spec_md_wraps_bare_url_in_resolved_vagueness_resolution() -> None:
+    f = Frame(slug="urlres", title="URL Resolution")
+    v = f.add_vagueness("check this later", "follow_up")
+    f.resolve_vagueness(v.id, "see https://example.com/decision for the writeup")
+    out = render.render(f, "spec-md")
+    assert (
+        "- [follow_up] check this later"
+        " — resolved: see <https://example.com/decision> for the writeup" in out
+    )
+
+
+def test_frame_md_resolved_item_with_empty_resolution_renders_no_marker() -> None:
+    # Never fabricate: a resolved flag with no resolution text (a malformed
+    # record — the CLI resolve move always requires --decision) must not
+    # produce a dangling "— resolved:" with nothing after it.
+    f = Frame(slug="edge", title="Edge")
+    v = f.add_vagueness("mystery", "unknown_nonblocking")
+    v.resolved = True
+    out = render.render(f, "frame-md")
+    assert "- [unknown_nonblocking] mystery" in out
+    assert "resolved:" not in out
+
+
+def test_spec_md_resolved_item_with_empty_resolution_is_omitted() -> None:
+    f = Frame(slug="edge2", title="Edge2")
+    v = f.add_vagueness("mystery2", "unknown_blocking")
+    v.resolved = True
+    out = render.render(f, "spec-md")
+    assert "## Resolved vagueness" not in out
+    assert "mystery2" not in out
+
+
+def test_spec_md_omits_resolved_vagueness_section_when_none_resolved() -> None:
+    out = render.render(_frame(), "spec-md")
+    assert "## Resolved vagueness" not in out
+
+
+def test_golden_resolved_vagueness_frame_md() -> None:
+    expected = (GOLDENS / "resolved_vagueness_frame.md").read_text(encoding="utf-8")
+    assert render.render(_resolved_vagueness_frame(), "frame-md") == expected
+
+
+def test_golden_resolved_vagueness_spec_md() -> None:
+    expected = (GOLDENS / "resolved_vagueness_spec.md").read_text(encoding="utf-8")
+    assert render.render(_resolved_vagueness_frame(), "spec-md") == expected
+
+
+# ── real markdownlint-cli2 check on a resolved blocking park (AC1's ──────────
+# "an exported spec from a frame with a resolved blocking park passes
+# markdownlint" honesty condition) — driven at the renderer level directly,
+# since the convergence-gate skip for resolved items (t3/t4) is a later,
+# parallel task this one does not depend on; devague export's CLI-level gate
+# is out of scope here. Skips cleanly when the binary is not on PATH, mirroring
+# tests/test_export_markdownlint_integration.py.
+_MARKDOWNLINT = shutil.which("markdownlint-cli2")
+_MD_CONFIG = Path(__file__).resolve().parent.parent / ".markdownlint-cli2.yaml"
+
+
+@pytest.mark.skipif(
+    _MARKDOWNLINT is None,
+    reason="markdownlint-cli2 not on PATH (dev tooling; not installed by this repo's CI)",
+)
+def test_resolved_blocking_park_spec_passes_real_markdownlint_cli2(tmp_path: Path) -> None:
+    out = render.render(_resolved_vagueness_frame(), "spec-md")
+    spec_path = tmp_path / "resolved-blocking-park.md"
+    spec_path.write_text(out, encoding="utf-8")
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only
+        [_MARKDOWNLINT, "--config", str(_MD_CONFIG), str(spec_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -132,4 +132,35 @@ def test_save_upgrades_stale_schema_version_on_write(tmp_path, monkeypatch) -> N
     store.save(f)
     assert store.load("demo").schema_version == SCHEMA_VERSION
     raw = json.loads(store.path_for("demo").read_text(encoding="utf-8"))
-    assert raw["schema_version"] == 2
+    assert raw["schema_version"] == SCHEMA_VERSION
+
+
+# --- resolve-parked-vagueness t1: Vagueness resolution state (schema v3) ------
+
+
+def test_save_load_roundtrip_resolved_vagueness_identical(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    f = Frame(slug="demo", title="Demo")
+    f.add_vagueness("unsure about scale", "unknown_blocking")
+    f.resolve_vagueness("v1", "decided: cap at 10k")
+    store.save(f)
+    loaded = store.load("demo")
+    assert to_dict(loaded) == to_dict(f)
+    assert loaded.open_vagueness[0].resolved is True
+    assert loaded.open_vagueness[0].resolution == "decided: cap at 10k"
+
+
+def test_load_legacy_v2_vagueness_defaults_resolved_fields(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store.FRAMES_DIR.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "slug": "demo",
+        "title": "Demo",
+        "schema_version": 2,
+        "claims": [],
+        "open_vagueness": [{"id": "v1", "text": "x", "kind": "follow_up", "claim_id": None}],
+    }
+    store.path_for("demo").write_text(json.dumps(legacy), encoding="utf-8")
+    loaded = store.load("demo")
+    assert loaded.open_vagueness[0].resolved is False
+    assert loaded.open_vagueness[0].resolution == ""

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "devague"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What ships

The close-out for parked vagueness, on both engines (0.20.0):

- **`devague park --resolve <vN> --decision "<text>" [--claim <cN>]`** — a decided blocking park resolves through a CLI move: the item stays on the record with its resolution text (and optionally the deciding claim via the new `resolution_claim_id`), drops out of the convergence gate and `parked_items`, and renders under a `## Resolved vagueness` section in exported specs. A bare `--resolve` without `--decision` is refused (evidence-bearing close-out); unknown and already-resolved ids are refused fail-closed.
- **`devague plan risk --resolve <rN> --decision "<text>"`** — the plan-side twin for blocking `PlanRisk`s.
- Frame `SCHEMA_VERSION` and `PLAN_SCHEMA_VERSION` bump 2 → 3; older binaries fail closed on v3 artifacts with the existing upgrade hint, v2 artifacts load with defaults.
- The blocking-vagueness / blocking-risk convergence hints now name the executable resolve move — previously they recommended "re-park it as non-blocking", which only ever appended a second item while the first kept blocking (#45's acceptance bar, confirmed live in #45's lobes-cli comment).
- Teaching surfaces (`devague learn`, `docs/llm-guidance.md`, the `/think` skill, `docs/spec-contract.md`) teach the resolve close-out wherever park is taught.

Closes #45, closes #55, closes #57, closes #60 — four independent reports of the same gap in five weeks, across colleague, lobes-cli, league-of-agents, and devague's own dogfooding. (#60's task-text half was already shipped as `plan amend` in 0.18.0/#68; only its vagueness half was live.)

## How it was built

Full seven-leg dogfood: `/scope` → `/think` → `/challenge` → `/spec-to-plan` → `/assign-to-workforce` (9 tasks fanned out to subagent worktrees across 3 waves, TDD-gated merges) → this PR. Artifacts: `docs/specs/2026-07-17-resolve-parked-vagueness.md`, `docs/plans/2026-07-17-resolve-parked-vagueness.md` (frame/plan state committed under `.devague/`).

The `/challenge` pass (rigorous — schema-migration + data-loss signals) caught the two secondary consumers of open vagueness (`parked_items` in both gates, `plan deliverables` open items) that the initial spec missed; they're covered here (c18).

## Verification

- 689 tests pass (was 616 at baseline); coverage 98.1% (gate ≥ 95%); flake8 / black / isort / bandit / markdownlint clean.
- New e2e test drives issue #57's exact repro through the real CLI on both engines: park blocking → capture decision → resolve → converge passes → export renders the resolution. Zero `.devague` hand-edits anywhere.
- Boundary held: the package diff introduces no subprocess/network/LLM usage (`git diff main...HEAD -- devague/` grep is empty).

## Note for the reviewer

The pre-existing `resolve-parked-vagueness` branch (commit b5c9e7c, an earlier session) specs a **different shape** — a new flat `resolve` verb with `--kind` re-kinding, widened to scope entries. This session's frame decisions (q1: extend `park --resolve`, no new verb; q3: `--decision` required) supersede it; that branch was left untouched and can be deleted if you agree it's superseded.

- devague (Claude)
